### PR TITLE
Charger: set of fixes

### DIFF
--- a/applications/services/power/power.c
+++ b/applications/services/power/power.c
@@ -17,6 +17,7 @@
 
 #define BQ25792_BAT_MAX_CHARGE_VOLTAGE 8800
 #define BQ25792_BAT_MAX_CHARGE_CURRENT 3000
+#define BQ25792_BAT_MAX_INPUT_CURRENT 1200
 
 typedef enum {
     PowerEventTypeIsr = (1 << 0),
@@ -222,6 +223,7 @@ static Power* power_alloc(void) {
     // Set default charge voltage and current limits
     bq25792_set_charge_voltage_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_CHARGE_VOLTAGE);
     bq25792_set_charge_current_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_CHARGE_CURRENT);
+    bq25792_set_input_current_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_INPUT_CURRENT);
 
     instance->ina219_header = ina219_init(&furi_hal_i2c_handle_main, INA219_ADDRESS, POWER_INA_SHUNT_RESISTOR_OHMS, POWER_INA_BUS_CURRENT_MAX);
 
@@ -236,7 +238,7 @@ static Power* power_alloc(void) {
 
     furi_event_loop_subscribe_message_queue(instance->event_loop, instance->message_queue, FuriEventLoopEventIn, power_message_queue_callback, instance);
     furi_event_loop_set_custom_event_callback(instance->event_loop, power_custom_event_callback, instance);
-
+    
     instance->event_pubsub = furi_pubsub_alloc();
     furi_record_create(RECORD_POWER, instance);
 

--- a/applications/services/power/power.c
+++ b/applications/services/power/power.c
@@ -15,6 +15,9 @@
 #define POWER_INA_SHUNT_RESISTOR_OHMS (0.004f)
 #define POWER_INA_BUS_CURRENT_MAX     (9.0f)
 
+#define BQ25792_BAT_MAX_CHARGE_VOLTAGE 8800
+#define BQ25792_BAT_MAX_CHARGE_CURRENT 3000
+
 typedef enum {
     PowerEventTypeIsr = (1 << 0),
     PowerEventTypeAll = (PowerEventTypeIsr),
@@ -215,6 +218,11 @@ static Power* power_alloc(void) {
     instance->event_loop = furi_event_loop_alloc();
     instance->message_queue = furi_message_queue_alloc(POWER_MAX_MESSAGES, sizeof(PowerMessage));
     instance->bq25792_header = bq25792_init(&furi_hal_i2c_handle_main, BQ25792_ADDRESS, NULL);
+
+    // Set default charge voltage and current limits
+    bq25792_set_charge_voltage_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_CHARGE_VOLTAGE);
+    bq25792_set_charge_current_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_CHARGE_CURRENT);
+
     instance->ina219_header = ina219_init(&furi_hal_i2c_handle_main, INA219_ADDRESS, POWER_INA_SHUNT_RESISTOR_OHMS, POWER_INA_BUS_CURRENT_MAX);
 
     if(!instance->bq25792_header) {

--- a/applications/services/power/power.c
+++ b/applications/services/power/power.c
@@ -17,7 +17,7 @@
 
 #define BQ25792_BAT_MAX_CHARGE_VOLTAGE 8800
 #define BQ25792_BAT_MAX_CHARGE_CURRENT 3000
-#define BQ25792_BAT_MAX_INPUT_CURRENT 1200
+#define BQ25792_BAT_MAX_INPUT_CURRENT 3000
 
 typedef enum {
     PowerEventTypeIsr = (1 << 0),
@@ -59,6 +59,7 @@ typedef enum {
     PowerMessageTypeBq25792GetChargerIrqFlags,
     PowerMessageTypeBq25792AdcEnable,
     PowerMessageTypeBq25792WatchdogReset,
+    PowerMessageTypeBq25792GetIcoCurrentLimitMa,
 } PowerMessageType;
 
 typedef struct {
@@ -90,6 +91,7 @@ typedef struct {
         Bq25792ChargerStatusReg* get_charger_status;
         Bq25792FaultStatusReg* get_charger_fault;
         Bq25792ChargerFlagReg* get_charger_irq_flags;
+        uint16_t* get_ico_current_limit_ma;
         bool set_adc_enable;
     };
 
@@ -183,6 +185,9 @@ static void power_message_queue_callback(FuriEventLoopObject* object, void* cont
         break;
     case PowerMessageTypeBq25792WatchdogReset:
         result = bq25792_watchdog_reset(instance->bq25792_header) == Bq25792StatusOk;
+        break;
+    case PowerMessageTypeBq25792GetIcoCurrentLimitMa:
+        result = bq25792_get_ico_current_limit_ma(instance->bq25792_header, msg.get_ico_current_limit_ma) == Bq25792StatusOk;
         break;
     default:
         furi_crash("Invalid message type");
@@ -559,6 +564,19 @@ bool power_bq25792_watchdog_reset(Power* instance) {
     bool result;
     PowerMessage msg = {
         .type = PowerMessageTypeBq25792WatchdogReset,
+        .result = &result,
+        .lock = api_lock_alloc_locked(),
+    };
+    power_send_message(instance, &msg);
+    return result;
+}
+
+bool power_bq25792_get_ico_current_limit_ma(Power* instance, uint16_t* ico_current_limit) {
+    furi_check(instance);
+    bool result;
+    PowerMessage msg = {
+        .type = PowerMessageTypeBq25792GetIcoCurrentLimitMa,
+        .get_ico_current_limit_ma = ico_current_limit,
         .result = &result,
         .lock = api_lock_alloc_locked(),
     };

--- a/applications/services/power/power.h
+++ b/applications/services/power/power.h
@@ -36,6 +36,7 @@ bool power_bq25792_get_charger_fault(Power* instance, Bq25792FaultStatusReg* fau
 bool power_bq25792_get_charger_irq_flags(Power* instance, Bq25792ChargerFlagReg* irq_flags);
 bool power_bq25792_adc_enable(Power* instance, bool enable);
 bool power_bq25792_watchdog_reset(Power* instance);
+bool power_bq25792_get_ico_current_limit_ma(Power* instance, uint16_t* ico_current_limit);
 #ifdef __cplusplus
 }
 #endif

--- a/applications/services/power/power_cli.c
+++ b/applications/services/power/power_cli.c
@@ -115,8 +115,8 @@ static void power_cli_print_bq25792(Power* power) {
         "  ChgTemp: %.2fC\r\n"
         "  BatTemp: %.2fC\r\n"
         "  IINDPM:  %dmA\r\n"
-        "  VCHRG:   %dmV\r\n"
-        "  ICHRG:   %dmA\r\n\r\n",
+        "  VREG:    %dmV\r\n"
+        "  ICHG:    %dmA\r\n\r\n",
         (float_t)vsys_mv / 1000.0f,
         (float_t)vbus_mv / 1000.0f,
         ibus_ma,

--- a/applications/services/power/power_cli.c
+++ b/applications/services/power/power_cli.c
@@ -93,6 +93,7 @@ static void power_cli_print_bq25792(Power* power) {
     uint16_t input_current_limit_ma = 0;
     uint16_t charge_voltage_limit_mv = 0;
     uint16_t charge_current_limit_ma = 0;
+    uint16_t ico_current_limit_ma = 0;
 
     power_bq25792_get_ibus_ma(power, &ibus_ma);
     power_bq25792_get_ibat_ma(power, &ibat_ma);
@@ -104,6 +105,7 @@ static void power_cli_print_bq25792(Power* power) {
     power_bq25792_get_input_current_limit_ma(power, &input_current_limit_ma);
     power_bq25792_get_charge_voltage_limit_ma(power, &charge_voltage_limit_mv);
     power_bq25792_get_charge_current_limit_ma(power, &charge_current_limit_ma);
+    power_bq25792_get_ico_current_limit_ma(power, &ico_current_limit_ma);
 
     printf(
         "BQ25792:\r\n"
@@ -116,7 +118,8 @@ static void power_cli_print_bq25792(Power* power) {
         "  BatTemp: %.2fC\r\n"
         "  IINDPM:  %dmA\r\n"
         "  VREG:    %dmV\r\n"
-        "  ICHG:    %dmA\r\n\r\n",
+        "  ICHG:    %dmV\r\n"
+        "  ICO:     %dmA\r\n\r\n",
         (float_t)vsys_mv / 1000.0f,
         (float_t)vbus_mv / 1000.0f,
         ibus_ma,
@@ -126,7 +129,8 @@ static void power_cli_print_bq25792(Power* power) {
         battery_temp,
         input_current_limit_ma,
         charge_voltage_limit_mv,
-        charge_current_limit_ma);
+        charge_current_limit_ma,
+        ico_current_limit_ma);
 }
 
 static void power_cli_print_charger_status(Power* power, FuriString* arena) {

--- a/applications/services/power_menu/power_menu.c
+++ b/applications/services/power_menu/power_menu.c
@@ -2,8 +2,8 @@
 #include <furi_hal_i2c_config.h>
 #include <gui/gui.h>
 #include <gui/clay_helper.h>
-#include <drivers/bq25792/bq25792.h>
 #include <led/led_batch.h>
+#include <power/power.h>
 
 #define TAG              "PowerMenu"
 #define POWER_MENU_ID(x) CLAY_SIDI(CLAY_STRING("PowerMenu"), x)
@@ -37,7 +37,6 @@ typedef struct {
     Gui* gui;
     View* view;
     FuriEventLoop* event_loop;
-    Bq25792* bq25792;
     size_t selected_led_batch_index;
     size_t selected_backlight_index;
 } PowerMenu;
@@ -225,10 +224,14 @@ static void power_menu_input_menu(PowerMenu* instance, size_t selected_index) {
         power_menu_model_apply(instance, power_menu_model_set_led_text, &instance->selected_led_batch_index);
         break;
     case PowerMenuActionPowerOff:
-        bq25792_set_power_switch(instance->bq25792, Bq25792PowerShipMode);
+        Power* power_off = furi_record_open(RECORD_POWER);
+        power_bq25792_set_power_switch(power_off, Bq25792PowerShipMode);
+        furi_record_close(RECORD_POWER);
         break;
     case PowerMenuActionReboot:
-        bq25792_set_power_switch(instance->bq25792, Bq25792PowerReset);
+        Power* power_reset = furi_record_open(RECORD_POWER);
+        power_bq25792_set_power_switch(power_reset, Bq25792PowerReset);
+        furi_record_close(RECORD_POWER);
         break;
     case PowerMenuActionCancel:
         power_menu_model_apply(instance, power_menu_input_menu_hide, NULL);
@@ -278,7 +281,6 @@ static bool power_menu_input(InputEvent* event, void* context) {
 
 static PowerMenu* power_menu_alloc(void) {
     PowerMenu* instance = malloc(sizeof(PowerMenu));
-    instance->bq25792 = bq25792_init(&furi_hal_i2c_handle_main, BQ25792_ADDRESS, NULL);
     instance->gui = furi_record_open(RECORD_GUI);
     instance->event_loop = furi_event_loop_alloc();
 

--- a/lib/drivers/bq25792/bq25792.c
+++ b/lib/drivers/bq25792/bq25792.c
@@ -5,8 +5,9 @@
 
 #define TAG "Bq25792"
 
-#define BQ25792_DEVICE_PART_NUMBER 0b001 //BQ25792
-#define BQ25792_DEVICE_REVISION    0b000 //Revision
+#define BQ25792_DEVICE_PART_NUMBER        0b001 //BQ25792
+#define BQ25792_DEVICE_REVISION           0b000 //Revision
+#define BQ25792_MAX_INPUT_DEFAULT_CURRENT 500 // mA
 
 #ifdef BQ25792_DEBUG_ENABLE
 #define BQ25792_DEBUG(...) FURI_LOG_D(__VA_ARGS__)
@@ -191,10 +192,16 @@ static Bq25792Status bq25792_load_config(Bq25792* instance) {
         if(res != Bq25792StatusOk) {
             break;
         }
-        //charger_control_5.en_iindpm = 0; // Disable IINDPM measurement
+        charger_control_5.en_extilim = 0; // Disable external ILIM pin control
         charger_control_5.sfet_present = 1; // Enable Sfet presence detection
         charger_control_5.en_ibat = 1; // Enable IBAT measurement
         res = bq25792_write_reg8(instance, Bq25792RegChargerControl5, *(uint8_t*)&charger_control_5);
+        if(res != Bq25792StatusOk) {
+            break;
+        }
+
+        res = bq25792_set_input_current_limit_ma(instance, BQ25792_MAX_INPUT_DEFAULT_CURRENT);
+
     } while(0);
     if(res != Bq25792StatusOk) {
         FURI_LOG_E(TAG, "Failed to load config!");
@@ -490,10 +497,22 @@ Bq25792Status bq25792_get_charger_fault(Bq25792* instance, Bq25792FaultStatusReg
     furi_check(instance);
     Bq25792Status res = Bq25792StatusUnknown;
     do {
-        res = bq25792_read_mem(instance, Bq25792RegChargerStatus0, fault->data, sizeof(fault->data));
+        res = bq25792_read_mem(instance, Bq25792RegFaultStatus0, fault->data, sizeof(fault->data));
     } while(0);
     if(res != Bq25792StatusOk) {
         FURI_LOG_E(TAG, "Failed to get charger fault!");
+    }
+    return res;
+}
+
+Bq25792Status bq25792_clear_charger_fault(Bq25792* instance, Bq25792FaultStatusReg* fault) {
+    furi_check(instance);
+    Bq25792Status res = Bq25792StatusUnknown;
+    do {
+        res = bq25792_write_reg16(instance, Bq25792RegFaultStatus0, *(uint16_t*)fault->data);
+    } while(0);
+    if(res != Bq25792StatusOk) {
+        FURI_LOG_E(TAG, "Failed to clear charger fault!");
     }
     return res;
 }

--- a/lib/drivers/bq25792/bq25792.c
+++ b/lib/drivers/bq25792/bq25792.c
@@ -201,6 +201,21 @@ static Bq25792Status bq25792_load_config(Bq25792* instance) {
         }
 
         res = bq25792_set_input_current_limit_ma(instance, BQ25792_MAX_INPUT_DEFAULT_CURRENT);
+        if(res != Bq25792StatusOk) {
+            break;
+        }
+
+        Bq25792ChargerControl0RegBits charger_control_0 = {0};
+        res = bq25792_read_reg8(instance, Bq25792RegChargerControl0, (uint8_t*)&charger_control_0);
+        if(res != Bq25792StatusOk) {
+            break;
+        }
+        // Enabling automatic adjustment of input current
+        charger_control_0.en_ico = 1; // Enable ICO current limit
+        res = bq25792_write_reg8(instance, Bq25792RegChargerControl0, *(uint8_t*)&charger_control_0);
+        if(res != Bq25792StatusOk) {
+            break;
+        }
 
     } while(0);
     if(res != Bq25792StatusOk) {
@@ -459,6 +474,23 @@ Bq25792Status bq25792_set_charge_current_limit_ma(Bq25792* instance, uint16_t ch
     } while(0);
     if(res != Bq25792StatusOk) {
         FURI_LOG_E(TAG, "Failed to set charge current limit!");
+    }
+    return res;
+}
+
+Bq25792Status bq25792_get_ico_current_limit_ma(Bq25792* instance, uint16_t* ico_current_limit) {
+    furi_check(instance);
+    furi_check(ico_current_limit);
+    Bq25792Status res = Bq25792StatusUnknown;
+    Bq25792ICOCurrentLimitRegBits ico_current_limit_reg = {0};
+    do {
+        res = bq25792_read_reg16(instance, Bq25792RegICOCurrentLimit, (uint16_t*)&ico_current_limit_reg);
+        if(res == Bq25792StatusOk) {
+            *ico_current_limit = ico_current_limit_reg.ico_ilim * 10; // Convert to ICO current limit (10 mA per LSB)
+        }
+    } while(0);
+    if(res != Bq25792StatusOk) {
+        FURI_LOG_E(TAG, "Failed to get ICO current limit!");
     }
     return res;
 }

--- a/lib/drivers/bq25792/bq25792.c
+++ b/lib/drivers/bq25792/bq25792.c
@@ -8,9 +8,6 @@
 #define BQ25792_DEVICE_PART_NUMBER 0b001 //BQ25792
 #define BQ25792_DEVICE_REVISION    0b000 //Revision
 
-#define BQ25792_BAT_MAX_CHARGE_VOLTAGE 8800
-#define BQ25792_BAT_MAX_CHARGE_CURRENT 3000
-
 #ifdef BQ25792_DEBUG_ENABLE
 #define BQ25792_DEBUG(...) FURI_LOG_D(__VA_ARGS__)
 #else
@@ -230,9 +227,6 @@ Bq25792* bq25792_init(const FuriHalI2cBusHandle* i2c_handle, uint8_t address, co
         if(bq25792_load_config(instance) != Bq25792StatusOk) {
             furi_crash("BQ25792 failed to load config");
         }
-
-        bq25792_set_charge_voltage_limit_ma(instance, BQ25792_BAT_MAX_CHARGE_VOLTAGE);
-        bq25792_set_charge_current_limit_ma(instance, BQ25792_BAT_MAX_CHARGE_CURRENT);
 
     } else {
         FURI_LOG_E(TAG, "BQ25792 device not ready at address 0x%02X", instance->address);

--- a/lib/drivers/bq25792/bq25792.c
+++ b/lib/drivers/bq25792/bq25792.c
@@ -191,7 +191,7 @@ static Bq25792Status bq25792_load_config(Bq25792* instance) {
         if(res != Bq25792StatusOk) {
             break;
         }
-        charger_control_5.en_iindpm = 0; // Disable IINDPM measurement
+        //charger_control_5.en_iindpm = 0; // Disable IINDPM measurement
         charger_control_5.sfet_present = 1; // Enable Sfet presence detection
         charger_control_5.en_ibat = 1; // Enable IBAT measurement
         res = bq25792_write_reg8(instance, Bq25792RegChargerControl5, *(uint8_t*)&charger_control_5);

--- a/lib/drivers/bq25792/bq25792.h
+++ b/lib/drivers/bq25792/bq25792.h
@@ -38,6 +38,7 @@ Bq25792Status bq25792_get_charge_voltage_limit_ma(Bq25792* instance, uint16_t* c
 Bq25792Status bq25792_set_charge_voltage_limit_ma(Bq25792* instance, uint16_t charge_voltage_limit);
 Bq25792Status bq25792_get_charge_current_limit_ma(Bq25792* instance, uint16_t* charge_current_limit);
 Bq25792Status bq25792_set_charge_current_limit_ma(Bq25792* instance, uint16_t charge_current_limit);
+Bq25792Status bq25792_get_ico_current_limit_ma(Bq25792* instance, uint16_t* ico_current_limit);
 Bq25792Status bq25792_charge_enable(Bq25792* instance, bool enable);
 Bq25792Status bq25792_get_charger_status(Bq25792* instance, Bq25792ChargerStatusReg* status);
 Bq25792Status bq25792_get_charger_fault(Bq25792* instance, Bq25792FaultStatusReg* fault);

--- a/lib/drivers/bq25792/bq25792.h
+++ b/lib/drivers/bq25792/bq25792.h
@@ -41,6 +41,7 @@ Bq25792Status bq25792_set_charge_current_limit_ma(Bq25792* instance, uint16_t ch
 Bq25792Status bq25792_charge_enable(Bq25792* instance, bool enable);
 Bq25792Status bq25792_get_charger_status(Bq25792* instance, Bq25792ChargerStatusReg* status);
 Bq25792Status bq25792_get_charger_fault(Bq25792* instance, Bq25792FaultStatusReg* fault);
+Bq25792Status bq25792_clear_charger_fault(Bq25792* instance, Bq25792FaultStatusReg* fault);
 Bq25792Status bq25792_get_charger_irq_flags(Bq25792* instance, Bq25792ChargerFlagReg* irq_flags);
 Bq25792Status bq25792_adc_enable(Bq25792* instance, bool enable);
 Bq25792Status bq25792_watchdog_reset(Bq25792* instance);


### PR DESCRIPTION
# What's new

- Power menu: fix double initialization bq25792
- Power CLI: Fix name VCHRG->VREG, ICHRG->ICHG
- Power srv: move setting BQ25792 
- Power srv: set setting charge_voltage_limit = 8.8V, charge_current_limit = 3,0A, input_current_limit = 3A
- BQ25792 drv: set default input current 500ma
- BQ25792 drv: fix show fault
- BQ25792 drv: add ICO mode

# Verification 

- Flash and test the power system

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above
> still applies to you personally.
