### PR TITLE
fix: use head_commit for push version when commits[] is empty

### DIFF
--- a/scripts/get_env.py
+++ b/scripts/get_env.py
@@ -74,8 +74,11 @@ def get_details(event, args):
         data["commit_hash"] = event["head_commit"]["id"]
         ref = event["ref"]
     else:
-        data["commit_comment"] = shlex.quote(event["commits"][-1]["message"])
-        data["commit_hash"] = event["commits"][-1]["id"]
+        # head_commit is always present on push events; commits[] can be empty
+        # on squash-merges, force pushes, or automated pushes.
+        head = event.get("head_commit") or event["commits"][-1]
+        data["commit_comment"] = shlex.quote(head["message"])
+        data["commit_hash"] = head["id"]
         ref = event["ref"]
     data["commit_sha"] = data["commit_hash"][:8]
     data["branch_name"] = re.sub(r"refs/\w+/", "", ref)


### PR DESCRIPTION
## Summary

- Fixes `get_env.py` crashing with `IndexError` when `event["commits"]` is empty on certain push events
- Uses `head_commit` (always present on push) as the primary source; falls back to `commits[-1]` only when `head_commit` is absent
- Empty `commits[]` happens on squash-merges, force pushes, and automated/API-triggered pushes - causing the artifact suffix to be missing and producing filenames like `flipper-one-mcu-f100-firmware-.uf2`

## Test plan

- [ ] Trigger a build via squash-merge to `dev` and confirm the UF2 artifact has a valid suffix
- [ ] Confirm normal push builds still produce correct version strings

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)