### PR TITLE
Haptic save/load calibration setting

### DIFF
--- a/applications/applications.c
+++ b/applications/applications.c
@@ -160,6 +160,13 @@ const FlipperInternalApplication FLIPPER_APPS[] = {
         .stack_size = 2048,
         .flags = FlipperInternalApplicationFlagDefault,
     },
+    {
+        .app = haptic_test_app,
+        .name = "Haptic Test",
+        .appid = "haptic_test",
+        .stack_size = 2048,
+        .flags = FlipperInternalApplicationFlagDefault,
+    },
 };
 const size_t FLIPPER_APPS_COUNT = COUNT_OF(FLIPPER_APPS);
 

--- a/applications/services/haptic/haptic.c
+++ b/applications/services/haptic/haptic.c
@@ -4,11 +4,13 @@
 #include <furi_hal_i2c_config.h>
 #include <furi_hal_resources.h>
 #include <api_lock.h>
+#include <furi_hal_nvm.h>
 
 #define TAG "Haptic"
 
 #define HAPTIC_MAX_MESSAGES   (8)
 #define HAPTIC_TIMEOUT_OFF_MS (3000)
+#define HAPTIC_KEY_CALIB_DATA "haptic_calib_data"
 
 struct Haptic {
     FuriEventLoop* event_loop;
@@ -102,6 +104,42 @@ static Haptic* haptic_alloc(void) {
     instance->message_queue = furi_message_queue_alloc(HAPTIC_MAX_MESSAGES, sizeof(HapticMessage));
 
     instance->haptic_header = drv2605l_init(&furi_hal_i2c_handle_control, &gpio_haptic_en, &gpio_haptic_pwm, DRV2605L_ADDRESS);
+
+    // // Load or perform auto-calibration
+    // if(instance->haptic_header) {
+    //     uint32_t calib_data_size = drv2605l_size_calibration_data(instance->haptic_header);
+    //     Drv2605lCalibrationData* calib_data = malloc(calib_data_size);
+\
+    //     drv2605l_enable(instance->haptic_header);
+
+    //     if(furi_hal_nvm_get_struct(HAPTIC_KEY_CALIB_DATA, calib_data, calib_data_size) == FuriHalNvmStorageOK) {
+    //         if(drv2605l_set_calibration_data(instance->haptic_header, calib_data)) {
+    //             FURI_LOG_I(TAG, "Loaded haptic calibration data from NVM");
+    //         } else {
+    //             FURI_LOG_E(TAG, "Failed to set haptic calibration data from NVM");
+    //         }
+    //     } else {
+    //         FURI_LOG_W(TAG, "No haptic calibration data in NVM");
+    //         if(drv2605l_auto_calibration(instance->haptic_header)) {
+    //             FURI_LOG_I(TAG, "Haptic auto-calibration successful");
+    //             if(drv2605l_get_calibration_data(instance->haptic_header, calib_data)) {
+    //                 if(furi_hal_nvm_set_struct(HAPTIC_KEY_CALIB_DATA, calib_data, calib_data_size) == FuriHalNvmStorageOK) {
+    //                     FURI_LOG_I(TAG, "Saved haptic calibration data to NVM");
+    //                 } else {
+    //                     FURI_LOG_E(TAG, "Failed to save haptic calibration data to NVM");
+    //                 }
+    //             } else {
+    //                 FURI_LOG_E(TAG, "Failed to get haptic calibration data after auto-calibration");
+    //             }
+    //         } else {
+    //             FURI_LOG_E(TAG, "Haptic auto-calibration failed");
+    //         }
+    //     }
+
+    //     drv2605l_disable(instance->haptic_header);
+
+    //     free(calib_data);
+    // }
 
     furi_event_loop_subscribe_message_queue(instance->event_loop, instance->message_queue, FuriEventLoopEventIn, haptic_message_queue_callback, instance);
 

--- a/applications/services/haptic/haptic.c
+++ b/applications/services/haptic/haptic.c
@@ -5,12 +5,12 @@
 #include <furi_hal_resources.h>
 #include <api_lock.h>
 #include <furi_hal_nvm.h>
+#include <furi_nwm_key_config.h>
 
 #define TAG "Haptic"
 
 #define HAPTIC_MAX_MESSAGES   (8)
 #define HAPTIC_TIMEOUT_OFF_MS (3000)
-#define HAPTIC_KEY_CALIB_DATA "haptic_calib_data"
 
 struct Haptic {
     FuriEventLoop* event_loop;
@@ -105,41 +105,41 @@ static Haptic* haptic_alloc(void) {
 
     instance->haptic_header = drv2605l_init(&furi_hal_i2c_handle_control, &gpio_haptic_en, &gpio_haptic_pwm, DRV2605L_ADDRESS);
 
-    // // Load or perform auto-calibration
-    // if(instance->haptic_header) {
-    //     uint32_t calib_data_size = drv2605l_size_calibration_data(instance->haptic_header);
-    //     Drv2605lCalibrationData* calib_data = malloc(calib_data_size);
-\
-    //     drv2605l_enable(instance->haptic_header);
+    // Load or perform auto-calibration
+    if(instance->haptic_header) {
+        uint32_t calib_data_size = drv2605l_size_calibration_data(instance->haptic_header);
+        Drv2605lCalibrationData* calib_data = malloc(calib_data_size);
 
-    //     if(furi_hal_nvm_get_struct(HAPTIC_KEY_CALIB_DATA, calib_data, calib_data_size) == FuriHalNvmStorageOK) {
-    //         if(drv2605l_set_calibration_data(instance->haptic_header, calib_data)) {
-    //             FURI_LOG_I(TAG, "Loaded haptic calibration data from NVM");
-    //         } else {
-    //             FURI_LOG_E(TAG, "Failed to set haptic calibration data from NVM");
-    //         }
-    //     } else {
-    //         FURI_LOG_W(TAG, "No haptic calibration data in NVM");
-    //         if(drv2605l_auto_calibration(instance->haptic_header)) {
-    //             FURI_LOG_I(TAG, "Haptic auto-calibration successful");
-    //             if(drv2605l_get_calibration_data(instance->haptic_header, calib_data)) {
-    //                 if(furi_hal_nvm_set_struct(HAPTIC_KEY_CALIB_DATA, calib_data, calib_data_size) == FuriHalNvmStorageOK) {
-    //                     FURI_LOG_I(TAG, "Saved haptic calibration data to NVM");
-    //                 } else {
-    //                     FURI_LOG_E(TAG, "Failed to save haptic calibration data to NVM");
-    //                 }
-    //             } else {
-    //                 FURI_LOG_E(TAG, "Failed to get haptic calibration data after auto-calibration");
-    //             }
-    //         } else {
-    //             FURI_LOG_E(TAG, "Haptic auto-calibration failed");
-    //         }
-    //     }
+        drv2605l_enable(instance->haptic_header);
 
-    //     drv2605l_disable(instance->haptic_header);
+        if(furi_hal_nvm_get_struct(FURI_NWM_HAPTIC_KEY_CALIB_DATA, calib_data, calib_data_size) == FuriHalNvmStorageOK) {
+            if(drv2605l_set_calibration_data(instance->haptic_header, calib_data)) {
+                FURI_LOG_I(TAG, "Loaded haptic calibration data from NVM");
+            } else {
+                FURI_LOG_E(TAG, "Failed to set haptic calibration data from NVM");
+            }
+        } else {
+            FURI_LOG_W(TAG, "No haptic calibration data in NVM");
+            if(drv2605l_auto_calibration(instance->haptic_header)) {
+                FURI_LOG_I(TAG, "Haptic auto-calibration successful");
+                if(drv2605l_get_calibration_data(instance->haptic_header, calib_data)) {
+                    if(furi_hal_nvm_set_struct(FURI_NWM_HAPTIC_KEY_CALIB_DATA, calib_data, calib_data_size) == FuriHalNvmStorageOK) {
+                        FURI_LOG_I(TAG, "Saved haptic calibration data to NVM");
+                    } else {
+                        FURI_LOG_E(TAG, "Failed to save haptic calibration data to NVM");
+                    }
+                } else {
+                    FURI_LOG_E(TAG, "Failed to get haptic calibration data after auto-calibration");
+                }
+            } else {
+                FURI_LOG_E(TAG, "Haptic auto-calibration failed");
+            }
+        }
 
-    //     free(calib_data);
-    // }
+        drv2605l_disable(instance->haptic_header);
+
+        free(calib_data);
+    }
 
     furi_event_loop_subscribe_message_queue(instance->event_loop, instance->message_queue, FuriEventLoopEventIn, haptic_message_queue_callback, instance);
 

--- a/lib/drivers/drv2605l/drv2605l.c
+++ b/lib/drivers/drv2605l/drv2605l.c
@@ -20,6 +20,14 @@ struct Drv2605l {
     uint8_t address;
 };
 
+struct Drv2605lCalibrationData {
+    uint8_t rated_voltage_reg;
+    uint8_t overdrive_clamp_reg;
+    uint8_t auto_cal_comp_reg;
+    uint8_t auto_cal_bemf_reg;
+    uint8_t feedback_reg;
+};
+
 static int drv2605l_write_reg(Drv2605l* instance, Drv2605lReg reg, uint8_t* data) {
     furi_check(instance);
 
@@ -38,7 +46,7 @@ static int drv2605l_write_reg(Drv2605l* instance, Drv2605lReg reg, uint8_t* data
     return ret;
 }
 
-static int drv2605l_read_reg(Drv2605l* instance, Drv2605lReg reg, uint16_t* data) {
+static int drv2605l_read_reg(Drv2605l* instance, Drv2605lReg reg, uint8_t* data) {
     furi_check(instance);
     furi_check(data);
 
@@ -70,7 +78,7 @@ FURI_ALWAYS_INLINE void drv2605l_disable(Drv2605l* instance) {
 }
 
 //https://www.ti.com/lit/an/sloa189/sloa189.pdf?ts=1763909348509&ref_url=https%253A%252F%252Fwww.google.com%252F
-bool drv2605l_auto_calibrate(Drv2605l* instance) {
+bool drv2605l_auto_calibration(Drv2605l* instance) {
     furi_check(instance);
 
     uint8_t rated_voltage_reg = 0x53; //Vrms = 2 <--Setting
@@ -80,6 +88,168 @@ bool drv2605l_auto_calibrate(Drv2605l* instance) {
         .brake_factor = 3, //4x
         .loop_gain = 1, //Medium
         .bemf_gain = 2, //1.365x
+    };
+    // Drv2605lControl1 control1_reg = {
+    //     .startup_boost = 1, //enabled
+    //     .ac_couple = 0, //DC coupled
+    //     .drive_time = 19, // <--Setting
+    // };
+    // Drv2605lControl2 control2_reg = {
+    //     .bidir_input = 1, //Bidir input
+    //     .brake_stabilizer = 0, //disabled
+    //     .sample_time = 3, //300us
+    //     .blanking_time = 1,
+    //     .idiss_time = 1,
+    // };
+    // Drv2605lControl3 control3_reg = {
+    //     .ng_thresh = 2, //4%
+    //     .erm_open_loop = 0, //Closed loop
+    //     .supply_comp_dis = 0, //Enabled
+    //     .data_fomat_rtp = 0, //Signed
+    //     .lra_drive_mode = 0, //Once per cycle
+    //     .n_pwm_analog = 0, //PWM Input
+    //     .lra_open_loop = 0, //Auto-resonance mode
+    // };
+    // Drv2605lControl4 control4_reg = {
+    //     .auto_cal_time = 2, //1000:1200 ms
+    //     .otp_status = 0,
+    //     .otp_program = 0, //OTP Memory has not been programmed
+    //     .zc_det_time = 0, //100us
+    // };
+
+    Drv2605lMode mode_reg = {
+        .device_reset = 0, //Normal operation
+        .standby = 0, //Active mode
+        .mode_select = 0b111, //Auto-calibration mode
+    };
+
+    Drv2605lGo go_reg = {
+        .go_bit = 1, //Start auto-calibration
+    };
+
+    drv2605l_write_reg(instance, Drv2605lRegRatedVoltage, &rated_voltage_reg);
+    drv2605l_write_reg(instance, Drv2605lRegOverdriveClamp, &overdrive_clamp_reg);
+    drv2605l_write_reg(instance, Drv2605lRegFeedback, (uint8_t*)&feedback_reg);
+    drv2605l_write_reg(instance, Drv2605lRegMode, (uint8_t*)&mode_reg);
+    drv2605l_write_reg(instance, Drv2605lRegGo, (uint8_t*)&go_reg);
+
+    // Wait for completion
+    uint32_t timeout = furi_get_tick() + 2000;
+    while(furi_get_tick() < timeout) {
+        uint8_t go_status = 0;
+        drv2605l_read_reg(instance, Drv2605lRegGo, &go_status);
+        Drv2605lGo* go_reg_status = (Drv2605lGo*)&go_status;
+        if(go_reg_status->go_bit == 0) {
+            break;
+        }
+        furi_delay_ms(10);
+    }
+
+    uint8_t status = 0;
+    drv2605l_read_reg(instance, Drv2605lRegStatus, &status);
+    Drv2605lStatus* status_reg = (Drv2605lStatus*)&status;
+
+    if(status_reg->diagnostic_result) {
+        FURI_LOG_E(TAG, "Auto-calibration failed");
+        return false;
+    }
+
+    FURI_LOG_I(TAG, "Auto-calibration successful");
+
+    //Calib reg 0x18, 0x19, 0x1A (BEMFGain)
+    uint8_t calib_data = 0;
+
+    drv2605l_read_reg(instance, Drv2605lRegAutoCalComp, (uint8_t*)&calib_data);
+    FURI_LOG_I(TAG, "Auto Cal Compensation: reg 0x%02X -> 0x%02X", Drv2605lRegAutoCalComp, calib_data);
+    drv2605l_read_reg(instance, Drv2605lRegAutoCalBemf, (uint8_t*)&calib_data);
+    FURI_LOG_I(TAG, "Auto Cal BEMF: reg 0x%02X -> 0x%02X", Drv2605lRegAutoCalBemf, calib_data);
+    drv2605l_read_reg(instance, Drv2605lRegFeedback, (uint8_t*)&calib_data);
+    FURI_LOG_I(TAG, "Feedback: reg 0x%02X -> 0x%02X", Drv2605lRegFeedback, calib_data);
+
+    return true;
+}
+
+bool drv2605l_get_calibration_data(Drv2605l* instance, Drv2605lCalibrationData* calib_data) {
+    furi_check(instance);
+    furi_check(calib_data);
+    int ret = 0;
+    do {
+        ret = drv2605l_read_reg(instance, Drv2605lRegRatedVoltage, (uint8_t*)&calib_data->rated_voltage_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to read Rated Voltage reg");
+            break;
+        }
+        ret = drv2605l_read_reg(instance, Drv2605lRegOverdriveClamp, (uint8_t*)&calib_data->overdrive_clamp_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to read Overdrive Clamp reg");
+            break;
+        }
+        ret = drv2605l_read_reg(instance, Drv2605lRegAutoCalComp, (uint8_t*)&calib_data->auto_cal_comp_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to read Auto Cal Comp reg");
+            break;
+        }
+        ret = drv2605l_read_reg(instance, Drv2605lRegAutoCalBemf, (uint8_t*)&calib_data->auto_cal_bemf_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to read Auto Cal BEMF reg");
+            break;
+        }
+        ret = drv2605l_read_reg(instance, Drv2605lRegFeedback, (uint8_t*)&calib_data->feedback_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to read Feedback reg");
+            break;
+        }
+    } while(0);
+    return ret >= PICO_OK;
+}
+
+bool drv2605l_set_calibration_data(Drv2605l* instance, const Drv2605lCalibrationData* calib_data) {
+    furi_check(instance);
+    furi_check(calib_data);
+    int ret = 0;
+    do {
+        ret = drv2605l_write_reg(instance, Drv2605lRegRatedVoltage, (uint8_t*)&calib_data->rated_voltage_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Rated Voltage reg");
+            break;
+        }
+        ret = drv2605l_write_reg(instance, Drv2605lRegOverdriveClamp, (uint8_t*)&calib_data->overdrive_clamp_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Overdrive Clamp reg");
+            break;
+        }
+        ret = drv2605l_write_reg(instance, Drv2605lRegAutoCalComp, (uint8_t*)&calib_data->auto_cal_comp_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Auto Cal Comp reg");
+            break;
+        }
+        ret = drv2605l_write_reg(instance, Drv2605lRegAutoCalBemf, (uint8_t*)&calib_data->auto_cal_bemf_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Auto Cal BEMF reg");
+            break;
+        }
+        ret = drv2605l_write_reg(instance, Drv2605lRegFeedback, (uint8_t*)&calib_data->feedback_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Feedback reg");
+            break;
+        }
+    } while(0);
+
+    return ret >= PICO_OK;
+}
+
+uint32_t drv2605l_size_calibration_data(Drv2605l* instance) {
+    furi_check(instance);
+    UNUSED(instance);
+    return sizeof(Drv2605lCalibrationData);
+}
+
+static bool drv2605l_load_settings(Drv2605l* instance) {
+    furi_assert(instance);
+    //Set LNA library
+    Drv2605lLibSelect lib_select_reg = {
+        .hi_z_mode = 0, //Normal mode
+        .library_sel = 6, //LRA
     };
     Drv2605lControl1 control1_reg = {
         .startup_boost = 1, //enabled
@@ -102,65 +272,42 @@ bool drv2605l_auto_calibrate(Drv2605l* instance) {
         .n_pwm_analog = 0, //PWM Input
         .lra_open_loop = 0, //Auto-resonance mode
     };
-    Drv2605lMode mode_reg = {
-        .device_reset = 0, //Normal operation
-        .standby = 0, //Active mode
-        .mode_select = 0b111, //Auto-calibration mode
-    };
     Drv2605lControl4 control4_reg = {
         .auto_cal_time = 2, //1000:1200 ms
         .otp_status = 0,
         .otp_program = 0, //OTP Memory has not been programmed
         .zc_det_time = 0, //100us
     };
-    Drv2605lGo go_reg = {
-        .go_bit = 1, //Start auto-calibration
-    };
 
-    drv2605l_write_reg(instance, Drv2605lRegRatedVoltage, &rated_voltage_reg);
-    drv2605l_write_reg(instance, Drv2605lRegOverdriveClamp, &overdrive_clamp_reg);
-    drv2605l_write_reg(instance, Drv2605lRegFeedback, (uint8_t*)&feedback_reg);
-    drv2605l_write_reg(instance, Drv2605lRegControl1, (uint8_t*)&control1_reg);
-    drv2605l_write_reg(instance, Drv2605lRegControl2, (uint8_t*)&control2_reg);
-    drv2605l_write_reg(instance, Drv2605lRegControl3, (uint8_t*)&control3_reg);
-    drv2605l_write_reg(instance, Drv2605lRegMode, (uint8_t*)&mode_reg);
-    drv2605l_write_reg(instance, Drv2605lRegControl4, (uint8_t*)&control4_reg);
-    drv2605l_write_reg(instance, Drv2605lRegGo, (uint8_t*)&go_reg);
-
-    // Wait for completion
-    uint32_t timeout = furi_get_tick() + 2000;
-    while(furi_get_tick() < timeout) {
-        uint16_t go_status = 0;
-        drv2605l_read_reg(instance, Drv2605lRegGo, &go_status);
-        Drv2605lGo* go_reg_status = (Drv2605lGo*)&go_status;
-        if(go_reg_status->go_bit == 0) {
+    int ret = 0;
+    do {
+        ret = drv2605l_write_reg(instance, Drv2605lRegLibSelect, (uint8_t*)&lib_select_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Lib Select reg");
             break;
         }
-        furi_delay_ms(10);
-    }
-
-    uint16_t status = 0;
-    drv2605l_read_reg(instance, Drv2605lRegStatus, &status);
-    Drv2605lStatus* status_reg = (Drv2605lStatus*)&status;
-
-    if(status_reg->diagnostic_result) {
-        FURI_LOG_E(TAG, "Auto-calibration failed");
-        return false;
-    }
-
-    FURI_LOG_I(TAG, "Auto-calibration successful");
-
-    //Calib reg 0x18, 0x19, 0x1A (BEMFGain)
-    uint8_t calib_data = 0;
-
-    drv2605l_read_reg(instance, Drv2605lRegAutoCalComp, (uint16_t*)&calib_data);
-    FURI_LOG_I(TAG, "Auto Cal Compensation: reg 0x%02X -> 0x%02X", Drv2605lRegAutoCalComp, calib_data);
-    drv2605l_read_reg(instance, Drv2605lRegAutoCalBemf, (uint16_t*)&calib_data);
-    FURI_LOG_I(TAG, "Auto Cal BEMF: reg 0x%02X -> 0x%02X", Drv2605lRegAutoCalBemf, calib_data);
-    drv2605l_read_reg(instance, Drv2605lRegFeedback, (uint16_t*)&calib_data);
-    FURI_LOG_I(TAG, "Feedback: reg 0x%02X -> 0x%02X", Drv2605lRegFeedback, calib_data);
-
-    return true;
+        ret = drv2605l_write_reg(instance, Drv2605lRegControl1, (uint8_t*)&control1_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Control1 reg");
+            break;
+        }
+        ret = drv2605l_write_reg(instance, Drv2605lRegControl2, (uint8_t*)&control2_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Control2 reg");
+            break;
+        }
+        ret = drv2605l_write_reg(instance, Drv2605lRegControl3, (uint8_t*)&control3_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Control3 reg");
+            break;
+        }
+        ret = drv2605l_write_reg(instance, Drv2605lRegControl4, (uint8_t*)&control4_reg);
+        if(ret < PICO_OK) {
+            FURI_LOG_E(TAG, "Failed to write Control4 reg");
+            break;
+        }
+    } while(0);
+    return ret >= PICO_OK;
 }
 
 Drv2605l* drv2605l_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pin_en, const GpioPin* pin_trigger, uint8_t address) {
@@ -183,14 +330,17 @@ Drv2605l* drv2605l_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pi
     if(ret) {
         drv2605l_enable(instance);
 
-        //Set LNA library
-        Drv2605lLibSelect lib_select_reg = {
-            .hi_z_mode = 0, //Normal mode
-            .library_sel = 6, //LRA
-        };
-        drv2605l_write_reg(instance, Drv2605lRegLibSelect, (uint8_t*)&lib_select_reg);
+        // //Set LNA library
+        // Drv2605lLibSelect lib_select_reg = {
+        //     .hi_z_mode = 0, //Normal mode
+        //     .library_sel = 6, //LRA
+        // };
+        // drv2605l_write_reg(instance, Drv2605lRegLibSelect, (uint8_t*)&lib_select_reg);
+        if(!drv2605l_load_settings(instance)) {
+            FURI_LOG_E(TAG, "Failed to load settings");
+        }
 
-        drv2605l_auto_calibrate(instance);
+        // drv2605l_auto_calibration(instance);
 
         drv2605l_disable(instance);
     } else {

--- a/lib/drivers/drv2605l/drv2605l.c
+++ b/lib/drivers/drv2605l/drv2605l.c
@@ -89,34 +89,7 @@ bool drv2605l_auto_calibration(Drv2605l* instance) {
         .loop_gain = 1, //Medium
         .bemf_gain = 2, //1.365x
     };
-    // Drv2605lControl1 control1_reg = {
-    //     .startup_boost = 1, //enabled
-    //     .ac_couple = 0, //DC coupled
-    //     .drive_time = 19, // <--Setting
-    // };
-    // Drv2605lControl2 control2_reg = {
-    //     .bidir_input = 1, //Bidir input
-    //     .brake_stabilizer = 0, //disabled
-    //     .sample_time = 3, //300us
-    //     .blanking_time = 1,
-    //     .idiss_time = 1,
-    // };
-    // Drv2605lControl3 control3_reg = {
-    //     .ng_thresh = 2, //4%
-    //     .erm_open_loop = 0, //Closed loop
-    //     .supply_comp_dis = 0, //Enabled
-    //     .data_fomat_rtp = 0, //Signed
-    //     .lra_drive_mode = 0, //Once per cycle
-    //     .n_pwm_analog = 0, //PWM Input
-    //     .lra_open_loop = 0, //Auto-resonance mode
-    // };
-    // Drv2605lControl4 control4_reg = {
-    //     .auto_cal_time = 2, //1000:1200 ms
-    //     .otp_status = 0,
-    //     .otp_program = 0, //OTP Memory has not been programmed
-    //     .zc_det_time = 0, //100us
-    // };
-
+    
     Drv2605lMode mode_reg = {
         .device_reset = 0, //Normal operation
         .standby = 0, //Active mode
@@ -246,6 +219,7 @@ uint32_t drv2605l_size_calibration_data(Drv2605l* instance) {
 
 static bool drv2605l_load_settings(Drv2605l* instance) {
     furi_assert(instance);
+
     //Set LNA library
     Drv2605lLibSelect lib_select_reg = {
         .hi_z_mode = 0, //Normal mode
@@ -330,18 +304,10 @@ Drv2605l* drv2605l_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pi
     if(ret) {
         drv2605l_enable(instance);
 
-        // //Set LNA library
-        // Drv2605lLibSelect lib_select_reg = {
-        //     .hi_z_mode = 0, //Normal mode
-        //     .library_sel = 6, //LRA
-        // };
-        // drv2605l_write_reg(instance, Drv2605lRegLibSelect, (uint8_t*)&lib_select_reg);
         if(!drv2605l_load_settings(instance)) {
             FURI_LOG_E(TAG, "Failed to load settings");
         }
-
-        // drv2605l_auto_calibration(instance);
-
+        
         drv2605l_disable(instance);
     } else {
         FURI_LOG_E(TAG, "DRV2605L device not ready at address 0x%02X", instance->address);

--- a/lib/drivers/drv2605l/drv2605l.h
+++ b/lib/drivers/drv2605l/drv2605l.h
@@ -7,6 +7,7 @@
 #define DRV2605L_ADDRESS (0x5Au)
 
 typedef struct Drv2605l Drv2605l;
+typedef struct Drv2605lCalibrationData Drv2605lCalibrationData;
 
 typedef enum {
     Drv2605lModeTriggerGo = 0b000,
@@ -29,6 +30,11 @@ void drv2605l_trigger_set_effect(Drv2605l* instance, Drv2605lModeTrigger trigger
 void drv2605l_trigger_go(Drv2605l* instance, bool play);
 void drv2605l_trigger_set_effect_and_play(Drv2605l* instance, Drv2605lEffect effect_index);
 void drv2605l_test_all_effects(Drv2605l* instance);
+
+bool drv2605l_auto_calibration(Drv2605l* instance);
+uint32_t drv2605l_size_calibration_data(Drv2605l* instance);
+bool drv2605l_get_calibration_data(Drv2605l* instance, Drv2605lCalibrationData* calib_data);
+bool drv2605l_set_calibration_data(Drv2605l* instance, const Drv2605lCalibrationData* calib_data);
 
 #ifdef __cplusplus
 }

--- a/targets/f100/config/furi_nwm_key_config.h
+++ b/targets/f100/config/furi_nwm_key_config.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define FURI_NWM_HAPTIC_KEY_CALIB_DATA "haptic_calib_data"

--- a/targets/f100/furi_hal/furi_hal_nvm.c
+++ b/targets/f100/furi_hal/furi_hal_nvm.c
@@ -103,3 +103,17 @@ FuriHalNvmStorage furi_hal_nvm_get_bool(const char* key, bool* value) {
     int rc = kvs_get(key, value, sizeof(*value), NULL);
     return furi_hal_nvm_check_error(key, rc);
 }
+
+FuriHalNvmStorage furi_hal_nvm_set_struct(const char* key, const void* ptr, size_t size) {
+    furi_check(key);
+    furi_check(ptr);
+    int rc = kvs_set(key, ptr, size);
+    return furi_hal_nvm_check_error(key, rc);
+}
+
+FuriHalNvmStorage furi_hal_nvm_get_struct(const char* key, void* ptr, size_t size) {
+    furi_check(key);
+    furi_check(ptr);
+    int rc = kvs_get(key, ptr, size, NULL);
+    return furi_hal_nvm_check_error(key, rc);
+}

--- a/targets/f100/furi_hal/furi_hal_nvm.c
+++ b/targets/f100/furi_hal/furi_hal_nvm.c
@@ -1,9 +1,45 @@
 #include "furi_hal_nvm.h"
 #include <kvstore.h>
+#include <blockdevice/flash.h>
+#include <kvstore_logkvs.h>
+#include <pico/btstack_flash_bank.h>
 
 #define TAG "FuriHalNvm"
 
 #define FURI_HAL_NVM_MAX_STR_SIZE 256
+
+//#include "kvstore.h"
+
+#define FURI_HAL_NVM_BANK_DEFAULT_SIZE (128 * 1024)
+#define FURI_HAL_NVM_BANK_OFFSET       (PICO_FLASH_BANK_STORAGE_OFFSET - FURI_HAL_NVM_BANK_DEFAULT_SIZE)
+
+bool kvs_init(void) {
+    FURI_LOG_I(
+        TAG,
+        "Create a block device that uses 0x%08x->0x%08x(%uKB) areas of flash memory",
+        XIP_BASE + FURI_HAL_NVM_BANK_OFFSET,
+        XIP_BASE + FURI_HAL_NVM_BANK_OFFSET + FURI_HAL_NVM_BANK_DEFAULT_SIZE,
+        FURI_HAL_NVM_BANK_DEFAULT_SIZE / 1024);
+    blockdevice_t* bd = blockdevice_flash_create(FURI_HAL_NVM_BANK_OFFSET, FURI_HAL_NVM_BANK_DEFAULT_SIZE);
+
+    FURI_LOG_I(TAG, "Create a Log structured Key-Value Store that uses a block device");
+    kvs_t* kvs = kvs_logkvs_create(bd);
+
+    if(!kvs) {
+        FURI_LOG_E(TAG, "Failed to create Key-Value Store");
+        return false;
+    }
+
+    FURI_LOG_I(TAG, "Assign to global Key-Value Store");
+    kvs_assign(kvs);
+
+    return true;
+}
+
+static void furi_hal_nvm_wipe(void) {
+    // Erase the entire area used for NVM
+    flash_range_erase(FURI_HAL_NVM_BANK_OFFSET, FURI_HAL_NVM_BANK_DEFAULT_SIZE);
+}
 
 FuriHalNvmBootMode furi_hal_nvm_get_boot_mode(void) {
     return FuriHalRtcBootModeDummy;
@@ -17,7 +53,11 @@ void furi_hal_nvm_set_fault_data(uint32_t value) {
 void furi_hal_nvm_init(void) {
     // Initialize Key-Value Store
     // Defalut setting uses 128KB of flash memory for KV store, at the end of flash memory
-    kvs_init();
+    if(!kvs_init()) {
+        // ToDo: add notice that NWM is scribbled
+        furi_crash("Failed to initialize Key-Value Store");
+        furi_hal_nvm_wipe();
+    }
 }
 
 void furi_hal_nvm_deinit(void) {

--- a/targets/f100/furi_hal/furi_hal_nvm.h
+++ b/targets/f100/furi_hal/furi_hal_nvm.h
@@ -109,6 +109,24 @@ FuriHalNvmStorage furi_hal_nvm_set_bool(const char* key, bool value);
  */
 FuriHalNvmStorage furi_hal_nvm_get_bool(const char* key, bool* value);
 
+/** Set a struct in NVM storage
+ *
+ * @param      key    The key
+ * @param      ptr    Pointer to the struct
+ * @param      size   Size of the struct
+ * @return     Storage status
+ */
+FuriHalNvmStorage furi_hal_nvm_set_struct(const char* key, const void* ptr, size_t size);
+
+/** Get a struct from NVM storage
+ *
+ * @param      key    The key
+ * @param      ptr    Pointer to the struct
+ * @param      size   Size of the struct
+ * @return     Storage status
+ */
+FuriHalNvmStorage furi_hal_nvm_get_struct(const char* key, void* ptr, size_t size);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# What's new

- Furi_hal_nwm: add NVM wipe
- Haptic Srv: add save/load calibration setting

# Verification 

- The first boot is calibrated by Haptic, and the settings are saved in NVM.
- Subsequent boot cycles load calibration values ​​without recalibration.

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above
> still applies to you personally.
