### PR TITLE
Revert "I2C: ability to choose different speed for different devices"

### DIFF
--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -207,7 +207,7 @@ static void cli_command_free_blocks(Cli* cli, FuriString* args, void* context) {
 }
 
 static void cli_scan_i2c_bus(const FuriHalI2cBusHandle* handle, const char* bus_name) {
-    furi_hal_i2c_acquire(handle, FURI_HAL_I2C_TYPES_TIMINGS_100);
+    furi_hal_i2c_acquire(handle);
     furi_check(handle);
 
     printf("Scanning %s bus (%s):\r\n", bus_name, furi_hal_i2c_bus_name(handle));

--- a/applications/services/i2c_intercom/i2c_intercom.c
+++ b/applications/services/i2c_intercom/i2c_intercom.c
@@ -218,7 +218,7 @@ int32_t i2c_intercom_srv(void* p) {
     i2c_register_add(I2C_HEADPHONES_STATE_REG_ADDRESS, 0, I2CRegFlagRead);
     furi_pubsub_subscribe(furi_record_open(RECORD_HEADPHONES), i2c_registers_headphones_event_glue, NULL);
 
-    furi_hal_i2c_acquire(instance->bus_handle, FURI_HAL_I2C_TYPES_TIMINGS_1000);
+    furi_hal_i2c_acquire(instance->bus_handle);
     furi_hal_i2c_slave_set_callback(instance->bus_handle, i2c_intercom_isr, instance);
     instance->state = I2cIntercomStateIdle;
     instance->mem_address = I2C_INTERCOM_DEFAULT_ADDRESS_REGISTER;

--- a/lib/drivers/bq25792/bq25792.c
+++ b/lib/drivers/bq25792/bq25792.c
@@ -49,7 +49,7 @@ static Bq25792Status bq25792_write_reg8(Bq25792* instance, Bq25792Reg reg, uint8
 
     uint8_t buffer[2] = {reg, data};
 
-    furi_hal_i2c_acquire(instance->i2c_handle, BQ25792_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
@@ -67,7 +67,7 @@ static Bq25792Status bq25792_write_reg16(Bq25792* instance, Bq25792Reg reg, uint
 
     uint8_t buffer[3] = {reg, data >> 8, data & 0xFF};
 
-    furi_hal_i2c_acquire(instance->i2c_handle, BQ25792_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
@@ -84,7 +84,7 @@ static Bq25792Status bq25792_read_reg8(Bq25792* instance, Bq25792Reg reg, uint8_
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, BQ25792_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, FURI_HAL_I2C_TIMEOUT_US);
     if(!(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)) {
         uint8_t buffer[2] = {0};
@@ -106,7 +106,7 @@ static Bq25792Status bq25792_read_reg16(Bq25792* instance, Bq25792Reg reg, uint1
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, BQ25792_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, FURI_HAL_I2C_TIMEOUT_US);
     if(!(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)) {
         uint8_t buffer[2] = {0};
@@ -128,7 +128,7 @@ static Bq25792Status bq25792_read_mem(Bq25792* instance, Bq25792Reg reg, uint8_t
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, BQ25792_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, FURI_HAL_I2C_TIMEOUT_US);
     if(!(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)) {
         ret = furi_hal_i2c_master_rx_blocking(instance->i2c_handle, instance->address, data, length, FURI_HAL_I2C_TIMEOUT_US);
@@ -229,7 +229,7 @@ Bq25792* bq25792_init(const FuriHalI2cBusHandle* i2c_handle, uint8_t address, co
     instance->i2c_handle = i2c_handle;
     instance->address = address;
 
-    furi_hal_i2c_acquire(instance->i2c_handle, BQ25792_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 

--- a/lib/drivers/bq25792/bq25792.h
+++ b/lib/drivers/bq25792/bq25792.h
@@ -6,7 +6,6 @@
 #include "bq25792_helper.h"
 
 #define BQ25792_ADDRESS 0x6B
-#define BQ25792_I2C_SPEED_HZ FURI_HAL_I2C_TYPES_TIMINGS_1000
 
 typedef struct Bq25792 Bq25792;
 typedef void (*Bq25792CallbackInput)(void* context);

--- a/lib/drivers/bq28z620/bq28z620.c
+++ b/lib/drivers/bq28z620/bq28z620.c
@@ -35,7 +35,7 @@ static Bq28z620Status bq28z620_check_status(int stataus) {
 static Bq28z620Status bq28z620_std_cmd(Bq28z620* instance, Bq28z620StdCmd std_cmd, uint8_t* response, size_t response_length) {
     furi_check(instance);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, BQ28Z620_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret =
         furi_hal_i2c_master_trx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&std_cmd, 1, response, response_length, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
@@ -62,7 +62,7 @@ Bq28z620* bq28z620_init(const FuriHalI2cBusHandle* i2c_handle, uint8_t address) 
     instance->i2c_handle = i2c_handle;
     instance->address = address;
 
-    furi_hal_i2c_acquire(instance->i2c_handle, BQ28Z620_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
     if(ret) {

--- a/lib/drivers/bq28z620/bq28z620.h
+++ b/lib/drivers/bq28z620/bq28z620.h
@@ -5,7 +5,6 @@
 #include "bq28z620_reg.h"
 
 #define BQ28Z620_ADDRESS 0x55
-#define BQ28Z620_I2C_SPEED_HZ FURI_HAL_I2C_TYPES_TIMINGS_100
 
 typedef struct Bq28z620 Bq28z620;
 

--- a/lib/drivers/drv2605l/drv2605l.c
+++ b/lib/drivers/drv2605l/drv2605l.c
@@ -25,7 +25,7 @@ static int drv2605l_write_reg(Drv2605l* instance, Drv2605lReg reg, uint8_t* data
 
     uint8_t buffer[2] = {reg, *data};
 
-    furi_hal_i2c_acquire(instance->i2c_handle, DRV2605L_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
@@ -42,7 +42,7 @@ static int drv2605l_read_reg(Drv2605l* instance, Drv2605lReg reg, uint16_t* data
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, DRV2605L_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, FURI_HAL_I2C_TIMEOUT_US);
     if(!(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)) {
         uint8_t buffer[1] = {0};
@@ -176,7 +176,7 @@ Drv2605l* drv2605l_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pi
     //Todo: GpioModeOutputPushPull
     //furi_hal_gpio_init_simple(instance->pin_trigger, GpioModeOutputPushPull);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, DRV2605L_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 

--- a/lib/drivers/drv2605l/drv2605l.h
+++ b/lib/drivers/drv2605l/drv2605l.h
@@ -5,7 +5,6 @@
 #include <drivers/drv2605l/drv2605l_effect.h>
 
 #define DRV2605L_ADDRESS (0x5Au)
-#define DRV2605L_I2C_SPEED_HZ FURI_HAL_I2C_TYPES_TIMINGS_400
 
 typedef struct Drv2605l Drv2605l;
 

--- a/lib/drivers/fusb302/fusb302.c
+++ b/lib/drivers/fusb302/fusb302.c
@@ -42,7 +42,7 @@ static Fusb302Status fusb302_write_reg(Fusb302* instance, Fusb302Reg reg, uint8_
 
     uint8_t buffer[2] = {reg, data};
 
-    furi_hal_i2c_acquire(instance->i2c_handle, FUSB302_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
@@ -59,7 +59,7 @@ static Fusb302Status fusb302_read_reg(Fusb302* instance, Fusb302Reg reg, uint8_t
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, FUSB302_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
 
     int ret = furi_hal_i2c_master_trx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, data, 1, FURI_HAL_I2C_TIMEOUT_US);
     if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
@@ -75,7 +75,7 @@ static Fusb302Status fusb302_read_reg(Fusb302* instance, Fusb302Reg reg, uint8_t
 static Fusb302Status fusb302_write_buf(Fusb302* instance, Fusb302Reg reg, uint8_t* data, size_t length) {
     furi_check(instance);
     furi_check(data);
-    furi_hal_i2c_acquire(instance->i2c_handle, FUSB302_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
 
     int ret = furi_hal_i2c_master_trx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, data, length, FURI_HAL_I2C_TIMEOUT_US);
     if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
@@ -92,7 +92,7 @@ static Fusb302Status fusb302_read_buf(Fusb302* instance, Fusb302Reg reg, uint8_t
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, FUSB302_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
 
     int ret = furi_hal_i2c_master_trx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, data, length, FURI_HAL_I2C_TIMEOUT_US);
     if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
@@ -223,7 +223,7 @@ Fusb302* fusb302_init(const FuriHalI2cBusHandle* i2c_handle, uint8_t address, co
     instance->address = address;
     instance->pin_interrupt = pin_interrupt;
 
-    furi_hal_i2c_acquire(instance->i2c_handle, FUSB302_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 

--- a/lib/drivers/fusb302/fusb302.h
+++ b/lib/drivers/fusb302/fusb302.h
@@ -4,7 +4,6 @@
 #include <furi_hal_gpio.h>
 
 #define FUSB302_ADDRESS 0x22
-#define FUSB302_I2C_SPEED_HZ FURI_HAL_I2C_TYPES_TIMINGS_1000
 
 typedef struct Fusb302 Fusb302;
 typedef void (*Fusb302Callback)(void* context);

--- a/lib/drivers/ina219/ina219.c
+++ b/lib/drivers/ina219/ina219.c
@@ -28,7 +28,7 @@ static FURI_ALWAYS_INLINE int ina219_write_reg(Ina219* instance, Ina219Reg reg, 
 
     uint8_t buffer[3] = {reg, data >> 8, data & 0xFF};
 
-    furi_hal_i2c_acquire(instance->i2c_handle, INA219_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
@@ -45,7 +45,7 @@ static FURI_ALWAYS_INLINE int ina219_read_reg(Ina219* instance, Ina219Reg reg, u
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, INA219_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, FURI_HAL_I2C_TIMEOUT_US);
     if(!(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)) {
         uint8_t buffer[2] = {0};
@@ -126,7 +126,7 @@ Ina219* ina219_init(const FuriHalI2cBusHandle* i2c_handle, uint8_t address, floa
     instance->i2c_handle = i2c_handle;
     instance->address = address;
 
-    furi_hal_i2c_acquire(instance->i2c_handle, INA219_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 

--- a/lib/drivers/ina219/ina219.h
+++ b/lib/drivers/ina219/ina219.h
@@ -4,7 +4,6 @@
 #include <furi_hal_gpio.h>
 
 #define INA219_ADDRESS 0x45
-#define INA219_I2C_SPEED_HZ FURI_HAL_I2C_TYPES_TIMINGS_1000
 
 typedef struct Ina219 Ina219;
 typedef void (*Ina219CallbackInput)(void* context);

--- a/lib/drivers/ina4230/ina4230.c
+++ b/lib/drivers/ina4230/ina4230.c
@@ -37,7 +37,7 @@ static FURI_ALWAYS_INLINE int ina4230_write_reg(Ina4230* instance, Ina4230Reg re
 
     uint8_t buffer[3] = {reg, data >> 8, data & 0xFF};
 
-    furi_hal_i2c_acquire(instance->i2c_handle, INA4230_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
@@ -54,7 +54,7 @@ static FURI_ALWAYS_INLINE int ina4230_read_reg(Ina4230* instance, Ina4230Reg reg
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, INA4230_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, FURI_HAL_I2C_TIMEOUT_US);
     if(!(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)) {
         uint8_t buffer[2] = {0};
@@ -116,8 +116,8 @@ void ina4230_set_config_channel(Ina4230* instance, uint32_t channel, const char*
         calibration_value,
         instance->channel_config[channel].power_lsb,
         instance->channel_config[channel].energy_lsb);
-
-    furi_check(calibration_value <= 0x7FFF, "Calculated calibration value exceeds maximum allowed value for channel");
+    
+    furi_check(calibration_value <= 0x7FFF, "Calculated calibration value exceeds maximum allowed value for channel");    
     instance->channel_config[channel].calibration.shunt_cal = calibration_value;
 
     furi_string_set(instance->channel_config[channel].name, name);
@@ -151,7 +151,7 @@ Ina4230* ina4230_init(const FuriHalI2cBusHandle* i2c_handle, uint8_t address) {
         instance->channel_config[i].name = furi_string_alloc();
     }
 
-    furi_hal_i2c_acquire(instance->i2c_handle, INA4230_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 

--- a/lib/drivers/ina4230/ina4230.h
+++ b/lib/drivers/ina4230/ina4230.h
@@ -82,8 +82,6 @@ typedef enum {
     Ina4230AlertMaskReserved2 = 0b111,
 } Ina4230AlertMask;
 
-#define INA4230_I2C_SPEED_HZ FURI_HAL_I2C_TYPES_TIMINGS_400
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/drivers/iqs7211e/iqs7211e.c
+++ b/lib/drivers/iqs7211e/iqs7211e.c
@@ -87,7 +87,7 @@ static __isr __not_in_flash_func(void) iqs7211e_interrupt_handler(void* ctx) {
 static FURI_ALWAYS_INLINE void iqs7211e_i2c_acquire(Iqs7211e* instance) {
     if(!instance->i2c_session_active) {
         instance->i2c_session_active = true;
-        furi_hal_i2c_acquire(instance->i2c_handle, IQS7211E_I2C_SPEED_HZ);
+        furi_hal_i2c_acquire(instance->i2c_handle);
     }
 }
 
@@ -672,7 +672,7 @@ Iqs7211e* iqs7211e_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pi
     furi_hal_gpio_add_int_callback(instance->pin_rdy, GpioConditionFall, iqs7211e_interrupt_handler, instance);
     iqs7211e_reset(instance);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, IQS7211E_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
     if(ret) {

--- a/lib/drivers/iqs7211e/iqs7211e.h
+++ b/lib/drivers/iqs7211e/iqs7211e.h
@@ -4,7 +4,6 @@
 #include <furi_hal_gpio.h>
 
 #define IQS7211E_ADDRESS 0x56
-#define IQS7211E_I2C_SPEED_HZ FURI_HAL_I2C_TYPES_TIMINGS_1000
 
 typedef struct Iqs7211e Iqs7211e;
 typedef void (*Iqs7211eCallbackInput)(void* context);

--- a/lib/drivers/tca6416a/tca6416a.c
+++ b/lib/drivers/tca6416a/tca6416a.c
@@ -13,6 +13,7 @@
 #define TCA6416A_DEBUG(...)
 #endif
 
+
 struct Tca6416a {
     const FuriHalI2cBusHandle* i2c_handle;
     const GpioPin* pin_reset;
@@ -40,7 +41,7 @@ Tca6416a* tca6416a_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pi
     furi_hal_gpio_write_open_drain(instance->pin_reset, true);
     furi_delay_ms(10);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, TCA6416A_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
@@ -78,11 +79,11 @@ static FURI_ALWAYS_INLINE int tca6416a_write_reg(Tca6416a* instance, Tca6416aReg
 
     uint8_t buffer[3] = {reg, data & 0xFF, data >> 8};
 
-    furi_hal_i2c_acquire(instance->i2c_handle, TCA6416A_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
-    if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
+    if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)  {
         FURI_LOG_E(TAG, "Failed to write reg 0x%02X", reg);
     } else {
         TCA6416A_DEBUG(TAG, "Wrote reg 0x%02X: %016b", reg, data);
@@ -95,7 +96,7 @@ static FURI_ALWAYS_INLINE int tca6416a_read_reg(Tca6416a* instance, Tca6416aReg 
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, TCA6416A_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, FURI_HAL_I2C_TIMEOUT_US);
     if(!(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)) {
         uint8_t buffer[2] = {0};

--- a/lib/drivers/tca6416a/tca6416a.h
+++ b/lib/drivers/tca6416a/tca6416a.h
@@ -5,7 +5,6 @@
 
 #define TCA6416A_ADDRESS_A0 0x20
 #define TCA6416A_ADDRESS_A1 0x21
-#define TCA6416A_I2C_SPEED_HZ FURI_HAL_I2C_TYPES_TIMINGS_400
 
 typedef struct Tca6416a Tca6416a;
 typedef void (*Tca6416aCallbackInput)(void* context);

--- a/lib/drivers/tps62868x/tps62868x.c
+++ b/lib/drivers/tps62868x/tps62868x.c
@@ -34,11 +34,11 @@ Tps62868x* tps62868x_init(const FuriHalI2cBusHandle* handle, uint8_t address) {
     furi_hal_gpio_write(&gpio_display_vci_en, true);
     furi_delay_ms(100);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, TPS62868X_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
     if(ret) {
-        tps62868x_set_pwm_on(instance);
+      tps62868x_set_pwm_on(instance);
     }
 
     return instance;
@@ -69,7 +69,7 @@ int tps62868x_read_reg(Tps62868x* instance, uint8_t reg, uint8_t* data) {
     furi_check(instance);
     furi_check(data);
 
-    furi_hal_i2c_acquire(instance->i2c_handle, TPS62868X_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_trx_blocking(instance->i2c_handle, instance->address, &reg, 1, data, 1, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
@@ -86,12 +86,12 @@ int tps62868x_write_reg(Tps62868x* instance, uint8_t reg, uint8_t* data) {
     furi_check(instance);
     furi_check(data);
     uint8_t buffer[2] = {reg, data[0]};
-    furi_hal_i2c_acquire(instance->i2c_handle, TPS62868X_I2C_SPEED_HZ);
+    furi_hal_i2c_acquire(instance->i2c_handle);
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, 2, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
-    if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
-        FURI_LOG_E(TAG, "Failed to write reg 0x%02X", reg);
+    if (ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)  {
+        FURI_LOG_E(TAG,"Failed to write reg 0x%02X", reg);
     } else {
         TPS62868X_DEBUG(TAG, "Wrote reg 0x%02X: %02X", reg, data[0]);
     }
@@ -101,7 +101,7 @@ int tps62868x_write_reg(Tps62868x* instance, uint8_t reg, uint8_t* data) {
 
 int tps62868x_set_voltage(Tps62868x* instance, float volt) {
     furi_check((volt >= TPS62868X_VOLTAGE_MIN) || (volt <= TPS62868X_VOLTAGE_MAX));
-
+    
     //Vout = TPS62868X_VOLTAGE_FACTOR * (0.4v + (VOx_SET*0.005v))
     uint8_t volt_data_reg = (uint8_t)(((volt / TPS62868X_VOLTAGE_FACTOR) - 0.4f) / 0.005f);
     TPS62868X_DEBUG(TAG, "Setting voltage to %.2f V , 0x%02X", volt, volt_data_reg);
@@ -112,7 +112,7 @@ float tps62868x_get_voltage(Tps62868x* instance) {
     uint8_t volt_data_reg[1] = {0};
     float voltage = 0.0f;
     int ret = tps62868x_read_reg(instance, TPS62868X_REG_1, volt_data_reg);
-
+    
     if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
         FURI_LOG_E(TAG, "Failed to get voltage");
         voltage = -1.0f;

--- a/lib/drivers/tps62868x/tps62868x.h
+++ b/lib/drivers/tps62868x/tps62868x.h
@@ -5,8 +5,6 @@
 #include <furi_hal_i2c_types.h>
 
 #define TPS62868_ADDRESS 0x47
-#define TPS62868X_I2C_SPEED_HZ FURI_HAL_I2C_TYPES_TIMINGS_400
-
 typedef struct Tps62868x Tps62868x;
 
 #ifdef __cplusplus

--- a/targets/f100/furi_hal/furi_hal_i2c.c
+++ b/targets/f100/furi_hal/furi_hal_i2c.c
@@ -19,7 +19,7 @@ static inline void furi_hal_i2c_check_handle_is_acquired_slave(const FuriHalI2cB
     furi_check(handle->bus->mode == FuriHalI2cModeSlave);
 }
 
-void furi_hal_i2c_acquire(const FuriHalI2cBusHandle* handle, uint32_t speed_hz) {
+void furi_hal_i2c_acquire(const FuriHalI2cBusHandle* handle) {
     furi_hal_power_insomnia_enter();
     // Lock bus access
     handle->bus->api.event(handle->bus, FuriHalI2cBusEventLock);
@@ -29,8 +29,6 @@ void furi_hal_i2c_acquire(const FuriHalI2cBusHandle* handle, uint32_t speed_hz) 
     handle->bus->current_handle = handle;
     // Activate bus
     handle->bus->api.event(handle->bus, FuriHalI2cBusEventActivate);
-    // Set bus speed
-    handle->bus->current_speed_hz = speed_hz;
     // Activate handle
     handle->callback(handle, FuriHalI2cBusHandleEventActivate);
 }

--- a/targets/f100/furi_hal/furi_hal_i2c.h
+++ b/targets/f100/furi_hal/furi_hal_i2c.h
@@ -15,7 +15,7 @@ void furi_hal_i2c_deinit_main(void);
 void furi_hal_i2c_init_cpu(void);
 void furi_hal_i2c_deinit_cpu(void);
 
-void furi_hal_i2c_acquire(const FuriHalI2cBusHandle* handle, uint32_t speed_hz);
+void furi_hal_i2c_acquire(const FuriHalI2cBusHandle* handle);
 void furi_hal_i2c_release(const FuriHalI2cBusHandle* handle);
 
 bool furi_hal_i2c_device_ready(const FuriHalI2cBusHandle* handle, uint8_t device_address, uint32_t timeout_us);

--- a/targets/f100/furi_hal/furi_hal_i2c_config.c
+++ b/targets/f100/furi_hal/furi_hal_i2c_config.c
@@ -4,6 +4,9 @@
 #include <drivers/i2c_master_pio/pio_i2c.h>
 #include <drivers/i2c_slave/i2c_slave.h>
 
+#define FURI_HAL_I2C_CONFIG_I2C_TIMINGS_100   100000
+#define FURI_HAL_I2C_CONFIG_I2C_TIMINGS_400   400000
+#define FURI_HAL_I2C_CONFIG_I2C_TIMINGS_1000  1000000
 #define FURI_HAL_I2C_CONFIG_I2C_SLAVE_ADDRESS 0x69
 
 extern FuriHalI2cBus furi_hal_i2c_bus_control;
@@ -61,7 +64,7 @@ void furi_hal_i2c_bus_handle_main_event(const FuriHalI2cBusHandle* handle, FuriH
 
     if(event == FuriHalI2cBusHandleEventActivate) {
         furi_assert(handle->bus->data == NULL);
-        handle->bus->data = pio_i2c_init(handle->bus->sda, handle->bus->scl, handle->bus->current_speed_hz);
+        handle->bus->data = pio_i2c_init(handle->bus->sda, handle->bus->scl, FURI_HAL_I2C_CONFIG_I2C_TIMINGS_100);
     } else if(event == FuriHalI2cBusHandleEventDeactivate) {
         furi_assert(handle->bus->data != NULL);
         pio_i2c_deinit(handle->bus->data);
@@ -119,7 +122,7 @@ FuriHalI2cBus furi_hal_i2c_bus_control = {
 
 void furi_hal_i2c_bus_handle_control_event(const FuriHalI2cBusHandle* handle, FuriHalI2cBusHandleEvent event) {
     if(event == FuriHalI2cBusHandleEventActivate) {
-        i2c_init(handle->bus->data, handle->bus->current_speed_hz);
+        i2c_init(handle->bus->data, FURI_HAL_I2C_CONFIG_I2C_TIMINGS_400);
 
         furi_hal_gpio_init_ex(handle->bus->sda, GpioModeOutputPushPull, GpioPullNo, GpioSpeedFast, GpioAltFn3I2c);
         furi_hal_gpio_set_drive_strength(handle->bus->sda, GpioDriveStrengthMedium);
@@ -239,7 +242,7 @@ FuriHalI2cBus furi_hal_i2c_bus_cpu = {
 
 void furi_hal_i2c_bus_handle_cpu_event(const FuriHalI2cBusHandle* handle, FuriHalI2cBusHandleEvent event) {
     if(event == FuriHalI2cBusHandleEventActivate) {
-        i2c_init(handle->bus->data, handle->bus->current_speed_hz);
+        i2c_init(handle->bus->data, FURI_HAL_I2C_CONFIG_I2C_TIMINGS_1000);
 
         furi_hal_gpio_init_ex(handle->bus->sda, GpioModeOutputPushPull, GpioPullNo, GpioSpeedFast, GpioAltFn3I2c);
         furi_hal_gpio_set_drive_strength(handle->bus->sda, GpioDriveStrengthMedium);

--- a/targets/f100/furi_hal/furi_hal_i2c_types.h
+++ b/targets/f100/furi_hal/furi_hal_i2c_types.h
@@ -7,10 +7,6 @@
 typedef struct FuriHalI2cBus FuriHalI2cBus;
 typedef struct FuriHalI2cBusHandle FuriHalI2cBusHandle;
 
-#define FURI_HAL_I2C_TYPES_TIMINGS_100   100000
-#define FURI_HAL_I2C_TYPES_TIMINGS_400   400000
-#define FURI_HAL_I2C_TYPES_TIMINGS_1000  1000000
-
 /** FuriHal i2c bus states */
 typedef enum {
     FuriHalI2cBusEventInit, /**< Bus initialization event, called on system start */
@@ -98,7 +94,6 @@ struct FuriHalI2cBus {
     const GpioPin* sda;
     const GpioPin* scl;
     const FuriHalI2cMode mode;
-    uint32_t current_speed_hz;
     FuriMutex* mutex;
     FuriHalI2cBusAPI api;
 };


### PR DESCRIPTION
This reverts PR #96

This reverts commit f7f5892c5973ca4211dd982542f52a4b25729b10.

# What's new

- [ Describe changes here ]

# Verification 

- [ Describe how to verify changes ]

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above
> still applies to you personally.
