### PR TITLE
feat: show power consumption in power menu

### DIFF
--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -212,6 +212,9 @@ static void desktop_scene_event_logic(FuriEventLoopObject* object, void* context
         scene_enter(desktop->debug_menu_scene, desktop);
         consumed = true;
         break;
+    case DesktopSceneEventTypePowerUpdate:
+        scene_event(desktop->power_menu_scene, message.event, message.data);
+        break;
     }
 
     if(!consumed) {

--- a/applications/services/desktop/scenes/power_menu.c
+++ b/applications/services/desktop/scenes/power_menu.c
@@ -2,6 +2,7 @@
 #include <gui/gui.h>
 #include <gui/modules/popup_menu.h>
 #include <gui/clay_helper.h>
+#include <power/power.h>
 #include "../scene.h"
 #include "../desktop_i.h"
 
@@ -30,6 +31,28 @@ static void power_menu_item_selected(size_t item_id, void* context) {
     }
 }
 
+static void power_menu_update_consumption(Scene* scene) {
+    PowerMenuData* scene_data = scene_get_data(scene);
+    furi_check(scene_data);
+
+    Power* power = furi_record_open(RECORD_POWER);
+
+    PowerDevice devices = 0;
+    power_is_device_initialized(power, &devices);
+
+    if(devices & PowerDeviceIna219) {
+        float_t voltage = power_ina219_get_voltage_v(power);
+        float_t current = power_ina219_get_current_a(power);
+        float_t consumption = power_ina219_get_power_w(power);
+
+        popup_menu_set_status(scene_data->menu, "%.1fV %.2fA %.2fW", (double)voltage, (double)current, (double)consumption);
+    } else {
+        popup_menu_set_status(scene_data->menu, NULL);
+    }
+
+    furi_record_close(RECORD_POWER);
+}
+
 static void power_menu_on_alloc(Scene* scene, void* context) {
     PowerMenuData* scene_data = malloc(sizeof(PowerMenuData));
     scene_data->desktop = context;
@@ -50,11 +73,38 @@ static void power_menu_on_enter(Scene* scene, void* app) {
 
     popup_menu_set_position(scene_data->menu, PowerMenuItemStartCpu);
     popup_menu_set_visible(scene_data->menu, true);
+
+    power_menu_update_consumption(scene);
+}
+
+static void power_menu_on_exit(Scene* scene, void* context) {
+    UNUSED(context);
+    PowerMenuData* scene_data = scene_get_data(scene);
+    furi_check(scene_data);
+
+    popup_menu_set_visible(scene_data->menu, false);
+}
+
+static bool power_menu_on_event(Scene* scene, uint32_t event, void* data) {
+    UNUSED(data);
+    PowerMenuData* scene_data = scene_get_data(scene);
+    furi_check(scene_data);
+
+    bool consumed = false;
+
+    if(event == DesktopSceneEventTypePowerUpdate) {
+        if(popup_menu_is_visible(scene_data->menu)) {
+            power_menu_update_consumption(scene);
+        }
+        consumed = true;
+    }
+
+    return consumed;
 }
 
 const SceneCallbacks scene_power_menu_callbacks = {
     .on_alloc = power_menu_on_alloc,
     .on_enter = power_menu_on_enter,
-    .on_exit = NULL,
-    .on_event = NULL,
+    .on_exit = power_menu_on_exit,
+    .on_event = power_menu_on_event,
 };

--- a/applications/services/gui/gui.c
+++ b/applications/services/gui/gui.c
@@ -6,6 +6,7 @@
 #include "clay.h"
 #include "clay_render.h"
 #include "clay_helper.h"
+#include <gui/modules/popup_menu.h>
 #include <drivers/display/display_jd9853_qspi.h>
 #include <drivers/display/display_jd9853_reg.h>
 #include <string.h>

--- a/applications/services/gui/gui_i.h
+++ b/applications/services/gui/gui_i.h
@@ -7,6 +7,3 @@ void gui_update(Gui* gui);
 void gui_lock(Gui* gui);
 
 void gui_unlock(Gui* gui);
-
-/* Internal: whether the registered popup menu overlay is currently visible. */
-bool popup_menu_is_visible(PopupMenu* menu);

--- a/applications/services/gui/modules/popup_menu.c
+++ b/applications/services/gui/modules/popup_menu.c
@@ -27,6 +27,7 @@ ARRAY_DEF(PopupMenuItemArray, PopupMenuItem, M_POD_OPLIST); // TODO: dict, use i
 
 typedef struct {
     char* title;
+    char status[32];
     PopupMenuItemArray_t items;
     size_t position;
     bool visible;
@@ -134,6 +135,23 @@ static void popup_menu_draw_title(const char* title) {
     }
 }
 
+static void popup_menu_draw_status(const char* status) {
+    if(status[0] == '\0') {
+        return;
+    }
+
+    CLAY_AUTO_ID({
+        .layout =
+            {
+                .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(11)},
+            },
+        .border = {.color = COLOR_BLACK, .width = {.bottom = 1}},
+    }) {
+        CLAY_TEXT(clay_helper_string_from_chars(status), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_BLACK, .wrapMode = CLAY_TEXT_WRAP_NONE}));
+    }
+}
+
 static bool popup_menu_layout_callback(void* _model) {
     PopupMenuViewModel* model = _model;
     furi_assert(model);
@@ -175,6 +193,7 @@ static bool popup_menu_layout_callback(void* _model) {
             .cornerRadius = CLAY_CORNER_RADIUS(5),
         }) {
             popup_menu_draw_title(model->title);
+            popup_menu_draw_status(model->status);
             popup_menu_draw_item_list(model);
         }
     }
@@ -287,6 +306,7 @@ PopupMenu* popup_menu_alloc(View* view) {
         PopupMenuViewModel * model,
         {
             PopupMenuItemArray_init(model->items);
+            model->status[0] = '\0';
             model->power_pressed = true;
         },
         false);
@@ -332,6 +352,24 @@ void popup_menu_set_title(PopupMenu* menu, const char* title) {
             model->title = title ? strdup(title) : NULL;
         },
         true);
+}
+
+void popup_menu_set_status(PopupMenu* menu, const char* format, ...) {
+    furi_check(menu);
+    va_list args;
+    va_start(args, format);
+    with_view_model(
+        menu->view,
+        PopupMenuViewModel * model,
+        {
+            if(format) {
+                vsnprintf(model->status, sizeof(model->status), format, args);
+            } else {
+                model->status[0] = '\0';
+            }
+        },
+        true);
+    va_end(args);
 }
 
 void popup_menu_set_position(PopupMenu* menu, size_t item_id) {

--- a/applications/services/gui/modules/popup_menu.h
+++ b/applications/services/gui/modules/popup_menu.h
@@ -16,9 +16,13 @@ void popup_menu_free(PopupMenu* menu);
 
 void popup_menu_set_title(PopupMenu* menu, const char* title);
 
+void popup_menu_set_status(PopupMenu* menu, const char* format, ...);
+
 void popup_menu_set_position(PopupMenu* menu, size_t item_id);
 
 void popup_menu_set_visible(PopupMenu* menu, bool visible);
+
+bool popup_menu_is_visible(PopupMenu* menu);
 
 void popup_menu_set_callback(PopupMenu* menu, PopupMenuCallback callback, void* context);
 

--- a/applications/services/power_menu/power_menu.c
+++ b/applications/services/power_menu/power_menu.c
@@ -4,9 +4,11 @@
 #include <gui/clay_helper.h>
 #include <drivers/bq25792/bq25792.h>
 #include <led/led_batch.h>
+#include <power/power.h>
 
-#define TAG              "PowerMenu"
-#define POWER_MENU_ID(x) CLAY_SIDI(CLAY_STRING("PowerMenu"), x)
+#define TAG                          "PowerMenu"
+#define POWER_MENU_ID(x)             CLAY_SIDI(CLAY_STRING("PowerMenu"), x)
+#define POWER_MENU_UPDATE_INTERVAL_MS 1000
 
 typedef enum {
     PowerMenuActionLeds,
@@ -31,6 +33,7 @@ typedef struct {
     size_t selected_index;
     FuriString* backlight_text;
     const char* led_text;
+    FuriString* power_text;
 } PowerMenuModel;
 
 typedef struct {
@@ -38,6 +41,8 @@ typedef struct {
     View* view;
     FuriEventLoop* event_loop;
     Bq25792* bq25792;
+    Power* power;
+    FuriEventLoopTimer* power_timer;
     size_t selected_led_batch_index;
     size_t selected_backlight_index;
 } PowerMenu;
@@ -112,6 +117,19 @@ static bool power_menu_layout(void* _model) {
         }) {
             CLAY_TEXT(CLAY_STRING("Power"), CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_BLACK}));
         }
+        if(furi_string_size(model->power_text) > 0) {
+            CLAY_AUTO_ID({
+                .layout =
+                    {
+                        .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(11)},
+                        .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                    },
+            }) {
+                CLAY_TEXT(
+                    clay_helper_string_from(model->power_text),
+                    CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_BLACK}));
+            }
+        }
         for(uint32_t i = 0; i < power_menu_items_count; i++) {
             bool selected = (i == model->selected_index);
             CLAY(
@@ -146,6 +164,7 @@ static bool power_menu_layout(void* _model) {
 
 static bool power_menu_model_init(PowerMenuModel* model, void* context) {
     model->backlight_text = furi_string_alloc();
+    model->power_text = furi_string_alloc();
     model->led_text = led_batch_names[0];
     return false;
 }
@@ -153,6 +172,8 @@ static bool power_menu_model_init(PowerMenuModel* model, void* context) {
 static bool power_menu_model_deinit(PowerMenuModel* model, void* context) {
     furi_string_free(model->backlight_text);
     model->backlight_text = NULL;
+    furi_string_free(model->power_text);
+    model->power_text = NULL;
     return false;
 }
 
@@ -165,6 +186,12 @@ static bool power_menu_model_set_backlight_text(PowerMenuModel* model, void* con
 static bool power_menu_model_set_led_text(PowerMenuModel* model, void* context) {
     size_t* led_batch_index = context;
     model->led_text = led_batch_names[*led_batch_index];
+    return true;
+}
+
+static bool power_menu_model_set_power_text(PowerMenuModel* model, void* context) {
+    FuriString* text = context;
+    furi_string_set(model->power_text, text);
     return true;
 }
 
@@ -200,6 +227,21 @@ static bool power_menu_input_menu_show(PowerMenuModel* model, void* context) {
 static bool power_menu_input_menu_hide(PowerMenuModel* model, void* context) {
     model->visible = false;
     return true;
+}
+
+static void power_menu_model_apply(PowerMenu* instance, bool (*callback)(PowerMenuModel* model, void* context), void* context);
+
+static void power_menu_power_timer_callback(void* context) {
+    furi_assert(context);
+    PowerMenu* instance = context;
+
+    float_t voltage = power_ina219_get_voltage_v(instance->power);
+    float_t current = power_ina219_get_current_a(instance->power);
+    float_t power = power_ina219_get_power_w(instance->power);
+
+    FuriString* text = furi_string_alloc_printf("%.1fV %.2fA %.2fW", (double)voltage, (double)current, (double)power);
+    power_menu_model_apply(instance, power_menu_model_set_power_text, text);
+    furi_string_free(text);
 }
 
 static void power_menu_model_apply(PowerMenu* instance, bool (*callback)(PowerMenuModel* model, void* context), void* context) {
@@ -280,6 +322,7 @@ static PowerMenu* power_menu_alloc(void) {
     PowerMenu* instance = malloc(sizeof(PowerMenu));
     instance->bq25792 = bq25792_init(&furi_hal_i2c_handle_main, BQ25792_ADDRESS, NULL);
     instance->gui = furi_record_open(RECORD_GUI);
+    instance->power = furi_record_open(RECORD_POWER);
     instance->event_loop = furi_event_loop_alloc();
 
     instance->view = view_alloc();
@@ -291,12 +334,22 @@ static PowerMenu* power_menu_alloc(void) {
     gui_add_view(instance->gui, instance->view, GuiViewPriorityMenu);
     instance->selected_backlight_index = 3; // 20%
     power_menu_apply_backlight(instance);
+
+    instance->power_timer = furi_event_loop_timer_alloc(
+        instance->event_loop,
+        power_menu_power_timer_callback,
+        FuriEventLoopTimerTypePeriodic,
+        instance);
+    furi_event_loop_timer_start(instance->power_timer, POWER_MENU_UPDATE_INTERVAL_MS);
+
     return instance;
 }
 
 static void power_menu_free(PowerMenu* instance) {
+    furi_event_loop_timer_free(instance->power_timer);
     gui_remove_view(instance->gui, instance->view);
     furi_record_close(RECORD_GUI);
+    furi_record_close(RECORD_POWER);
     power_menu_model_apply(instance, power_menu_model_deinit, NULL);
     view_free(instance->view);
     furi_event_loop_free(instance->event_loop);


### PR DESCRIPTION
- Display INA219 voltage, current, and power readings in the power menu header
- Values update every 1 second via periodic FuriEventLoopTimer
- Uses existing Power service API (power_ina219_get_voltage_v/current_a/power_w)

Closes #23