### PR TITLE
Check init device

### DIFF
--- a/applications/applications.c
+++ b/applications/applications.c
@@ -27,6 +27,7 @@ extern int32_t haptic_test_app(void* p);
 
 // CLI commands
 extern void power_cli(Cli* cli, FuriString* args, void* context);
+extern void power_consumption_cli(Cli* cli, FuriString* args, void* context);
 extern void led_cli(Cli* cli, FuriString* args, void* context);
 
 const FlipperInternalApplication FLIPPER_SERVICES[] = {
@@ -167,6 +168,11 @@ const FlipperInternalCommandApplication FLIPPER_CLI_COMMANDS[] = {
     {
         .callback = power_cli,
         .name = "power",
+        .flags = CliCommandFlagParallelSafe,
+    },
+    {
+        .callback = power_consumption_cli,
+        .name = "power_consumption",
         .flags = CliCommandFlagParallelSafe,
     },
     {

--- a/applications/applications.c
+++ b/applications/applications.c
@@ -161,6 +161,13 @@ const FlipperInternalApplication FLIPPER_APPS[] = {
         .stack_size = 2048,
         .flags = FlipperInternalApplicationFlagDefault,
     },
+    {
+        .app = haptic_test_app,
+        .name = "Haptic Test",
+        .appid = "haptic_test",
+        .stack_size = 2048,
+        .flags = FlipperInternalApplicationFlagDefault,
+    },
 };
 const size_t FLIPPER_APPS_COUNT = COUNT_OF(FLIPPER_APPS);
 

--- a/applications/services/haptic/haptic.c
+++ b/applications/services/haptic/haptic.c
@@ -15,6 +15,7 @@ struct Haptic {
     Drv2605l* haptic_header;
     FuriMessageQueue* message_queue;
     FuriEventLoopTimer* timer;
+    HapticDevice devices;
 };
 
 typedef enum {
@@ -102,7 +103,11 @@ static Haptic* haptic_alloc(void) {
     instance->message_queue = furi_message_queue_alloc(HAPTIC_MAX_MESSAGES, sizeof(HapticMessage));
 
     instance->haptic_header = drv2605l_init(&furi_hal_i2c_handle_control, &gpio_haptic_en, &gpio_haptic_pwm, DRV2605L_ADDRESS);
-
+    if(instance->haptic_header) {
+        instance->devices |= HapticDeviceOk;
+    } else {
+        FURI_LOG_E(TAG, "Failed to initialize DRV2605L");
+    }
     furi_event_loop_subscribe_message_queue(instance->event_loop, instance->message_queue, FuriEventLoopEventIn, haptic_message_queue_callback, instance);
 
     instance->timer = furi_event_loop_timer_alloc(instance->event_loop, haptic_timer_callback, FuriEventLoopTimerTypeOnce, instance);
@@ -110,6 +115,19 @@ static Haptic* haptic_alloc(void) {
     furi_record_create(RECORD_HAPTIC, instance);
 
     return instance;
+}
+
+bool haptic_is_device_initialized(Haptic* instance, HapticDevice* device) {
+    furi_check(instance);
+    bool initialized = (instance->devices & HapticDeviceOk) == HapticDeviceOk;
+
+    if(device) {
+        *device = instance->devices;
+    }
+    if(!initialized) {
+        FURI_LOG_E(TAG, "Haptic device not initialized");
+    }
+    return initialized;
 }
 
 int32_t haptic_srv(void* p) {
@@ -121,38 +139,50 @@ int32_t haptic_srv(void* p) {
     return 0;
 }
 
-void haptic_play_effect(Haptic* instance, Drv2605lEffect effect_index, uint32_t time_ms) {
+bool haptic_play_effect(Haptic* instance, Drv2605lEffect effect_index, uint32_t time_ms) {
     furi_check(instance);
     furi_check(effect_index < Drv2605lEffectCountMax);
 
-    const HapticMessage msg = {
-        .type = HapticMessageTypePlayEffect,
-        .as.play_effect =
-            {
-                .effect_index = effect_index,
-                .time_ms = time_ms <= 1 ? HAPTIC_TIMEOUT_OFF_MS : time_ms,
-            },
-    };
+    if(haptic_is_device_initialized(instance, NULL)) {
+        return false;
 
-    haptic_send_message(instance, &msg);
+        const HapticMessage msg = {
+            .type = HapticMessageTypePlayEffect,
+            .as.play_effect =
+                {
+                    .effect_index = effect_index,
+                    .time_ms = time_ms <= 1 ? HAPTIC_TIMEOUT_OFF_MS : time_ms,
+                },
+        };
+
+        haptic_send_message(instance, &msg);
+        return true;
+    }
+    return false;
 }
 
-void haptic_start(Haptic* instance) {
+bool haptic_start(Haptic* instance) {
     furi_check(instance);
+    if(haptic_is_device_initialized(instance, NULL)) {
+        const HapticMessage msg = {
+            .type = HapticMessageTypeStart,
+        };
 
-    const HapticMessage msg = {
-        .type = HapticMessageTypeStart,
-    };
-
-    haptic_send_message(instance, &msg);
+        haptic_send_message(instance, &msg);
+        return true;
+    }
+    return false;
 }
 
-void haptic_stop(Haptic* instance) {
+bool haptic_stop(Haptic* instance) {
     furi_check(instance);
+    if(haptic_is_device_initialized(instance, NULL)) {
+        const HapticMessage msg = {
+            .type = HapticMessageTypeStop,
+        };
 
-    const HapticMessage msg = {
-        .type = HapticMessageTypeStop,
-    };
-
-    haptic_send_message(instance, &msg);
+        haptic_send_message(instance, &msg);
+        return true;
+    }
+    return false;
 }

--- a/applications/services/haptic/haptic.c
+++ b/applications/services/haptic/haptic.c
@@ -104,7 +104,7 @@ static Haptic* haptic_alloc(void) {
 
     instance->haptic_header = drv2605l_init(&furi_hal_i2c_handle_control, &gpio_haptic_en, &gpio_haptic_pwm, DRV2605L_ADDRESS);
     if(instance->haptic_header) {
-        instance->devices |= HapticDeviceOk;
+        instance->devices |= HapticDeviceDrv2605l;
     } else {
         FURI_LOG_E(TAG, "Failed to initialize DRV2605L");
     }
@@ -119,7 +119,7 @@ static Haptic* haptic_alloc(void) {
 
 bool haptic_is_device_initialized(Haptic* instance, HapticDevice* device) {
     furi_check(instance);
-    bool initialized = (instance->devices & HapticDeviceOk) == HapticDeviceOk;
+    bool initialized = (instance->devices & HapticDeviceDrv2605l) == HapticDeviceDrv2605l;
 
     if(device) {
         *device = instance->devices;
@@ -144,8 +144,6 @@ bool haptic_play_effect(Haptic* instance, Drv2605lEffect effect_index, uint32_t 
     furi_check(effect_index < Drv2605lEffectCountMax);
 
     if(haptic_is_device_initialized(instance, NULL)) {
-        return false;
-
         const HapticMessage msg = {
             .type = HapticMessageTypePlayEffect,
             .as.play_effect =

--- a/applications/services/haptic/haptic.h
+++ b/applications/services/haptic/haptic.h
@@ -4,11 +4,25 @@
 #include <drivers/drv2605l/drv2605l_effect.h>
 
 #define RECORD_HAPTIC "haptic"
+
 typedef struct Haptic Haptic;
+
+typedef enum {
+   HapticDeviceOk = (1 << 0),
+} HapticDevice;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Checks if the Haptic device is initialized.
+ * 
+ * @param instance The Haptic instance.
+ * @param device Pointer to store the initialized device(s).
+ * @return true  if initialization was successful, false otherwise.
+ */
+bool haptic_is_device_initialized(Haptic* instance, HapticDevice* device);
 
 /**
  * @brief Plays a haptic effect on the device. The effect will be automatically stopped after time_ms has elapsed, or can be stopped early by calling haptic_stop.
@@ -16,22 +30,25 @@ extern "C" {
  * @param instance The Haptic instance.
  * @param effect_index The index of the effect to play.
  * @param time_ms The duration to play the effect in milliseconds.
+ * @return true if the effect was successfully played, false otherwise.
  */
-void haptic_play_effect(Haptic* instance, Drv2605lEffect effect_index, uint32_t time_ms);
+bool haptic_play_effect(Haptic* instance, Drv2605lEffect effect_index, uint32_t time_ms);
 
 /**
  * @brief Starts previously played effect.
  * 
  * @param instance The Haptic instance.
+ * @return true if the effect was successfully started, false otherwise.
  */
-void haptic_start(Haptic* instance);
+bool haptic_start(Haptic* instance);
 
 /**
  * @brief Stops currently playing effect.
  * 
  * @param instance The Haptic instance.
+ * @return true if the effect was successfully stopped, false otherwise.
  */
-void haptic_stop(Haptic* instance);
+bool haptic_stop(Haptic* instance);
 
 #ifdef __cplusplus
 }

--- a/applications/services/haptic/haptic.h
+++ b/applications/services/haptic/haptic.h
@@ -8,7 +8,7 @@
 typedef struct Haptic Haptic;
 
 typedef enum {
-   HapticDeviceOk = (1 << 0),
+   HapticDeviceDrv2605l = (1 << 0),
 } HapticDevice;
 
 #ifdef __cplusplus

--- a/applications/services/input/input.c
+++ b/applications/services/input/input.c
@@ -3,6 +3,8 @@
 #include <furi.h>
 #include <furi_bsp.h>
 
+#define TAG "InputService"
+
 #define INPUT_DEBOUNCE_TICKS      4
 #define INPUT_DEBOUNCE_TICKS_HALF (INPUT_DEBOUNCE_TICKS / 2)
 #define INPUT_PRESS_TICKS         150
@@ -96,11 +98,23 @@ int32_t input_srv(void* p) {
 
     InputPinState pin_states[input_pins_count];
 
+    furi_record_create(RECORD_INPUT_EVENTS, event_pubsub);
+
+    // Check if Control Expander is initialized
+    FuriBspDevice initialized_devices;
+    furi_bsp_expander_is_initialized(&initialized_devices);
+    if(!(initialized_devices & FuriBspDeviceExpanderControl)) {
+        FURI_LOG_E(TAG, "Control Expander not initialized, input service cannot run");
+        while (1)
+        {
+            furi_delay_ms(FuriWaitForever);
+        }
+        
+    }
+
     furi_bsp_expander_control_attach_buttons_callback(input_isr, thread_id);
 
     uint16_t input_state = furi_bsp_expander_control_read_buttons();
-
-    furi_record_create(RECORD_INPUT_EVENTS, event_pubsub);
 
     for(size_t i = 0; i < input_pins_count; i++) {
         pin_states[i].pin = &input_pins[i];

--- a/applications/services/input_touch/input_touch.c
+++ b/applications/services/input_touch/input_touch.c
@@ -75,9 +75,9 @@ int32_t input_touch_srv(void* p) {
     furi_record_create(RECORD_INPUT_TOUCH_EVENTS, instance->event_pubsub);
 
     if(!instance->iqs7211e) {
-        FURI_LOG_E(TAG, "Failed to set input callback for IQS7211E touchpad");
+        FURI_LOG_E(TAG, "Not initialized IQS7211E, input touch service cannot run");
         while(1) {
-            furi_delay_ms(1000);
+            furi_delay_ms(FuriWaitForever);
         }
     }
 

--- a/applications/services/input_touch/input_touch.c
+++ b/applications/services/input_touch/input_touch.c
@@ -6,8 +6,6 @@
 
 #define TAG "InputTouch"
 
-// #define INPUT_TOUCH_DEBUG_ENABLE
-
 #ifdef INPUT_TOUCH_DEBUG_ENABLE
 #define INPUT_TOUCH_DEBUG(...) FURI_LOG_I(TAG, __VA_ARGS__)
 #else

--- a/applications/services/power/power.c
+++ b/applications/services/power/power.c
@@ -32,6 +32,7 @@ struct Power {
     Ina219* ina219_header;
     Bq28z620* bq28z620_header;
     FuriMessageQueue* message_queue;
+    PowerDevice devices;
 };
 
 static void power_bq25792_print_charger_irq(Power* instance) {
@@ -214,25 +215,34 @@ static Power* power_alloc(void) {
     Power* instance = (Power*)malloc(sizeof(Power));
     instance->event_loop = furi_event_loop_alloc();
     instance->message_queue = furi_message_queue_alloc(POWER_MAX_MESSAGES, sizeof(PowerMessage));
+    instance->devices = 0;
+
+    // init bq25792
     instance->bq25792_header = bq25792_init(&furi_hal_i2c_handle_main, BQ25792_ADDRESS, NULL);
-
-    // Set default charge voltage and current limits
-    bq25792_set_charge_voltage_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_CHARGE_VOLTAGE);
-    bq25792_set_charge_current_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_CHARGE_CURRENT);
-    bq25792_set_input_current_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_INPUT_CURRENT);
-
-    instance->ina219_header = ina219_init(&furi_hal_i2c_handle_main, INA219_ADDRESS, POWER_INA_SHUNT_RESISTOR_OHMS, POWER_INA_BUS_CURRENT_MAX);
-    instance->bq28z620_header = bq28z620_init(&furi_hal_i2c_handle_main, BQ28Z620_ADDRESS);
-
-    if(!instance->bq25792_header) {
-        FURI_LOG_E(TAG, "Failed to initialize BQ25792");
-    } else {
+    if(instance->bq25792_header) {
+        instance->devices |= PowerDeviceBq25792;
+        // Set default charge voltage and current limits
+        bq25792_set_charge_voltage_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_CHARGE_VOLTAGE);
+        bq25792_set_charge_current_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_CHARGE_CURRENT);
+        bq25792_set_input_current_limit_ma(instance->bq25792_header, BQ25792_BAT_MAX_INPUT_CURRENT);
         furi_bsp_expander_main_attach_bq25792_callback(power_bq25792_event_isr, instance);
+    } else {
+        FURI_LOG_E(TAG, "Failed to initialize BQ25792");
     }
-    if(!instance->ina219_header) {
+
+    // init ina219
+    instance->ina219_header = ina219_init(&furi_hal_i2c_handle_main, INA219_ADDRESS, POWER_INA_SHUNT_RESISTOR_OHMS, POWER_INA_BUS_CURRENT_MAX);
+    if(instance->ina219_header) {
+        instance->devices |= PowerDeviceIna219;
+    } else {
         FURI_LOG_E(TAG, "Failed to initialize INA219");
     }
-    if(!instance->bq28z620_header) {
+
+    // init bq28z620
+    instance->bq28z620_header = bq28z620_init(&furi_hal_i2c_handle_main, BQ28Z620_ADDRESS);
+    if(instance->bq28z620_header) {
+        instance->devices |= PowerDeviceBq28z620;
+    } else {
         FURI_LOG_E(TAG, "Failed to initialize BQ28Z620");
     }
 
@@ -259,36 +269,50 @@ FuriPubSub* power_get_pubsub(Power* power) {
     return power->event_pubsub;
 }
 
-#define POWER_API_CALL_PARAM(fn, ctx, par, res) \
-    do {                                        \
-        if(0) {                                 \
-            /* typechecking */                  \
-            res = fn(ctx, par);                 \
-        }                                       \
-        PowerMessage msg = {                    \
-            .function = fn##_api,               \
-            .context = ctx,                     \
-            .param = &(par),                    \
-            .result = &(res),                   \
-            .lock = api_lock_alloc_locked(),    \
-        };                                      \
-        power_send_message(instance, &msg);     \
+#define POWER_API_CALL_PARAM(dev, fn, ctx, par, res)                             \
+    do {                                                                         \
+        if(0) {                                                                  \
+            /* typechecking */                                                   \
+            res = fn(ctx, par);                                                  \
+        }                                                                        \
+        if(dev) {                                                                \
+            /* device checking */                                                \
+            if(!((instance)->devices & (dev))) {                                 \
+                FURI_LOG_E(TAG, "Device not initialized for API call: %s", #fn); \
+                break;                                                           \
+            }                                                                    \
+        }                                                                        \
+        PowerMessage msg = {                                                     \
+            .function = fn##_api,                                                \
+            .context = ctx,                                                      \
+            .param = &(par),                                                     \
+            .result = &(res),                                                    \
+            .lock = api_lock_alloc_locked(),                                     \
+        };                                                                       \
+        power_send_message(instance, &msg);                                      \
     } while(0);
 
-#define POWER_API_CALL(fn, ctx, res)         \
-    do {                                     \
-        if(0) {                              \
-            /* typechecking */               \
-            res = fn(ctx);                   \
-        }                                    \
-        PowerMessage msg = {                 \
-            .function = fn##_api,            \
-            .context = ctx,                  \
-            .param = NULL,                   \
-            .result = &(res),                \
-            .lock = api_lock_alloc_locked(), \
-        };                                   \
-        power_send_message(instance, &msg);  \
+#define POWER_API_CALL(dev, fn, ctx, res)                                        \
+    do {                                                                         \
+        if(0) {                                                                  \
+            /* typechecking */                                                   \
+            res = fn(ctx);                                                       \
+        }                                                                        \
+        if(dev) {                                                                \
+            /* device checking */                                                \
+            if(!((instance)->devices & (dev))) {                                 \
+                FURI_LOG_E(TAG, "Device not initialized for API call: %s", #fn); \
+                break;                                                           \
+            }                                                                    \
+        }                                                                        \
+        PowerMessage msg = {                                                     \
+            .function = fn##_api,                                                \
+            .context = ctx,                                                      \
+            .param = NULL,                                                       \
+            .result = &(res),                                                    \
+            .lock = api_lock_alloc_locked(),                                     \
+        };                                                                       \
+        power_send_message(instance, &msg);                                      \
     } while(0);
 
 // Ina219 API functions
@@ -296,28 +320,28 @@ FuriPubSub* power_get_pubsub(Power* power) {
 float_t power_ina219_get_voltage_v(Power* instance) {
     furi_check(instance);
     float_t voltage;
-    POWER_API_CALL(ina219_get_bus_voltage_v, instance->ina219_header, voltage);
+    POWER_API_CALL(PowerDeviceIna219, ina219_get_bus_voltage_v, instance->ina219_header, voltage);
     return voltage;
 }
 
 float_t power_ina219_get_current_a(Power* instance) {
     furi_check(instance);
     float_t current;
-    POWER_API_CALL(ina219_get_current_a, instance->ina219_header, current);
+    POWER_API_CALL(PowerDeviceIna219, ina219_get_current_a, instance->ina219_header, current);
     return current;
 }
 
 float_t power_ina219_get_power_w(Power* instance) {
     furi_check(instance);
     float_t power;
-    POWER_API_CALL(ina219_get_power_w, instance->ina219_header, power);
+    POWER_API_CALL(PowerDeviceIna219, ina219_get_power_w, instance->ina219_header, power);
     return power;
 }
 
 float_t power_ina219_get_shunt_voltage_mv(Power* instance) {
     furi_check(instance);
     float_t shunt_voltage;
-    POWER_API_CALL(ina219_get_shunt_voltage_mv, instance->ina219_header, shunt_voltage);
+    POWER_API_CALL(PowerDeviceIna219, ina219_get_shunt_voltage_mv, instance->ina219_header, shunt_voltage);
     return shunt_voltage;
 }
 
@@ -326,147 +350,147 @@ float_t power_ina219_get_shunt_voltage_mv(Power* instance) {
 bool power_bq25792_set_power_switch(Power* instance, Bq25792PowerSwitch power_switch) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_set_power_switch, instance->bq25792_header, power_switch, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_set_power_switch, instance->bq25792_header, power_switch, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_ibus_ma(Power* instance, int16_t* ibus) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_ibus_ma, instance->bq25792_header, ibus, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_ibus_ma, instance->bq25792_header, ibus, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_ibat_ma(Power* instance, int16_t* ibat) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_ibat_ma, instance->bq25792_header, ibat, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_ibat_ma, instance->bq25792_header, ibat, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_vbus_mv(Power* instance, uint16_t* vbus) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_vbus_mv, instance->bq25792_header, vbus, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_vbus_mv, instance->bq25792_header, vbus, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_vbat_mv(Power* instance, uint16_t* vbat) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_vbat_mv, instance->bq25792_header, vbat, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_vbat_mv, instance->bq25792_header, vbat, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_vsys_mv(Power* instance, uint16_t* vsys) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_vsys_mv, instance->bq25792_header, vsys, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_vsys_mv, instance->bq25792_header, vsys, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_charger_temperature(Power* instance, float* temperature) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_charger_temperature, instance->bq25792_header, temperature, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_charger_temperature, instance->bq25792_header, temperature, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_temperature_battery_celsius(Power* instance, float* temperature) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_temperature_battery_celsius, instance->bq25792_header, temperature, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_temperature_battery_celsius, instance->bq25792_header, temperature, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_input_current_limit_ma(Power* instance, uint16_t* input_current_limit) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_input_current_limit_ma, instance->bq25792_header, input_current_limit, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_input_current_limit_ma, instance->bq25792_header, input_current_limit, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_set_input_current_limit_ma(Power* instance, uint16_t input_current_limit) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_set_input_current_limit_ma, instance->bq25792_header, input_current_limit, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_set_input_current_limit_ma, instance->bq25792_header, input_current_limit, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_charge_voltage_limit_ma(Power* instance, uint16_t* charge_voltage_limit) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_charge_voltage_limit_ma, instance->bq25792_header, charge_voltage_limit, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_charge_voltage_limit_ma, instance->bq25792_header, charge_voltage_limit, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_set_charge_voltage_limit_ma(Power* instance, uint16_t charge_voltage_limit) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_set_charge_voltage_limit_ma, instance->bq25792_header, charge_voltage_limit, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_set_charge_voltage_limit_ma, instance->bq25792_header, charge_voltage_limit, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_charge_current_limit_ma(Power* instance, uint16_t* charge_current_limit) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_charge_current_limit_ma, instance->bq25792_header, charge_current_limit, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_charge_current_limit_ma, instance->bq25792_header, charge_current_limit, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_set_charge_current_limit_ma(Power* instance, uint16_t charge_current_limit) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_set_charge_current_limit_ma, instance->bq25792_header, charge_current_limit, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_set_charge_current_limit_ma, instance->bq25792_header, charge_current_limit, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_charge_enable(Power* instance, bool enable) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_charge_enable, instance->bq25792_header, enable, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_charge_enable, instance->bq25792_header, enable, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_charger_status(Power* instance, Bq25792ChargerStatusReg* status) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_charger_status, instance->bq25792_header, status, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_charger_status, instance->bq25792_header, status, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_charger_fault(Power* instance, Bq25792FaultStatusReg* fault) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_charger_fault, instance->bq25792_header, fault, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_charger_fault, instance->bq25792_header, fault, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_charger_irq_flags(Power* instance, Bq25792ChargerFlagReg* irq_flags) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_charger_irq_flags, instance->bq25792_header, irq_flags, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_charger_irq_flags, instance->bq25792_header, irq_flags, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_adc_enable(Power* instance, bool enable) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_adc_enable, instance->bq25792_header, enable, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_adc_enable, instance->bq25792_header, enable, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_watchdog_reset(Power* instance) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL(bq25792_watchdog_reset, instance->bq25792_header, result);
+    POWER_API_CALL(PowerDeviceBq25792, bq25792_watchdog_reset, instance->bq25792_header, result);
     return result == Bq25792StatusOk;
 }
 
 bool power_bq25792_get_ico_current_limit_ma(Power* instance, uint16_t* ico_current_limit) {
     furi_check(instance);
     Bq25792Status result;
-    POWER_API_CALL_PARAM(bq25792_get_ico_current_limit_ma, instance->bq25792_header, ico_current_limit, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq25792, bq25792_get_ico_current_limit_ma, instance->bq25792_header, ico_current_limit, result);
     return result == Bq25792StatusOk;
 }
 
@@ -475,160 +499,160 @@ bool power_bq25792_get_ico_current_limit_ma(Power* instance, uint16_t* ico_curre
 bool power_bq28z620_get_control_status(Power* instance, Bq28z620StdCmdControlStatusRegBits* control_status) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_control_status, instance->bq28z620_header, control_status, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_control_status, instance->bq28z620_header, control_status, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_time_to_empty(Power* instance, uint16_t* time_to_empty) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_time_to_empty, instance->bq28z620_header, time_to_empty, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_time_to_empty, instance->bq28z620_header, time_to_empty, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_temperature(Power* instance, float* temperature) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_temperature, instance->bq28z620_header, temperature, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_temperature, instance->bq28z620_header, temperature, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_voltage(Power* instance, float* voltage) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_voltage, instance->bq28z620_header, voltage, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_voltage, instance->bq28z620_header, voltage, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_battery_status(Power* instance, Bq28z620StdCmdBatteryStatusRegBits* battery_status) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_battery_status, instance->bq28z620_header, battery_status, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_battery_status, instance->bq28z620_header, battery_status, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_current(Power* instance, int16_t* current) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_current, instance->bq28z620_header, current, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_current, instance->bq28z620_header, current, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_remaining_capacity(Power* instance, uint16_t* remaining_capacity) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_remaining_capacity, instance->bq28z620_header, remaining_capacity, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_remaining_capacity, instance->bq28z620_header, remaining_capacity, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_full_charge_capacity(Power* instance, uint16_t* full_charge_capacity) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_full_charge_capacity, instance->bq28z620_header, full_charge_capacity, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_full_charge_capacity, instance->bq28z620_header, full_charge_capacity, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_average_current(Power* instance, int16_t* average_current) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_average_current, instance->bq28z620_header, average_current, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_average_current, instance->bq28z620_header, average_current, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_average_time_to_empty(Power* instance, uint16_t* average_time_to_empty) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_average_time_to_empty, instance->bq28z620_header, average_time_to_empty, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_average_time_to_empty, instance->bq28z620_header, average_time_to_empty, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_average_time_to_full(Power* instance, uint16_t* average_time_to_full) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_average_time_to_full, instance->bq28z620_header, average_time_to_full, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_average_time_to_full, instance->bq28z620_header, average_time_to_full, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_standby_current(Power* instance, int16_t* standby_current) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_standby_current, instance->bq28z620_header, standby_current, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_standby_current, instance->bq28z620_header, standby_current, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_standby_time_to_empty(Power* instance, uint16_t* standby_time_to_empty) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_standby_time_to_empty, instance->bq28z620_header, standby_time_to_empty, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_standby_time_to_empty, instance->bq28z620_header, standby_time_to_empty, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_max_load_current(Power* instance, int16_t* max_load_current) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_max_load_current, instance->bq28z620_header, max_load_current, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_max_load_current, instance->bq28z620_header, max_load_current, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_max_load_time_to_empty(Power* instance, uint16_t* max_load_time_to_empty) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_max_load_time_to_empty, instance->bq28z620_header, max_load_time_to_empty, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_max_load_time_to_empty, instance->bq28z620_header, max_load_time_to_empty, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_average_power(Power* instance, int16_t* average_power) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_average_power, instance->bq28z620_header, average_power, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_average_power, instance->bq28z620_header, average_power, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_internal_temperature(Power* instance, float* internal_temperature) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_internal_temperature, instance->bq28z620_header, internal_temperature, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_internal_temperature, instance->bq28z620_header, internal_temperature, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_cycle_count(Power* instance, uint16_t* cycle_count) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_cycle_count, instance->bq28z620_header, cycle_count, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_cycle_count, instance->bq28z620_header, cycle_count, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_relative_state_of_charge(Power* instance, uint8_t* relative_state_of_charge) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_relative_state_of_charge, instance->bq28z620_header, relative_state_of_charge, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_relative_state_of_charge, instance->bq28z620_header, relative_state_of_charge, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_state_of_health(Power* instance, uint8_t* state_of_health) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_state_of_health, instance->bq28z620_header, state_of_health, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_state_of_health, instance->bq28z620_header, state_of_health, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_charging_voltage(Power* instance, float* charging_voltage) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_charging_voltage, instance->bq28z620_header, charging_voltage, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_charging_voltage, instance->bq28z620_header, charging_voltage, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_charging_current(Power* instance, int16_t* charging_current) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_charging_current, instance->bq28z620_header, charging_current, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_charging_current, instance->bq28z620_header, charging_current, result);
     return result == Bq28z620StatusOk;
 }
 
 bool power_bq28z620_get_design_capacity(Power* instance, uint16_t* design_capacity) {
     furi_check(instance);
     Bq28z620Status result;
-    POWER_API_CALL_PARAM(bq28z620_get_design_capacity, instance->bq28z620_header, design_capacity, result);
+    POWER_API_CALL_PARAM(PowerDeviceBq28z620, bq28z620_get_design_capacity, instance->bq28z620_header, design_capacity, result);
     return result == Bq28z620StatusOk;
 }

--- a/applications/services/power/power.c
+++ b/applications/services/power/power.c
@@ -255,6 +255,14 @@ static Power* power_alloc(void) {
     return instance;
 }
 
+bool power_is_device_all_initialized(Power* instance, PowerDevice* device) {
+    furi_check(instance);
+    if(device) {
+        *device = instance->devices;
+    }
+    return (instance->devices & PowerDeviceAllInit) == PowerDeviceAllInit;
+}
+
 int32_t power_srv(void* p) {
     UNUSED(p);
 

--- a/applications/services/power/power.h
+++ b/applications/services/power/power.h
@@ -7,6 +7,12 @@
 #define RECORD_POWER "power"
 typedef struct Power Power;
 
+typedef enum {
+    PowerDeviceIna219 = (1 << 0),
+    PowerDeviceBq25792 = (1 << 1),
+    PowerDeviceBq28z620 = (1 << 2),
+} PowerDevice;
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/applications/services/power/power.h
+++ b/applications/services/power/power.h
@@ -11,12 +11,15 @@ typedef enum {
     PowerDeviceIna219 = (1 << 0),
     PowerDeviceBq25792 = (1 << 1),
     PowerDeviceBq28z620 = (1 << 2),
+    PowerDeviceAllInit = (PowerDeviceIna219 | PowerDeviceBq25792 | PowerDeviceBq28z620),
 } PowerDevice;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 FuriPubSub* power_get_pubsub(Power* power);
+
+bool power_is_device_all_initialized(Power* instance, PowerDevice* device);
 
 float_t power_ina219_get_voltage_v(Power* instance);
 float_t power_ina219_get_current_a(Power* instance);

--- a/applications/services/power/power.h
+++ b/applications/services/power/power.h
@@ -5,6 +5,7 @@
 #include <drivers/bq28z620/bq28z620_reg.h>
 
 #define RECORD_POWER "power"
+
 typedef struct Power Power;
 
 typedef enum {

--- a/applications/services/power/power_cli.c
+++ b/applications/services/power/power_cli.c
@@ -321,16 +321,16 @@ static void power_cli_print_bq28z620_control_status(Power* power, FuriString* ar
     if(s.ldmd) furi_string_cat_printf(arena, " LDMD");
     if(s.checksum_valid) furi_string_cat_printf(arena, " CHECKSUM_VALID");
     if(s.authcalm) furi_string_cat_printf(arena, " AUTHCALM");
-    if(s.sec) {
-        if(s.sec == 0b01) {
-            furi_string_cat_printf(arena, " SEC: Full_Access");
-        } else if(s.sec == 0b10) {
-            furi_string_cat_printf(arena, " SEC: Unsealed");
-        } else if(s.sec == 0b11) {
-            furi_string_cat_printf(arena, " SEC: Sealed");
-        } else {
-            furi_string_cat_printf(arena, " SEC: Unknown(%02b)", s.sec);
-        }
+    if(s.sec == 0b00) {
+        furi_string_cat_printf(arena, " SEC: Full_Access");
+    } else if(s.sec == 0b01) {
+        furi_string_cat_printf(arena, " SEC: Reserved");
+    } else if(s.sec == 0b10) {
+        furi_string_cat_printf(arena, " SEC: Unsealed");
+    } else if(s.sec == 0b11) {
+        furi_string_cat_printf(arena, " SEC: Sealed");
+    } else {
+        furi_string_cat_printf(arena, " SEC: Unknown(%02b)", s.sec);
     }
     if(furi_string_size(arena) == 0) furi_string_set(arena, " ---");
     printf("%s\r\n", furi_string_get_cstr(arena));
@@ -343,26 +343,24 @@ static void power_cli_print_bq28z620_battery_status(Power* power, FuriString* ar
     printf("  Battery Status: 0x%04X", *(uint16_t*)&s);
 
     furi_string_set(arena, "");
-    if(s.error_code) {
-        if(s.error_code == 0x00) {
-            furi_string_cat_printf(arena, " ERROR_CODE: OK");
-        } else if(s.error_code == 0x1) {
-            furi_string_cat_printf(arena, " ERROR_CODE: Busy");
-        } else if(s.error_code == 0x2) {
-            furi_string_cat_printf(arena, " ERROR_CODE: Reserved Command");
-        } else if(s.error_code == 0x3) {
-            furi_string_cat_printf(arena, " ERROR_CODE: Unsupported Command");
-        } else if(s.error_code == 0x4) {
-            furi_string_cat_printf(arena, " ERROR_CODE: AccessDenied");
-        } else if(s.error_code == 0x5) {
-            furi_string_cat_printf(arena, " ERROR_CODE: Overflow/Underflow");
-        } else if(s.error_code == 0x6) {
-            furi_string_cat_printf(arena, " ERROR_CODE: BadSize");
-        } else if(s.error_code == 0x7) {
-            furi_string_cat_printf(arena, " ERROR_CODE: UnknownError");
-        } else {
-            furi_string_cat_printf(arena, " ERROR_CODE: Unknown(%d)", s.error_code);
-        }
+    if(s.error_code == 0x00) {
+        furi_string_cat_printf(arena, " ERROR_CODE: OK");
+    } else if(s.error_code == 0x1) {
+        furi_string_cat_printf(arena, " ERROR_CODE: Busy");
+    } else if(s.error_code == 0x2) {
+        furi_string_cat_printf(arena, " ERROR_CODE: Reserved Command");
+    } else if(s.error_code == 0x3) {
+        furi_string_cat_printf(arena, " ERROR_CODE: Unsupported Command");
+    } else if(s.error_code == 0x4) {
+        furi_string_cat_printf(arena, " ERROR_CODE: AccessDenied");
+    } else if(s.error_code == 0x5) {
+        furi_string_cat_printf(arena, " ERROR_CODE: Overflow/Underflow");
+    } else if(s.error_code == 0x6) {
+        furi_string_cat_printf(arena, " ERROR_CODE: BadSize");
+    } else if(s.error_code == 0x7) {
+        furi_string_cat_printf(arena, " ERROR_CODE: UnknownError");
+    } else {
+        furi_string_cat_printf(arena, " ERROR_CODE: Unknown(%d)", s.error_code);
     }
     if(s.fully_discharged) furi_string_cat_printf(arena, " FULLY_DISCHARGED");
     if(s.fully_charged) furi_string_cat_printf(arena, " FULLY_CHARGED");

--- a/applications/services/power/power_consumption_cli.c
+++ b/applications/services/power/power_consumption_cli.c
@@ -1,0 +1,81 @@
+#include "power_cli.h"
+
+#include <args.h>
+#include <furi_hal_i2c.h>
+#include <furi_hal_i2c_config.h>
+#include <drivers/ina4230/ina4230.h>
+
+void power_consumption_cli(Cli* cli, FuriString* args, void* context) {
+    UNUSED(cli);
+    UNUSED(args);
+    UNUSED(context);
+
+    Ina4230* ina4230_add[5] = {0};
+
+    ina4230_add[0] = ina4230_init(&furi_hal_i2c_handle_main, 0x40);
+    if(ina4230_add[0]) {
+        ina4230_set_config_channel(ina4230_add[0], 0, "VDD_0V75_S3        ", 0.050f, 0.5f);
+        ina4230_set_config_channel(ina4230_add[0], 1, "VCC3V3_CONTROL     ", 0.010f, 6.0f);
+        ina4230_set_config_channel(ina4230_add[0], 2, "VDD0V85_DDR_S0     ", 0.020f, 3.0f);
+        ina4230_set_config_channel(ina4230_add[0], 3, "VCC_3V3_S3         ", 0.010f, 5.0f);
+    }
+
+    ina4230_add[1] = ina4230_init(&furi_hal_i2c_handle_main, 0x41);
+    if(ina4230_add[1]) {
+        ina4230_set_config_channel(ina4230_add[1], 0, "VDDQ0V51_DDR_S0    ", 0.020f, 3.0f);
+        ina4230_set_config_channel(ina4230_add[1], 1, "VDD0V75_NPU_S0     ", 0.010f, 5.0f);
+        ina4230_set_config_channel(ina4230_add[1], 2, "VDD0V75_GPU_S0     ", 0.020f, 3.0f);
+        ina4230_set_config_channel(ina4230_add[1], 3, "VDD0V75_LOGIC_S0   ", 0.020f, 3.0f);
+    }
+
+    ina4230_add[2] = ina4230_init(&furi_hal_i2c_handle_main, 0x46);
+    if(ina4230_add[2]) {
+        ina4230_set_config_channel(ina4230_add[2], 0, "VCCA_3V3_S0        ", 0.020f, 0.5f);
+        ina4230_set_config_channel(ina4230_add[2], 1, "VCCIO3V3/1V8_SD_S0 ", 0.050f, 0.3f);
+        ina4230_set_config_channel(ina4230_add[2], 2, "VDD2_1V05_DDR_S3   ", 0.020f, 2.5f);
+        ina4230_set_config_channel(ina4230_add[2], 3, "VCC_1V8_S3         ", 0.020f, 3.0f);
+    }
+
+    ina4230_add[3] = ina4230_init(&furi_hal_i2c_handle_main, 0x43);
+    if(ina4230_add[3]) {
+        ina4230_set_config_channel(ina4230_add[3], 0, "VDD0V75_CPU_BIG_S0 ", 0.010f, 6.5f);
+        ina4230_set_config_channel(ina4230_add[3], 1, "VDDA_1V2_S0        ", 0.050f, 0.3f);
+        ina4230_set_config_channel(ina4230_add[3], 2, "VCCA_1V8_S0        ", 0.020f, 0.5f);
+        ina4230_set_config_channel(ina4230_add[3], 3, "VDD0V75_CPU_LIT_S0 ", 0.010f, 5.0f);
+    }
+
+    ina4230_add[4] = ina4230_init(&furi_hal_i2c_handle_main, 0x44);
+    if(ina4230_add[4]) {
+        ina4230_set_config_channel(ina4230_add[4], 0, "VDDA_0V75_S0       ", 0.050f, 0.3f);
+        ina4230_set_config_channel(ina4230_add[4], 1, "VDDA_0V85_S0       ", 0.020f, 0.5f);
+        ina4230_set_config_channel(ina4230_add[4], 2, "VDDA0V75_HDMI_S0   ", 0.020f, 0.5f);
+        ina4230_set_config_channel(ina4230_add[4], 3, "VDDA0V85_DDR_PLL_S0", 0.050f, 0.3f);
+    }
+
+    while(!cli_cmd_interrupt_received(cli)) {
+        printf("\e[2J\e[0;0f"); // Clear display and return to 0
+        for(uint32_t ina = 0; ina < 5; ina++) {
+            printf("INA4230 %ld\r\n", ina);
+            if(ina4230_add[ina] == NULL) {
+                printf("Failed to initialize INA4230 %ld\r\n", ina);
+                continue;
+            }
+            for(uint32_t channel = 0; channel < 4; channel++) {
+                float bus_voltage = ina4230_get_bus_voltage_v(ina4230_add[ina], channel);
+                float shunt_voltage = ina4230_get_shunt_voltage_mv(ina4230_add[ina], channel);
+                float current = ina4230_get_current_a(ina4230_add[ina], channel);
+                float power = ina4230_get_power_w(ina4230_add[ina], channel);
+                const char* name = ina4230_get_channel_name(ina4230_add[ina], channel);
+                printf(
+                    "Channel %ld (%s): \tBus Voltage: %.3f V, \tShunt Voltage: %.3f mV, \tCurrent: %.3f A, \tPower: %.3f W\r\n",
+                    channel,
+                    name,
+                    bus_voltage,
+                    shunt_voltage,
+                    current,
+                    power);
+            }
+        }
+        furi_delay_ms(500);
+    }
+}

--- a/applications/services/power/power_consumption_cli.h
+++ b/applications/services/power/power_consumption_cli.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <cli/cli.h>
+
+void power_consumption_cli(Cli* cli, FuriString* args, void* context);

--- a/lib/drivers/bq25792/bq25792.h
+++ b/lib/drivers/bq25792/bq25792.h
@@ -11,10 +11,10 @@ typedef struct Bq25792 Bq25792;
 typedef void (*Bq25792CallbackInput)(void* context);
 
 typedef enum {
-    Bq25792StatusOk = 0,
+    Bq25792StatusUnknown = 0,
+    Bq25792StatusOk = 1,
     Bq25792StatusError = -1,
     Bq25792StatusTimeout = -2,
-    Bq25792StatusUnknown = -3,
 } Bq25792Status;
 
 #ifdef __cplusplus

--- a/lib/drivers/bq28z620/bq28z620.h
+++ b/lib/drivers/bq28z620/bq28z620.h
@@ -9,12 +9,12 @@
 typedef struct Bq28z620 Bq28z620;
 
 typedef enum {
-    Bq28z620StatusOk = 0,
+    Bq28z620StatusUnknown = 0,
+    Bq28z620StatusOk = 1,
     Bq28z620StatusRxEmpty,
     Bq28z620StatusTxEmpty,
     Bq28z620StatusError = -1,
     Bq28z620StatusTimeout = -2,
-    Bq28z620StatusUnknown = -3,
 } Bq28z620Status;
 
 #ifdef __cplusplus

--- a/lib/drivers/bq28z620/bq28z620_reg.h
+++ b/lib/drivers/bq28z620/bq28z620_reg.h
@@ -109,7 +109,7 @@ typedef struct {
     uint8_t checksum_valid  : 1; //Bit 9: Checksum is valid. 1 = Flash Writes are enabled, 0 = Flash Writes are disabled due to low voltage or PF condition.
     uint8_t                 : 2; //Bits 11–10: Reserved
     uint8_t authcalm        : 1; //Bit 12: Automatic CALIBRATION mode. 1 = Enabled, 0 = Disabled
-    uint8_t sec             : 2; //Bits 14–13: SECURITY mode 0b00 = Reserved, 0b01 = Full Access, 0b10 = Unsealed, 0b11 = Sealed
+    uint8_t sec             : 2; //Bits 14–13: SECURITY mode 0b00 = Full Access (Reserved), 0b01 = Reserved (Full Access), 0b10 = Unsealed, 0b11 = Sealed. !!!ERROR dataheet!!!
     uint8_t                 : 1; //Bit 15: Reserved
 } Bq28z620StdCmdControlStatusRegBits;
 _Static_assert(

--- a/lib/drivers/display/display_jd9853_qspi.c
+++ b/lib/drivers/display/display_jd9853_qspi.c
@@ -272,8 +272,10 @@ DisplayJd9853QSPI* display_jd9853_qspi_init(void) {
 
     //tps62868x init
     display->power_supply = tps62868x_init(&furi_hal_i2c_handle_control, TPS62868_ADDRESS);
-    tps62868x_set_voltage(display->power_supply, 3.3f);
-    tps62868x_get_voltage(display->power_supply);
+    if(display->power_supply) {
+        tps62868x_set_voltage(display->power_supply, 3.3f);
+        tps62868x_get_voltage(display->power_supply);
+    }
 
     //dma init
     display->dma_tx_channel = dma_claim_unused_channel(true);
@@ -346,7 +348,7 @@ void display_jd9853_qspi_deinit(DisplayJd9853QSPI* display) {
     hw_clear_bits(&dma_hw->inte3, 1u << display->dma_tx_channel);
     dma_channel_unclaim(display->dma_tx_channel);
 
-    tps62868x_deinit(display->power_supply);
+    if(display->power_supply) tps62868x_deinit(display->power_supply);
 
     free(display);
     display_instance = NULL;
@@ -365,10 +367,11 @@ void display_jd9853_qspi_eco_mode(DisplayJd9853QSPI* display, bool enable) {
 
 void display_jd9853_qspi_set_vci(DisplayJd9853QSPI* display, float_t voltage) {
     furi_check(display);
-    tps62868x_set_voltage(display->power_supply, voltage);
+    if(display->power_supply) tps62868x_set_voltage(display->power_supply, voltage);
 }
 
 float_t display_jd9853_qspi_get_vci(DisplayJd9853QSPI* display) {
     furi_check(display);
-    return tps62868x_get_voltage(display->power_supply);
+    if(display->power_supply) return tps62868x_get_voltage(display->power_supply);
+    return 0.0f;
 }

--- a/lib/drivers/fusb302/fusb302.h
+++ b/lib/drivers/fusb302/fusb302.h
@@ -9,12 +9,12 @@ typedef struct Fusb302 Fusb302;
 typedef void (*Fusb302Callback)(void* context);
 
 typedef enum {
-    Fusb302StatusOk = 0,
+    Fusb302StatusUnknown = 0,
+    Fusb302StatusOk = 1,
     Fusb302StatusRxEmpty,
     Fusb302StatusTxEmpty,
     Fusb302StatusError = -1,
     Fusb302StatusTimeout = -2,
-    Fusb302StatusUnknown = -3,
 } Fusb302Status;
 
 /**

--- a/lib/drivers/tps62868x/tps62868x.c
+++ b/lib/drivers/tps62868x/tps62868x.c
@@ -37,8 +37,13 @@ Tps62868x* tps62868x_init(const FuriHalI2cBusHandle* handle, uint8_t address) {
     furi_hal_i2c_acquire(instance->i2c_handle);
     ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
+    
     if(ret) {
-      tps62868x_set_pwm_on(instance);
+        tps62868x_set_pwm_on(instance);
+    } else {
+        FURI_LOG_E(TAG, "TPS62868x device not ready at address 0x%02X", instance->address);
+        free(instance);
+        return NULL;
     }
 
     return instance;
@@ -90,8 +95,8 @@ int tps62868x_write_reg(Tps62868x* instance, uint8_t reg, uint8_t* data) {
     int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, 2, FURI_HAL_I2C_TIMEOUT_US);
     furi_hal_i2c_release(instance->i2c_handle);
 
-    if (ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)  {
-        FURI_LOG_E(TAG,"Failed to write reg 0x%02X", reg);
+    if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
+        FURI_LOG_E(TAG, "Failed to write reg 0x%02X", reg);
     } else {
         TPS62868X_DEBUG(TAG, "Wrote reg 0x%02X: %02X", reg, data[0]);
     }
@@ -101,7 +106,7 @@ int tps62868x_write_reg(Tps62868x* instance, uint8_t reg, uint8_t* data) {
 
 int tps62868x_set_voltage(Tps62868x* instance, float volt) {
     furi_check((volt >= TPS62868X_VOLTAGE_MIN) || (volt <= TPS62868X_VOLTAGE_MAX));
-    
+
     //Vout = TPS62868X_VOLTAGE_FACTOR * (0.4v + (VOx_SET*0.005v))
     uint8_t volt_data_reg = (uint8_t)(((volt / TPS62868X_VOLTAGE_FACTOR) - 0.4f) / 0.005f);
     TPS62868X_DEBUG(TAG, "Setting voltage to %.2f V , 0x%02X", volt, volt_data_reg);
@@ -112,7 +117,7 @@ float tps62868x_get_voltage(Tps62868x* instance) {
     uint8_t volt_data_reg[1] = {0};
     float voltage = 0.0f;
     int ret = tps62868x_read_reg(instance, TPS62868X_REG_1, volt_data_reg);
-    
+
     if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
         FURI_LOG_E(TAG, "Failed to get voltage");
         voltage = -1.0f;

--- a/targets/f100/furi_bsp/furi_bsp_expander.c
+++ b/targets/f100/furi_bsp/furi_bsp_expander.c
@@ -45,6 +45,14 @@ typedef struct {
 static ExpanderControl* expander_control = NULL;
 static ExpanderMain* expander_main = NULL;
 
+static void furi_bsp_show_error_message_main_expander(void) {
+    FURI_LOG_E(TAG, "Not initialized Main Expander");
+}
+
+static void furi_bsp_show_error_message_control_expander(void) {
+    FURI_LOG_E(TAG, "Not initialized Control Expander");
+}
+
 static void furi_bsp_set_callback(ExpanderCallbackStorage* storage, FuriCallback callback, void* context) {
     FURI_CRITICAL_ENTER();
     storage->callback = callback;
@@ -54,11 +62,16 @@ static void furi_bsp_set_callback(ExpanderCallbackStorage* storage, FuriCallback
 
 static void furi_bsp_expander_control_init(void) {
     furi_check(expander_control == NULL);
-    FURI_LOG_I(TAG, "Initializing Control Expander");
+
     expander_control = malloc(sizeof(ExpanderControl));
     expander_control->handle = tca6416a_init(&furi_hal_i2c_handle_control, &gpio_expander_reset, &gpio_expander_int, TCA6416A_ADDRESS_A0);
-    tca6416a_write_output(expander_control->handle, 0x0000); // All outputs low by default
-    tca6416a_write_mode(expander_control->handle, InputKeyMask);
+    if(expander_control->handle) {
+        FURI_LOG_I(TAG, "Initializing Control Expander");
+        tca6416a_write_output(expander_control->handle, 0x0000); // All outputs low by default
+        tca6416a_write_mode(expander_control->handle, InputKeyMask);
+    } else {
+        FURI_LOG_E(TAG, "Failed to initialize Control Expander");
+    }
 }
 
 static __isr __not_in_flash_func(void) furi_bsp_expander_main_interrupt_handler(void* ctx) {
@@ -133,44 +146,46 @@ static int32_t furi_bsp_expander_callback_thread(void* context) {
 
 static void furi_bsp_expander_main_init(void) {
     furi_check(expander_main == NULL);
-    FURI_LOG_I(TAG, "Initializing Main Expander");
+
     expander_main = malloc(sizeof(ExpanderMain));
     expander_main->handle = tca6416a_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, TCA6416A_ADDRESS_A0);
 
-    if(expander_main->handle == NULL) {
-        FURI_LOG_E(TAG, "Failed to initialize expander on Main PCB");
-        return;
+    if(expander_main->handle) {
+        FURI_LOG_I(TAG, "Initializing Main Expander");
+        tca6416a_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+        expander_main->control_state = FuriBspControlExpanderMainMcu;
+        // Todo: Errata lay the I2C line
+        uint32_t output_mask = furi_bsp_expander_main_read_output();
+        furi_bsp_expander_main_write_output(output_mask | OutputExpMainVcc5v0DevS0En);
+        tca6416a_write_mode(expander_main->handle, InputExpMainInputMask);
+
+        expander_main->input_mask_old = ~tca6416a_read_input(expander_main->handle) & InputExpMainInputMask;
+        expander_main->thread_id = furi_thread_alloc_ex("ExpanderMainWorker", 1024, furi_bsp_expander_callback_thread, expander_main);
+        furi_thread_start(expander_main->thread_id);
+    } else {
+        FURI_LOG_E(TAG, "Failed to initialize Main Expander");
     }
-
-    tca6416a_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
-    expander_main->control_state = FuriBspControlExpanderMainMcu;
-    // Todo: Errata lay the I2C line
-    uint32_t output_mask = furi_bsp_expander_main_read_output();
-    furi_bsp_expander_main_write_output(output_mask | OutputExpMainVcc5v0DevS0En);
-    tca6416a_write_mode(expander_main->handle, InputExpMainInputMask);
-
-    expander_main->input_mask_old = ~tca6416a_read_input(expander_main->handle) & InputExpMainInputMask;
-    expander_main->thread_id = furi_thread_alloc_ex("ExpanderMainWorker", 1024, furi_bsp_expander_callback_thread, expander_main);
-    furi_thread_start(expander_main->thread_id);
 }
 
 void furi_bsp_main_reset(void) {
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
+    if(expander_main->handle) {
+        tca6416a_deinit(expander_main->handle);
 
-    tca6416a_deinit(expander_main->handle);
+        furi_hal_gpio_write_open_drain(&gpio_main_board_reset, false);
+        furi_delay_ms(50);
+        furi_hal_gpio_write_open_drain(&gpio_main_board_reset, true);
+        furi_delay_ms(10);
 
-    furi_hal_gpio_write_open_drain(&gpio_main_board_reset, false);
-    furi_delay_ms(50);
-    furi_hal_gpio_write_open_drain(&gpio_main_board_reset, true);
-    furi_delay_ms(10);
-
-    tca6416a_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, TCA6416A_ADDRESS_A0);
-    tca6416a_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
-    expander_main->control_state = FuriBspControlExpanderMainMcu;
-    // Todo: Errata lay the I2C line
-    furi_bsp_expander_main_write_output(OutputExpMainVcc5v0DevS0En);
-    tca6416a_write_mode(expander_main->handle, InputExpMainInputMask);
+        tca6416a_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, TCA6416A_ADDRESS_A0);
+        tca6416a_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+        expander_main->control_state = FuriBspControlExpanderMainMcu;
+        // Todo: Errata lay the I2C line
+        furi_bsp_expander_main_write_output(OutputExpMainVcc5v0DevS0En);
+        tca6416a_write_mode(expander_main->handle, InputExpMainInputMask);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }
 
 void furi_bsp_expander_init(void) {
@@ -180,123 +195,193 @@ void furi_bsp_expander_init(void) {
     furi_bsp_expander_main_init();
 }
 
+bool furi_bsp_expander_is_initialized(FuriBspDevice* device) {
+    bool control_initialized = expander_control != NULL && expander_control->handle != NULL;
+    bool main_initialized = expander_main != NULL && expander_main->handle != NULL;
+
+    if(device) {
+        *device = 0;
+        if(control_initialized) {
+            *device |= FuriBspDeviceExpanderControl;
+        }
+        if(main_initialized) {
+            *device |= FuriBspDeviceExpanderMain;
+        }
+    }
+
+    return control_initialized && main_initialized;
+}
+
 uint16_t furi_bsp_expander_control_read_buttons(void) {
     furi_assert(expander_control != NULL);
-    return tca6416a_read_input(expander_control->handle) & InputKeyMask;
+    if(expander_control->handle) {
+        return tca6416a_read_input(expander_control->handle) & InputKeyMask;
+    } else {
+        furi_bsp_show_error_message_control_expander();
+        return 0;
+    }
 }
 
 void furi_bsp_expander_control_attach_buttons_callback(FuriCallback callback, void* context) {
     furi_check(callback != NULL);
-    furi_check(expander_control != NULL);
-    furi_check(expander_control->callback == NULL);
-    tca6416a_set_input_callback(expander_control->handle, callback, context);
+    if(expander_control->handle) {
+        furi_check(expander_control->callback == NULL);
+        tca6416a_set_input_callback(expander_control->handle, callback, context);
+    } else {
+        furi_bsp_show_error_message_control_expander();
+    }
 }
 
 void furi_bsp_expander_control_led_power(uint16_t led_mask) {
     furi_check(expander_control != NULL);
-    tca6416a_write_output(expander_control->handle, led_mask & StatusLedPowerMask);
+    if(expander_control->handle) {
+        tca6416a_write_output(expander_control->handle, led_mask & StatusLedPowerMask);
+    } else {
+        furi_bsp_show_error_message_control_expander();
+    }
 }
 
 void furi_bsp_expander_main_write_output(uint16_t output_mask) {
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    tca6416a_write_output(expander_main->handle, output_mask & OutputExpMainMask);
+    if(expander_main->handle) {
+        tca6416a_write_output(expander_main->handle, output_mask & OutputExpMainMask);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }
 
 uint16_t furi_bsp_expander_main_read_output(void) {
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    return tca6416a_read_input(expander_main->handle) & OutputExpMainMask;
+    if(expander_main->handle) {
+        return tca6416a_read_input(expander_main->handle) & OutputExpMainMask;
+    } else {
+        furi_bsp_show_error_message_main_expander();
+        return 0;
+    }
 }
 
 uint16_t furi_bsp_expander_main_read_input(void) {
     furi_assert(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    return tca6416a_read_input(expander_main->handle) & InputExpMainInputMask;
+    if(expander_main->handle) {
+        return tca6416a_read_input(expander_main->handle) & InputExpMainInputMask;
+    } else {
+        furi_bsp_show_error_message_main_expander();
+        return 0;
+    }
 }
 
 void furi_bsp_expander_main_set_control(FuriBspControlExpanderMain control) {
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-
-    if(control == expander_main->control_state) {
-        return;
-    }
-    if(control == FuriBspControlExpanderMainMcu) {
-        tca6416a_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
-        expander_main->control_state = FuriBspControlExpanderMainMcu;
+    if(expander_main->handle) {
+        if(control == expander_main->control_state) {
+            return;
+        }
+        if(control == FuriBspControlExpanderMainMcu) {
+            tca6416a_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+            expander_main->control_state = FuriBspControlExpanderMainMcu;
+        } else {
+            tca6416a_set_input_callback(expander_main->handle, NULL, NULL);
+            expander_main->control_state = FuriBspControlExpanderMainCpu;
+        }
     } else {
-        tca6416a_set_input_callback(expander_main->handle, NULL, NULL);
-        expander_main->control_state = FuriBspControlExpanderMainCpu;
+        furi_bsp_show_error_message_main_expander();
     }
 }
 
 FuriBspControlExpanderMain furi_bsp_expander_main_get_control_state(void) {
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    return expander_main->control_state;
+    if(expander_main->handle) {
+        return expander_main->control_state;
+    } else {
+        furi_bsp_show_error_message_main_expander();
+        return FuriBspControlExpanderMainCpu; // Return a default value or handle error appropriately
+    }
 }
 
 void furi_bsp_expander_main_attach_gpio_5v0_flt_callback(FuriCallback callback, void* context) {
     furi_check(callback != NULL);
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    furi_check(expander_main->gpio_5v0_flt.callback == NULL);
-    furi_bsp_set_callback(&expander_main->gpio_5v0_flt, callback, context);
+    if(expander_main->handle) {
+        furi_check(expander_main->gpio_5v0_flt.callback == NULL);
+        furi_bsp_set_callback(&expander_main->gpio_5v0_flt, callback, context);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }
 
 void furi_bsp_expander_main_attach_gpio_3v3_flt_callback(FuriCallback callback, void* context) {
     furi_check(callback != NULL);
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    furi_check(expander_main->gpio_3v3_flt.callback == NULL);
-    furi_bsp_set_callback(&expander_main->gpio_3v3_flt, callback, context);
+    if(expander_main->handle) {
+        furi_check(expander_main->gpio_3v3_flt.callback == NULL);
+        furi_bsp_set_callback(&expander_main->gpio_3v3_flt, callback, context);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }
 
 void furi_bsp_expander_main_attach_bq25792_callback(FuriCallback callback, void* context) {
     furi_check(callback != NULL);
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    furi_check(expander_main->bq25792.callback == NULL);
-    furi_bsp_set_callback(&expander_main->bq25792, callback, context);
+    if(expander_main->handle) {
+        furi_check(expander_main->bq25792.callback == NULL);
+        furi_bsp_set_callback(&expander_main->bq25792, callback, context);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }
 
 void furi_bsp_expander_main_attach_fusb302_callback(FuriCallback callback, void* context) {
     furi_check(callback != NULL);
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    furi_check(expander_main->fusb302.callback == NULL);
-    furi_bsp_set_callback(&expander_main->fusb302, callback, context);
+    if(expander_main->handle) {
+        furi_check(expander_main->fusb302.callback == NULL);
+        furi_bsp_set_callback(&expander_main->fusb302, callback, context);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }
 
 void furi_bsp_expander_main_attach_mux_vconn_fault_callback(FuriCallback callback, void* context) {
     furi_check(callback != NULL);
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    furi_check(expander_main->mux_vconn_fault.callback == NULL);
-    furi_bsp_set_callback(&expander_main->mux_vconn_fault, callback, context);
+    if(expander_main->handle) {
+        furi_check(expander_main->mux_vconn_fault.callback == NULL);
+        furi_bsp_set_callback(&expander_main->mux_vconn_fault, callback, context);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }
 
 void furi_bsp_expander_main_attach_type_c_up_sw_pg_callback(FuriCallback callback, void* context) {
     furi_check(callback != NULL);
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    furi_check(expander_main->type_c_up_sw_pg.callback == NULL);
-    furi_bsp_set_callback(&expander_main->type_c_up_sw_pg, callback, context);
+    if(expander_main->handle) {
+        furi_check(expander_main->type_c_up_sw_pg.callback == NULL);
+        furi_bsp_set_callback(&expander_main->type_c_up_sw_pg, callback, context);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }
 
 void furi_bsp_expander_main_attach_type_a_up_sw_pg_callback(FuriCallback callback, void* context) {
     furi_check(callback != NULL);
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    furi_check(expander_main->type_a_up_sw_pg.callback == NULL);
-    furi_bsp_set_callback(&expander_main->type_a_up_sw_pg, callback, context);
+    if(expander_main->handle) {
+        furi_check(expander_main->type_a_up_sw_pg.callback == NULL);
+        furi_bsp_set_callback(&expander_main->type_a_up_sw_pg, callback, context);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }
 
 void furi_bsp_expander_main_attach_expander7_callback(FuriCallback callback, void* context) {
     furi_check(callback != NULL);
     furi_check(expander_main != NULL);
-    furi_check(expander_main->handle != NULL);
-    furi_check(expander_main->expander7.callback == NULL);
-    furi_bsp_set_callback(&expander_main->expander7, callback, context);
+    if(expander_main->handle) {
+        furi_check(expander_main->expander7.callback == NULL);
+        furi_bsp_set_callback(&expander_main->expander7, callback, context);
+    } else {
+        furi_bsp_show_error_message_main_expander();
+    }
 }

--- a/targets/f100/furi_bsp/furi_bsp_expander.h
+++ b/targets/f100/furi_bsp/furi_bsp_expander.h
@@ -3,18 +3,32 @@
 #include <toolbox/furi_callback.h>
 #include <furi_hal_resources.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef enum {
     FuriBspControlExpanderMainMcu,
     FuriBspControlExpanderMainCpu,
 } FuriBspControlExpanderMain;
 
+typedef enum {
+    FuriBspDeviceExpanderControl = (1 << 0),
+    FuriBspDeviceExpanderMain = (1 << 1),
+    FuriBspDeviceAllInit = (FuriBspDeviceExpanderControl | FuriBspDeviceExpanderMain),
+} FuriBspDevice;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
 /** Init all expander related hardware
  */
 void furi_bsp_expander_init(void);
+
+/** Check if expander hardware is initialized
+ * @param device - pointer to store which expander(s) are initialized
+ * @return bool - whether the requested expander(s) are initialized
+ */
+bool furi_bsp_expander_is_initialized(FuriBspDevice* device);
 
 /** Returns the current state of buttons from the expander
  * @return uint16_t - bitmask of button states (InputKey)


### PR DESCRIPTION
# What's new

- Power: add check init Ina219, Bq25792, Bq28z620
- Power_Cli: fix show Bq28z620 status
- Cli: add show "power_consumption"
- Haptic Srv: add ckeck init Drv2605l
- Gui: add haptic test app
- Furi_Bsp: add check init Tca6416a
- Input_Touch_Srv: add ckeck init Iqs7211e
- Display_Drv: add ckeck init Tps62868x

# Verification 

- Flash the firmware onto a test board with an RP2350 chip, check that the system boots and doesn't freeze.

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above
> still applies to you personally.
