### PR TITLE
CLI: hide otp command if it was already provided

### DIFF
--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -486,5 +486,7 @@ void cli_commands_init(Cli* cli) {
     cli_add_command(cli, "clock_out", CliCommandFlagParallelSafe, cli_command_clock_out, NULL);
     cli_add_command(cli, "gpio", CliCommandFlagParallelSafe, cli_command_gpio, NULL);
 
-    cli_add_command(cli, "otp", CliCommandFlagParallelSafe, cli_command_otp, NULL);
+    if(!furi_hal_otp_usb_white_label_valid()) {
+        cli_add_command(cli, "otp", CliCommandFlagParallelSafe, cli_command_otp, NULL);
+    }
 }


### PR DESCRIPTION
# What's new

- Hide `otp` command from cli if it was already provided

# Verification 

- [ Describe how to verify changes ]

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above
> still applies to you personally.
