### PR TITLE
Lib: add PCAL6416 drv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ file(GLOB_RECURSE SOURCES
     "lib/drivers/display/*.c*"  
     "lib/drivers/tps62868x/*.c*"
     "lib/drivers/tca6416a/*.c*"
+    "lib/drivers/pcal6416/*.c*"
     "lib/drivers/drv2605l/*.c*"
     "lib/drivers/iqs7211e/*.c*"
     "lib/drivers/spi_get_frame/*.c*"

--- a/applications/services/cli/cli.c
+++ b/applications/services/cli/cli.c
@@ -51,14 +51,19 @@ bool cli_is_connected(Cli* cli) {
 bool cli_cmd_interrupt_received(Cli* cli) {
     furi_check(cli);
     char c = '\0';
-    if(cli_is_connected(cli)) {
-        if(cli->session->rx((uint8_t*)&c, 1, 0) == 1) {
-            return c == CliSymbolAsciiETX;
-        }
-    } else {
+    if(!cli_is_connected(cli)) {
+        while(cli->session->rx((uint8_t*)&c, 1, 0) == 1) {
+        }; // Clear RX buffer
         return true;
     }
-    return false;
+
+    bool ret = false;
+    while(cli->session->rx((uint8_t*)&c, 1, 0) == 1) {
+        if(!ret && c == CliSymbolAsciiETX) {
+            ret = true;
+        }
+    }
+    return ret;
 }
 
 void cli_print_usage(const char* cmd, const char* usage, const char* arg) {

--- a/applications/services/cli/cli_ansi.h
+++ b/applications/services/cli/cli_ansi.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <furi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// text styling
+
+#define ANSI_RESET  "\e[0m"
+#define ANSI_BOLD   "\e[1m"
+#define ANSI_FAINT  "\e[2m"
+#define ANSI_INVERT "\e[7m"
+
+#define ANSI_FG_BLACK      "\e[30m"
+#define ANSI_FG_RED        "\e[31m"
+#define ANSI_FG_GREEN      "\e[32m"
+#define ANSI_FG_YELLOW     "\e[33m"
+#define ANSI_FG_BLUE       "\e[34m"
+#define ANSI_FG_MAGENTA    "\e[35m"
+#define ANSI_FG_CYAN       "\e[36m"
+#define ANSI_FG_WHITE      "\e[37m"
+#define ANSI_FG_BR_BLACK   "\e[90m"
+#define ANSI_FG_BR_RED     "\e[91m"
+#define ANSI_FG_BR_GREEN   "\e[92m"
+#define ANSI_FG_BR_YELLOW  "\e[93m"
+#define ANSI_FG_BR_BLUE    "\e[94m"
+#define ANSI_FG_BR_MAGENTA "\e[95m"
+#define ANSI_FG_BR_CYAN    "\e[96m"
+#define ANSI_FG_BR_WHITE   "\e[97m"
+
+#define ANSI_BG_BLACK      "\e[40m"
+#define ANSI_BG_RED        "\e[41m"
+#define ANSI_BG_GREEN      "\e[42m"
+#define ANSI_BG_YELLOW     "\e[43m"
+#define ANSI_BG_BLUE       "\e[44m"
+#define ANSI_BG_MAGENTA    "\e[45m"
+#define ANSI_BG_CYAN       "\e[46m"
+#define ANSI_BG_WHITE      "\e[47m"
+#define ANSI_BG_BR_BLACK   "\e[100m"
+#define ANSI_BG_BR_RED     "\e[101m"
+#define ANSI_BG_BR_GREEN   "\e[102m"
+#define ANSI_BG_BR_YELLOW  "\e[103m"
+#define ANSI_BG_BR_BLUE    "\e[104m"
+#define ANSI_BG_BR_MAGENTA "\e[105m"
+#define ANSI_BG_BR_CYAN    "\e[106m"
+#define ANSI_BG_BR_WHITE   "\e[107m"
+
+#define ANSI_FLIPPER_BRAND_ORANGE "\e[38;2;255;130;0m"
+
+// cursor positioning
+
+#define ANSI_CURSOR_UP_BY(rows)                    "\e[" rows "A"
+#define ANSI_CURSOR_DOWN_BY(rows)                  "\e[" rows "B"
+#define ANSI_CURSOR_RIGHT_BY(cols)                 "\e[" cols "C"
+#define ANSI_CURSOR_LEFT_BY(cols)                  "\e[" cols "D"
+#define ANSI_CURSOR_DOWN_BY_AND_FIRST_COLUMN(rows) "\e[" rows "E"
+#define ANSI_CURSOR_UP_BY_AND_FIRST_COLUMN(rows)   "\e[" rows "F"
+#define ANSI_CURSOR_HOR_POS(pos)                   "\e[" pos "G"
+#define ANSI_CURSOR_POS(row, col)                  "\e[" row ";" col "H"
+
+// erasing
+
+#define ANSI_ERASE_FROM_CURSOR_TO_END   "0"
+#define ANSI_ERASE_FROM_START_TO_CURSOR "1"
+#define ANSI_ERASE_ENTIRE               "2"
+
+#define ANSI_ERASE_DISPLAY(portion)  "\e[" portion "J"
+#define ANSI_ERASE_LINE(portion)     "\e[" portion "K"
+#define ANSI_ERASE_SCROLLBACK_BUFFER ANSI_ERASE_DISPLAY("3")
+
+// misc
+
+#define ANSI_INSERT_MODE_ENABLE  "\e[4h"
+#define ANSI_INSERT_MODE_DISABLE "\e[4l"
+
+typedef enum FURI_PACKED {
+    CliKeyUnrecognized = 0,
+
+    CliKeySOH = 0x01,
+    CliKeyETX = 0x03,
+    CliKeyEOT = 0x04,
+    CliKeyBell = 0x07,
+    CliKeyBackspace = 0x08,
+    CliKeyTab = 0x09,
+    CliKeyLF = 0x0A,
+    CliKeyFF = 0x0C,
+    CliKeyCR = 0x0D,
+    CliKeyETB = 0x17,
+    CliKeyEsc = 0x1B,
+    CliKeyUS = 0x1F,
+    CliKeySpace = 0x20,
+    CliKeyDEL = 0x7F,
+
+    CliKeySpecial = 0x80,
+    CliKeyLeft,
+    CliKeyRight,
+    CliKeyUp,
+    CliKeyDown,
+    CliKeyHome,
+    CliKeyEnd,
+} CliKey;
+static_assert(sizeof(CliKey) == sizeof(char));
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/services/power/power_cli.c
+++ b/applications/services/power/power_cli.c
@@ -2,6 +2,7 @@
 
 #include <args.h>
 #include <power/power.h>
+#include <cli/cli_ansi.h>
 
 static char* power_cli_get_charger_status1_vbus_str(uint8_t stat) {
     switch(stat) {
@@ -71,11 +72,8 @@ static void power_cli_print_ina219(Power* power) {
     float shunt_mv = power_ina219_get_shunt_voltage_mv(power);
 
     printf(
-        "\r\e[KINA219:\r\n"
-        "\r\e[K  VSYS:  %.3fV\r\n"
-        "\r\e[K  ISYS:  %.2fmA\r\n"
-        "\r\e[K  Shunt: %.4fmV\r\n"
-        "\r\e[K  Power: %.2fW\r\n\r\n",
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "INA219:\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VSYS:  %.3fV\r\n" ANSI_ERASE_LINE(
+            ANSI_ERASE_ENTIRE) "  ISYS:  %.2fmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Shunt: %.4fmV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Power: %.2fW\r\n\r\n",
         bus_v,
         current_a * 1000.0f,
         shunt_mv,
@@ -108,18 +106,8 @@ static void power_cli_print_bq25792(Power* power) {
     power_bq25792_get_ico_current_limit_ma(power, &ico_current_limit_ma);
 
     printf(
-        "\r\e[KBQ25792:\r\n"
-        "\r\e[K  VSYS:    %.3fV\r\n"
-        "\r\e[K  VBUS:    %.3fV\r\n"
-        "\r\e[K  IBUS:    %dmA\r\n"
-        "\r\e[K  VBAT:    %.3fV\r\n"
-        "\r\e[K  IBAT:    %dmA\r\n"
-        "\r\e[K  ChgTemp: %.2fC\r\n"
-        "\r\e[K  BatTemp: %.2fC\r\n"
-        "\r\e[K  IINDPM:  %dmA\r\n"
-        "\r\e[K  VREG:    %dmV\r\n"
-        "\r\e[K  ICHG:    %dmV\r\n"
-        "\r\e[K  ICO:     %dmA\r\n\r\n",
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "BQ25792:\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VSYS:    %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VBUS:    %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IBUS:    %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VBAT:    %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IBAT:    %dmA\r\n" ANSI_ERASE_LINE(
+            ANSI_ERASE_ENTIRE) "  ChgTemp: %.2fC\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  BatTemp: %.2fC\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IINDPM:  %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VREG:    %dmV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ICHG:    %dmV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ICO:     %dmA\r\n\r\n",
         (float_t)vsys_mv / 1000.0f,
         (float_t)vbus_mv / 1000.0f,
         ibus_ma,
@@ -179,28 +167,8 @@ static void power_cli_print_bq28z620(Power* power) {
     power_bq28z620_get_design_capacity(power, &design_capacity_mah);
 
     printf(
-        "\r\e[KBQ28Z620:\r\n"
-        "\r\e[K  Voltage:            %.3fV\r\n"
-        "\r\e[K  Current:            %dmA\r\n"
-        "\r\e[K  Temp:               %.2fC\r\n"
-        "\r\e[K  IntTemp:            %.2fC\r\n"
-        "\r\e[K  RemCap:             %dmAh\r\n"
-        "\r\e[K  FullCap:            %dmAh\r\n"
-        "\r\e[K  AvgCurr:            %dmA\r\n"
-        "\r\e[K  AvgPwr:             %dmW\r\n"
-        "\r\e[K  CycleCt:            %d\r\n"
-        "\r\e[K  SoC:                %d%%\r\n"
-        "\r\e[K  SoH:                %d%%\r\n"
-        "\r\e[K  ChgVolt:            %.3fV\r\n"
-        "\r\e[K  ChgCurr:            %dmA\r\n"
-        "\r\e[K  DesignCap:          %dmAh\r\n"
-        "\r\e[K  TimeToEmpty:        %d min\r\n"
-        "\r\e[K  AvgTimeToEmpty:     %d min\r\n"
-        "\r\e[K  TimeToFull:         %d min\r\n"
-        "\r\e[K  StandbyCurr:        %dmA\r\n"
-        "\r\e[K  StandbyTimeToEmpty: %d min\r\n"
-        "\r\e[K  MaxLoadCurr:        %dmA\r\n"
-        "\r\e[K  MaxLoadTimeToEmpty: %d min\r\n",
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "BQ28Z620:\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Voltage:            %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Current:            %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Temp:               %.2fC\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IntTemp:            %.2fC\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  RemCap:             %dmAh\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  FullCap:            %dmAh\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  AvgCurr:            %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  AvgPwr:             %dmW\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  CycleCt:            %d\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  SoC:                %d%%\r\n" ANSI_ERASE_LINE(
+            ANSI_ERASE_ENTIRE) "  SoH:                %d%%\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ChgVolt:            %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ChgCurr:            %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  DesignCap:          %dmAh\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  TimeToEmpty:        %d min\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  AvgTimeToEmpty:     %d min\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  TimeToFull:         %d min\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  StandbyCurr:        %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  StandbyTimeToEmpty: %d min\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  MaxLoadCurr:        %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  MaxLoadTimeToEmpty: %d min\r\n",
         voltage_v,
         current_ma,
         temperature_c,
@@ -229,7 +197,7 @@ static void power_cli_print_charger_status(Power* power, FuriString* arena) {
     power_bq25792_get_charger_status(power, &s);
     furi_string_set(arena, "");
 
-    printf("\r\e[K  Status0: 0x%02X", s.data[0]);
+    printf(ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Status0: 0x%02X", s.data[0]);
     if(s.stat0.vbus_present_stat) furi_string_cat_printf(arena, " VBUS_PRESENT");
     if(s.stat0.ac1_present_stat) furi_string_cat_printf(arena, " AC1_PRESENT");
     if(s.stat0.ac2_present_stat) furi_string_cat_printf(arena, " AC2_PRESENT");
@@ -243,7 +211,7 @@ static void power_cli_print_charger_status(Power* power, FuriString* arena) {
 
     // VBUS_STAT and CHG_STAT are enums — always show
     printf(
-        "\r\e[K  Status1: 0x%02X VBUS: \"%s\" CHG: \"%s\"",
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Status1: 0x%02X VBUS: \"%s\" CHG: \"%s\"",
         s.data[1],
         power_cli_get_charger_status1_vbus_str(s.stat1.vbus_stat),
         power_cli_get_status1_charger_str(s.stat1.chg_stat));
@@ -251,13 +219,13 @@ static void power_cli_print_charger_status(Power* power, FuriString* arena) {
     printf("\r\n");
 
     // ICO_STAT is an enum — always show
-    printf("\r\e[K  Status2: 0x%02X ICO: \"%s\"", s.data[2], power_cli_get_status2_ico_str(s.stat2.ico_stat));
+    printf(ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Status2: 0x%02X ICO: \"%s\"", s.data[2], power_cli_get_status2_ico_str(s.stat2.ico_stat));
     if(s.stat2.vbat_present_stat) printf(" VBAT_PRESENT");
     if(s.stat2.dpdm_stat) printf(" DPDM");
     if(s.stat2.treg_stat) printf(" TREG");
     printf("\r\n");
 
-    printf("\r\e[K  Status3: 0x%02X", s.data[3]);
+    printf(ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Status3: 0x%02X", s.data[3]);
     furi_string_set(arena, "");
     if(s.stat3.prechg_tmr_stat) furi_string_cat_printf(arena, " PRECHG_TMR");
     if(s.stat3.trichg_tmr_stat) furi_string_cat_printf(arena, " TRICHG_TMR");
@@ -269,7 +237,7 @@ static void power_cli_print_charger_status(Power* power, FuriString* arena) {
     if(furi_string_size(arena) == 0) furi_string_set(arena, " ---");
     printf("%s\r\n", furi_string_get_cstr(arena));
 
-    printf("\r\e[K  Status4: 0x%02X", s.data[4]);
+    printf(ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Status4: 0x%02X", s.data[4]);
     furi_string_set(arena, "");
     if(s.stat4.ts_hot_stat) furi_string_cat_printf(arena, " TS_HOT");
     if(s.stat4.ts_warm_stat) furi_string_cat_printf(arena, " TS_WARM");
@@ -284,7 +252,7 @@ static void power_cli_print_charger_faults(Power* power, FuriString* arena) {
     Bq25792FaultStatusReg f = {0};
     power_bq25792_get_charger_fault(power, &f);
 
-    printf("\r\e[K  Fault0:  0x%02X", f.data[0]);
+    printf(ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Fault0:  0x%02X", f.data[0]);
     furi_string_set(arena, "");
     if(f.fault0.vac1_ovp_stat) furi_string_cat_printf(arena, " VAC1_OVP");
     if(f.fault0.vac2_ovp_stat) furi_string_cat_printf(arena, " VAC2_OVP");
@@ -297,7 +265,7 @@ static void power_cli_print_charger_faults(Power* power, FuriString* arena) {
     if(furi_string_size(arena) == 0) furi_string_set(arena, " ---");
     printf("%s\r\n", furi_string_get_cstr(arena));
 
-    printf("\r\e[K  Fault1:  0x%02X", f.data[1]);
+    printf(ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Fault1:  0x%02X", f.data[1]);
     furi_string_set(arena, "");
     if(f.fault1.tshut_stat) furi_string_cat_printf(arena, " TSHUT");
     if(f.fault1.otg_uvp_stat) furi_string_cat_printf(arena, " OTG_UVP");
@@ -312,7 +280,7 @@ static void power_cli_print_bq28z620_control_status(Power* power, FuriString* ar
     Bq28z620StdCmdControlStatusRegBits s = {0};
     power_bq28z620_get_control_status(power, &s);
 
-    printf("\r\n\r\e[K  Control Status: 0x%04X", *(uint16_t*)&s);
+    printf(ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Control Status: 0x%04X", *(uint16_t*)&s);
 
     furi_string_set(arena, "");
     if(s.qmax) furi_string_cat_printf(arena, " QMAX");
@@ -340,7 +308,7 @@ static void power_cli_print_bq28z620_battery_status(Power* power, FuriString* ar
     Bq28z620StdCmdBatteryStatusRegBits s = {0};
     power_bq28z620_get_battery_status(power, &s);
 
-    printf("\r\e[K  Battery Status: 0x%04X", *(uint16_t*)&s);
+    printf(ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Battery Status: 0x%04X", *(uint16_t*)&s);
 
     furi_string_set(arena, "");
     if(s.error_code == 0x00) {
@@ -382,9 +350,9 @@ void power_cli(Cli* cli, FuriString* args, void* context) {
     UNUSED(context);
     Power* power = furi_record_open(RECORD_POWER);
     FuriString* arena = furi_string_alloc();
-    printf("\e[2J\e[0;0f"); // Clear display and return to 0
+    printf(ANSI_ERASE_DISPLAY(ANSI_ERASE_ENTIRE)); // Clear display
     while(!cli_cmd_interrupt_received(cli)) {
-        printf("\e[H\e[0;0H"); // Return to 0, but don't clear (faster and less flickery)
+        printf(ANSI_CURSOR_POS("0", "0")); // Return to 0, but don't clear (faster and less flickery)
         power_cli_print_ina219(power);
         power_cli_print_bq25792(power);
         power_cli_print_charger_status(power, arena);

--- a/applications/services/power/power_cli.c
+++ b/applications/services/power/power_cli.c
@@ -71,13 +71,18 @@ static void power_cli_print_ina219(Power* power) {
     float power_w = power_ina219_get_power_w(power);
     float shunt_mv = power_ina219_get_shunt_voltage_mv(power);
 
+    // clang-format off
     printf(
-        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "INA219:\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VSYS:  %.3fV\r\n" ANSI_ERASE_LINE(
-            ANSI_ERASE_ENTIRE) "  ISYS:  %.2fmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Shunt: %.4fmV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Power: %.2fW\r\n\r\n",
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "INA219:\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VSYS:  %.3fV\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ISYS:  %.2fmA\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Shunt: %.4fmV\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Power: %.2fW\r\n\r\n",
         bus_v,
         current_a * 1000.0f,
         shunt_mv,
         power_w);
+    // clang-format on
 }
 
 static void power_cli_print_bq25792(Power* power) {
@@ -105,9 +110,20 @@ static void power_cli_print_bq25792(Power* power) {
     power_bq25792_get_charge_current_limit_ma(power, &charge_current_limit_ma);
     power_bq25792_get_ico_current_limit_ma(power, &ico_current_limit_ma);
 
+    // clang-format off
     printf(
-        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "BQ25792:\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VSYS:    %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VBUS:    %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IBUS:    %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VBAT:    %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IBAT:    %dmA\r\n" ANSI_ERASE_LINE(
-            ANSI_ERASE_ENTIRE) "  ChgTemp: %.2fC\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  BatTemp: %.2fC\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IINDPM:  %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VREG:    %dmV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ICHG:    %dmV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ICO:     %dmA\r\n\r\n",
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "BQ25792:\r\n" 
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VSYS:    %.3fV\r\n" 
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VBUS:    %.3fV\r\n" 
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IBUS:    %dmA\r\n" 
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VBAT:    %.3fV\r\n" 
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IBAT:    %dmA\r\n" 
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ChgTemp: %.2fC\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  BatTemp: %.2fC\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IINDPM:  %dmA\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  VREG:    %dmV\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ICHG:    %dmV\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ICO:     %dmA\r\n\r\n",
         (float_t)vsys_mv / 1000.0f,
         (float_t)vbus_mv / 1000.0f,
         ibus_ma,
@@ -119,6 +135,7 @@ static void power_cli_print_bq25792(Power* power) {
         charge_voltage_limit_mv,
         charge_current_limit_ma,
         ico_current_limit_ma);
+    // clang-format on
 }
 
 static void power_cli_print_bq28z620(Power* power) {
@@ -166,9 +183,30 @@ static void power_cli_print_bq28z620(Power* power) {
     power_bq28z620_get_charging_current(power, &charging_current_ma);
     power_bq28z620_get_design_capacity(power, &design_capacity_mah);
 
+    // clang-format off
     printf(
-        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "BQ28Z620:\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Voltage:            %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Current:            %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Temp:               %.2fC\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IntTemp:            %.2fC\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  RemCap:             %dmAh\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  FullCap:            %dmAh\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  AvgCurr:            %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  AvgPwr:             %dmW\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  CycleCt:            %d\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  SoC:                %d%%\r\n" ANSI_ERASE_LINE(
-            ANSI_ERASE_ENTIRE) "  SoH:                %d%%\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ChgVolt:            %.3fV\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ChgCurr:            %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  DesignCap:          %dmAh\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  TimeToEmpty:        %d min\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  AvgTimeToEmpty:     %d min\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  TimeToFull:         %d min\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  StandbyCurr:        %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  StandbyTimeToEmpty: %d min\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  MaxLoadCurr:        %dmA\r\n" ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  MaxLoadTimeToEmpty: %d min\r\n",
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "BQ28Z620:\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Voltage:            %.3fV\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Current:            %dmA\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  Temp:               %.2fC\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  IntTemp:            %.2fC\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  RemCap:             %dmAh\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  FullCap:            %dmAh\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  AvgCurr:            %dmA\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  AvgPwr:             %dmW\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  CycleCt:            %d\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  SoC:                %d%%\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  SoH:                %d%%\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ChgVolt:            %.3fV\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  ChgCurr:            %dmA\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  DesignCap:          %dmAh\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  TimeToEmpty:        %d min\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  AvgTimeToEmpty:     %d min\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  TimeToFull:         %d min\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  StandbyCurr:        %dmA\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  StandbyTimeToEmpty: %d min\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  MaxLoadCurr:        %dmA\r\n"
+        ANSI_ERASE_LINE(ANSI_ERASE_ENTIRE) "  MaxLoadTimeToEmpty: %d min\r\n",
         voltage_v,
         current_ma,
         temperature_c,
@@ -190,6 +228,7 @@ static void power_cli_print_bq28z620(Power* power) {
         average_time_to_empty_min,
         max_load_current_ma,
         max_load_time_to_empty_min);
+    // clang-format on
 }
 
 static void power_cli_print_charger_status(Power* power, FuriString* arena) {

--- a/applications/services/power/power_cli.c
+++ b/applications/services/power/power_cli.c
@@ -229,7 +229,7 @@ static void power_cli_print_charger_status(Power* power, FuriString* arena) {
     power_bq25792_get_charger_status(power, &s);
     furi_string_set(arena, "");
 
-    printf("  Status0: 0x%02X", s.data[0]);
+    printf("\r\e[K  Status0: 0x%02X", s.data[0]);
     if(s.stat0.vbus_present_stat) furi_string_cat_printf(arena, " VBUS_PRESENT");
     if(s.stat0.ac1_present_stat) furi_string_cat_printf(arena, " AC1_PRESENT");
     if(s.stat0.ac2_present_stat) furi_string_cat_printf(arena, " AC2_PRESENT");

--- a/applications/services/power/power_cli.c
+++ b/applications/services/power/power_cli.c
@@ -71,11 +71,11 @@ static void power_cli_print_ina219(Power* power) {
     float shunt_mv = power_ina219_get_shunt_voltage_mv(power);
 
     printf(
-        "INA219:\r\n"
-        "  VSYS:  %.3fV\r\n"
-        "  ISYS:  %.2fmA\r\n"
-        "  Shunt: %.4fmV\r\n"
-        "  Power: %.2fW\r\n\r\n",
+        "\r\e[KINA219:\r\n"
+        "\r\e[K  VSYS:  %.3fV\r\n"
+        "\r\e[K  ISYS:  %.2fmA\r\n"
+        "\r\e[K  Shunt: %.4fmV\r\n"
+        "\r\e[K  Power: %.2fW\r\n\r\n",
         bus_v,
         current_a * 1000.0f,
         shunt_mv,
@@ -108,18 +108,18 @@ static void power_cli_print_bq25792(Power* power) {
     power_bq25792_get_ico_current_limit_ma(power, &ico_current_limit_ma);
 
     printf(
-        "BQ25792:\r\n"
-        "  VSYS:    %.3fV\r\n"
-        "  VBUS:    %.3fV\r\n"
-        "  IBUS:    %dmA\r\n"
-        "  VBAT:    %.3fV\r\n"
-        "  IBAT:    %dmA\r\n"
-        "  ChgTemp: %.2fC\r\n"
-        "  BatTemp: %.2fC\r\n"
-        "  IINDPM:  %dmA\r\n"
-        "  VREG:    %dmV\r\n"
-        "  ICHG:    %dmV\r\n"
-        "  ICO:     %dmA\r\n\r\n",
+        "\r\e[KBQ25792:\r\n"
+        "\r\e[K  VSYS:    %.3fV\r\n"
+        "\r\e[K  VBUS:    %.3fV\r\n"
+        "\r\e[K  IBUS:    %dmA\r\n"
+        "\r\e[K  VBAT:    %.3fV\r\n"
+        "\r\e[K  IBAT:    %dmA\r\n"
+        "\r\e[K  ChgTemp: %.2fC\r\n"
+        "\r\e[K  BatTemp: %.2fC\r\n"
+        "\r\e[K  IINDPM:  %dmA\r\n"
+        "\r\e[K  VREG:    %dmV\r\n"
+        "\r\e[K  ICHG:    %dmV\r\n"
+        "\r\e[K  ICO:     %dmA\r\n\r\n",
         (float_t)vsys_mv / 1000.0f,
         (float_t)vbus_mv / 1000.0f,
         ibus_ma,
@@ -179,28 +179,28 @@ static void power_cli_print_bq28z620(Power* power) {
     power_bq28z620_get_design_capacity(power, &design_capacity_mah);
 
     printf(
-        "BQ28Z620:\r\n"
-        "  Voltage:            %.3fV\r\n"
-        "  Current:            %dmA\r\n"
-        "  Temp:               %.2fC\r\n"
-        "  IntTemp:            %.2fC\r\n"
-        "  RemCap:             %dmAh\r\n"
-        "  FullCap:            %dmAh\r\n"
-        "  AvgCurr:            %dmA\r\n"
-        "  AvgPwr:             %dmW\r\n"
-        "  CycleCt:            %d\r\n"
-        "  SoC:                %d%%\r\n"
-        "  SoH:                %d%%\r\n"
-        "  ChgVolt:            %.3fV\r\n"
-        "  ChgCurr:            %dmA\r\n"
-        "  DesignCap:          %dmAh\r\n"
-        "  TimeToEmpty:        %d min\r\n"
-        "  AvgTimeToEmpty:     %d min\r\n"
-        "  TimeToFull:         %d min\r\n"
-        "  StandbyCurr:        %dmA\r\n"
-        "  StandbyTimeToEmpty: %d min\r\n"
-        "  MaxLoadCurr:        %dmA\r\n"
-        "  MaxLoadTimeToEmpty: %d min\r\n",
+        "\r\e[KBQ28Z620:\r\n"
+        "\r\e[K  Voltage:            %.3fV\r\n"
+        "\r\e[K  Current:            %dmA\r\n"
+        "\r\e[K  Temp:               %.2fC\r\n"
+        "\r\e[K  IntTemp:            %.2fC\r\n"
+        "\r\e[K  RemCap:             %dmAh\r\n"
+        "\r\e[K  FullCap:            %dmAh\r\n"
+        "\r\e[K  AvgCurr:            %dmA\r\n"
+        "\r\e[K  AvgPwr:             %dmW\r\n"
+        "\r\e[K  CycleCt:            %d\r\n"
+        "\r\e[K  SoC:                %d%%\r\n"
+        "\r\e[K  SoH:                %d%%\r\n"
+        "\r\e[K  ChgVolt:            %.3fV\r\n"
+        "\r\e[K  ChgCurr:            %dmA\r\n"
+        "\r\e[K  DesignCap:          %dmAh\r\n"
+        "\r\e[K  TimeToEmpty:        %d min\r\n"
+        "\r\e[K  AvgTimeToEmpty:     %d min\r\n"
+        "\r\e[K  TimeToFull:         %d min\r\n"
+        "\r\e[K  StandbyCurr:        %dmA\r\n"
+        "\r\e[K  StandbyTimeToEmpty: %d min\r\n"
+        "\r\e[K  MaxLoadCurr:        %dmA\r\n"
+        "\r\e[K  MaxLoadTimeToEmpty: %d min\r\n",
         voltage_v,
         current_ma,
         temperature_c,
@@ -243,7 +243,7 @@ static void power_cli_print_charger_status(Power* power, FuriString* arena) {
 
     // VBUS_STAT and CHG_STAT are enums — always show
     printf(
-        "  Status1: 0x%02X VBUS: \"%s\" CHG: \"%s\"",
+        "\r\e[K  Status1: 0x%02X VBUS: \"%s\" CHG: \"%s\"",
         s.data[1],
         power_cli_get_charger_status1_vbus_str(s.stat1.vbus_stat),
         power_cli_get_status1_charger_str(s.stat1.chg_stat));
@@ -251,13 +251,13 @@ static void power_cli_print_charger_status(Power* power, FuriString* arena) {
     printf("\r\n");
 
     // ICO_STAT is an enum — always show
-    printf("  Status2: 0x%02X ICO: \"%s\"", s.data[2], power_cli_get_status2_ico_str(s.stat2.ico_stat));
+    printf("\r\e[K  Status2: 0x%02X ICO: \"%s\"", s.data[2], power_cli_get_status2_ico_str(s.stat2.ico_stat));
     if(s.stat2.vbat_present_stat) printf(" VBAT_PRESENT");
     if(s.stat2.dpdm_stat) printf(" DPDM");
     if(s.stat2.treg_stat) printf(" TREG");
     printf("\r\n");
 
-    printf("  Status3: 0x%02X", s.data[3]);
+    printf("\r\e[K  Status3: 0x%02X", s.data[3]);
     furi_string_set(arena, "");
     if(s.stat3.prechg_tmr_stat) furi_string_cat_printf(arena, " PRECHG_TMR");
     if(s.stat3.trichg_tmr_stat) furi_string_cat_printf(arena, " TRICHG_TMR");
@@ -269,7 +269,7 @@ static void power_cli_print_charger_status(Power* power, FuriString* arena) {
     if(furi_string_size(arena) == 0) furi_string_set(arena, " ---");
     printf("%s\r\n", furi_string_get_cstr(arena));
 
-    printf("  Status4: 0x%02X", s.data[4]);
+    printf("\r\e[K  Status4: 0x%02X", s.data[4]);
     furi_string_set(arena, "");
     if(s.stat4.ts_hot_stat) furi_string_cat_printf(arena, " TS_HOT");
     if(s.stat4.ts_warm_stat) furi_string_cat_printf(arena, " TS_WARM");
@@ -284,7 +284,7 @@ static void power_cli_print_charger_faults(Power* power, FuriString* arena) {
     Bq25792FaultStatusReg f = {0};
     power_bq25792_get_charger_fault(power, &f);
 
-    printf("  Fault0:  0x%02X", f.data[0]);
+    printf("\r\e[K  Fault0:  0x%02X", f.data[0]);
     furi_string_set(arena, "");
     if(f.fault0.vac1_ovp_stat) furi_string_cat_printf(arena, " VAC1_OVP");
     if(f.fault0.vac2_ovp_stat) furi_string_cat_printf(arena, " VAC2_OVP");
@@ -297,7 +297,7 @@ static void power_cli_print_charger_faults(Power* power, FuriString* arena) {
     if(furi_string_size(arena) == 0) furi_string_set(arena, " ---");
     printf("%s\r\n", furi_string_get_cstr(arena));
 
-    printf("  Fault1:  0x%02X", f.data[1]);
+    printf("\r\e[K  Fault1:  0x%02X", f.data[1]);
     furi_string_set(arena, "");
     if(f.fault1.tshut_stat) furi_string_cat_printf(arena, " TSHUT");
     if(f.fault1.otg_uvp_stat) furi_string_cat_printf(arena, " OTG_UVP");
@@ -312,7 +312,7 @@ static void power_cli_print_bq28z620_control_status(Power* power, FuriString* ar
     Bq28z620StdCmdControlStatusRegBits s = {0};
     power_bq28z620_get_control_status(power, &s);
 
-    printf("\r\n  Control Status: 0x%04X", *(uint16_t*)&s);
+    printf("\r\n\r\e[K  Control Status: 0x%04X", *(uint16_t*)&s);
 
     furi_string_set(arena, "");
     if(s.qmax) furi_string_cat_printf(arena, " QMAX");
@@ -340,7 +340,7 @@ static void power_cli_print_bq28z620_battery_status(Power* power, FuriString* ar
     Bq28z620StdCmdBatteryStatusRegBits s = {0};
     power_bq28z620_get_battery_status(power, &s);
 
-    printf("  Battery Status: 0x%04X", *(uint16_t*)&s);
+    printf("\r\e[K  Battery Status: 0x%04X", *(uint16_t*)&s);
 
     furi_string_set(arena, "");
     if(s.error_code == 0x00) {
@@ -382,9 +382,9 @@ void power_cli(Cli* cli, FuriString* args, void* context) {
     UNUSED(context);
     Power* power = furi_record_open(RECORD_POWER);
     FuriString* arena = furi_string_alloc();
-
+    printf("\e[2J\e[0;0f"); // Clear display and return to 0
     while(!cli_cmd_interrupt_received(cli)) {
-        printf("\e[2J\e[0;0f"); // Clear display and return to 0
+        printf("\e[H\e[0;0H"); // Return to 0, but don't clear (faster and less flickery)
         power_cli_print_ina219(power);
         power_cli_print_bq25792(power);
         power_cli_print_charger_status(power, arena);

--- a/lib/drivers/bq28z620/bq28z620.h
+++ b/lib/drivers/bq28z620/bq28z620.h
@@ -11,8 +11,6 @@ typedef struct Bq28z620 Bq28z620;
 typedef enum {
     Bq28z620StatusUnknown = 0,
     Bq28z620StatusOk = 1,
-    Bq28z620StatusRxEmpty,
-    Bq28z620StatusTxEmpty,
     Bq28z620StatusError = -1,
     Bq28z620StatusTimeout = -2,
 } Bq28z620Status;

--- a/lib/drivers/pcal6416/pcal6416.c
+++ b/lib/drivers/pcal6416/pcal6416.c
@@ -1,0 +1,160 @@
+#include "furi_hal_gpio.h"
+#include "pcal6416_reg.h"
+#include "pcal6416.h"
+#include <furi.h>
+
+#include <furi_hal_i2c.h>
+
+#define TAG "Pcal6416"
+
+#ifdef PCAL6416_DEBUG_ENABLE
+#define PCAL6416_DEBUG(...) FURI_LOG_D(__VA_ARGS__)
+#else
+#define PCAL6416_DEBUG(...)
+#endif
+
+struct Pcal6416 {
+    const FuriHalI2cBusHandle* i2c_handle;
+    const GpioPin* pin_reset;
+    const GpioPin* pin_interrupt;
+    uint8_t address;
+    Pcal6416CallbackInput input_callback;
+    void* callback_context;
+};
+
+static __isr __not_in_flash_func(void) pcal6416_interrupt_handler(void* ctx) {
+    Pcal6416* instance = (Pcal6416*)ctx;
+    if(instance->input_callback) {
+        instance->input_callback(instance->callback_context);
+    }
+}
+
+Pcal6416* pcal6416_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pin_reset, const GpioPin* pin_interrupt, uint8_t address) {
+    Pcal6416* instance = (Pcal6416*)malloc(sizeof(Pcal6416));
+    instance->i2c_handle = i2c_handle;
+    instance->pin_reset = pin_reset;
+    instance->pin_interrupt = pin_interrupt;
+    instance->address = address;
+    furi_hal_gpio_write(instance->pin_reset, true);
+    furi_hal_gpio_init_simple(instance->pin_reset, GpioModeOutputOpenDrain);
+    furi_hal_gpio_write_open_drain(instance->pin_reset, true);
+    furi_delay_ms(10);
+
+    furi_hal_i2c_acquire(instance->i2c_handle);
+    int ret = furi_hal_i2c_device_ready(instance->i2c_handle, instance->address, FURI_HAL_I2C_TIMEOUT_US);
+    furi_hal_i2c_release(instance->i2c_handle);
+
+    if(ret) {
+        furi_hal_gpio_init_simple(instance->pin_interrupt, GpioModeInput);
+        furi_hal_gpio_add_int_callback(instance->pin_interrupt, GpioConditionFall, pcal6416_interrupt_handler, instance);
+    } else {
+        FURI_LOG_E(TAG, "PCAL6416 device not ready at address 0x%02X", instance->address);
+        furi_hal_gpio_init_ex(instance->pin_reset, GpioModeInput, GpioPullNo, GpioSpeedLow, GpioAltFnUnused);
+        free(instance);
+        return NULL;
+    }
+
+    return instance;
+}
+
+void pcal6416_deinit(Pcal6416* instance) {
+    furi_check(instance);
+    furi_hal_gpio_remove_int_callback(instance->pin_interrupt);
+    furi_hal_gpio_init_ex(instance->pin_interrupt, GpioModeInput, GpioPullNo, GpioSpeedLow, GpioAltFnUnused);
+    furi_hal_gpio_init_ex(instance->pin_reset, GpioModeInput, GpioPullNo, GpioSpeedLow, GpioAltFnUnused);
+    free(instance);
+}
+
+void pcal6416_set_input_callback(Pcal6416* instance, Pcal6416CallbackInput callback, void* context) {
+    furi_check(instance);
+    FURI_CRITICAL_ENTER();
+    instance->input_callback = callback;
+    instance->callback_context = context;
+    FURI_CRITICAL_EXIT();
+}
+
+static FURI_ALWAYS_INLINE int pcal6416_write_reg(Pcal6416* instance, Pcal6416Reg reg, uint16_t data) {
+    furi_check(instance);
+
+    uint8_t buffer[3] = {reg, data & 0xFF, data >> 8};
+
+    furi_hal_i2c_acquire(instance->i2c_handle);
+    int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
+    furi_hal_i2c_release(instance->i2c_handle);
+
+    if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
+        FURI_LOG_E(TAG, "Failed to write reg 0x%02X", reg);
+    } else {
+        PCAL6416_DEBUG(TAG, "Wrote reg 0x%02X: %016b", reg, data);
+    }
+
+    return ret;
+}
+
+static FURI_ALWAYS_INLINE int pcal6416_read_reg(Pcal6416* instance, Pcal6416Reg reg, uint16_t* data) {
+    furi_check(instance);
+    furi_check(data);
+
+    furi_hal_i2c_acquire(instance->i2c_handle);
+    int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, FURI_HAL_I2C_TIMEOUT_US);
+    if(!(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)) {
+        uint8_t buffer[2] = {0};
+        ret = furi_hal_i2c_master_rx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
+        if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
+            FURI_LOG_E(TAG, "Failed to read reg 0x%02X", reg);
+        } else {
+            *data = buffer[0] | (buffer[1] << 8);
+        }
+    } else {
+        FURI_LOG_E(TAG, "Failed to write reg address 0x%02X for reading", reg);
+    }
+    furi_hal_i2c_release(instance->i2c_handle);
+
+    return ret;
+}
+
+bool pcal6416_write_mode(Pcal6416* instance, uint16_t port_mask) {
+    furi_check(instance);
+    bool res = false;
+    int ret = PICO_ERROR_GENERIC;
+    do {
+        ret = pcal6416_write_reg(instance, Pcal6416RegInterruptMaskPort0, ~port_mask);
+        if(ret < PICO_OK) {
+            break;
+        }
+        ret = pcal6416_write_reg(instance, Pcal6416RegInputLatchPort0, port_mask);
+        if(ret < PICO_OK) {
+            break;
+        }
+        ret = pcal6416_write_reg(instance, Pcal6416RegConfigurationPort0, port_mask);
+        if(ret < PICO_OK) {
+            break;
+        }
+        res = true;
+    } while(0);
+
+    return res;
+}
+
+uint16_t pcal6416_read_mode(Pcal6416* instance) {
+    furi_check(instance);
+    uint16_t port_mask = 0;
+    if(pcal6416_read_reg(instance, Pcal6416RegConfigurationPort0, &port_mask) != PICO_ERROR_GENERIC) {
+        return port_mask;
+    }
+    return 0xFFFF; // Indicate error
+}
+
+bool pcal6416_write_output(Pcal6416* instance, uint16_t output_mask) {
+    furi_check(instance);
+    return pcal6416_write_reg(instance, Pcal6416RegOutputPort0, output_mask) != PICO_ERROR_GENERIC;
+}
+
+uint16_t pcal6416_read_input(Pcal6416* instance) {
+    furi_check(instance);
+    uint16_t input_mask = 0;
+    if(pcal6416_read_reg(instance, Pcal6416RegInputPort0, &input_mask) != PICO_ERROR_GENERIC) {
+        return input_mask;
+    }
+    return 0xFFFF; // Indicate error
+}

--- a/lib/drivers/pcal6416/pcal6416.c
+++ b/lib/drivers/pcal6416/pcal6416.c
@@ -29,6 +29,58 @@ static __isr __not_in_flash_func(void) pcal6416_interrupt_handler(void* ctx) {
     }
 }
 
+static Pcal6416Status pcal6416_check_status(int status) {
+    Pcal6416Status ret = Pcal6416StatusUnknown;
+    if(status >= PICO_OK) {
+        ret = Pcal6416StatusOk;
+    } else if(status == PICO_ERROR_GENERIC) {
+        ret = Pcal6416StatusError;
+    } else if(status == PICO_ERROR_TIMEOUT) {
+        ret = Pcal6416StatusTimeout;
+    } else {
+        ret = Pcal6416StatusUnknown;
+    }
+    return ret;
+}
+
+static FURI_ALWAYS_INLINE int pcal6416_read_reg(Pcal6416* instance, Pcal6416Reg reg, uint16_t* data) {
+    furi_check(instance);
+    furi_check(data);
+
+    uint8_t buffer[2] = {0};
+    int ret = PICO_ERROR_GENERIC;
+    furi_hal_i2c_acquire(instance->i2c_handle);
+    ret = furi_hal_i2c_master_trx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
+    furi_hal_i2c_release(instance->i2c_handle);
+
+    if(ret < PICO_OK) {
+        FURI_LOG_E(TAG, "Failed to read reg 0x%02X", reg);
+    } else {
+        *data = buffer[0] | (buffer[1] << 8);
+        PCAL6416_DEBUG(TAG, "Read reg 0x%02X: 0x%02X", reg, *data);
+    }
+
+    return pcal6416_check_status(ret);
+}
+
+static FURI_ALWAYS_INLINE Pcal6416Status pcal6416_write_reg(Pcal6416* instance, Pcal6416Reg reg, uint16_t data) {
+    furi_check(instance);
+
+    uint8_t buffer[3] = {reg, data & 0xFF, data >> 8};
+
+    furi_hal_i2c_acquire(instance->i2c_handle);
+    int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
+    furi_hal_i2c_release(instance->i2c_handle);
+
+    if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
+        FURI_LOG_E(TAG, "Failed to write reg 0x%02X", reg);
+    } else {
+        PCAL6416_DEBUG(TAG, "Wrote reg 0x%02X: %016b", reg, data);
+    }
+
+    return pcal6416_check_status(ret);
+}
+
 Pcal6416* pcal6416_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pin_reset, const GpioPin* pin_interrupt, uint8_t address) {
     Pcal6416* instance = (Pcal6416*)malloc(sizeof(Pcal6416));
     instance->i2c_handle = i2c_handle;
@@ -73,73 +125,31 @@ void pcal6416_set_input_callback(Pcal6416* instance, Pcal6416CallbackInput callb
     FURI_CRITICAL_EXIT();
 }
 
-static FURI_ALWAYS_INLINE int pcal6416_write_reg(Pcal6416* instance, Pcal6416Reg reg, uint16_t data) {
-    furi_check(instance);
-
-    uint8_t buffer[3] = {reg, data & 0xFF, data >> 8};
-
-    furi_hal_i2c_acquire(instance->i2c_handle);
-    int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
-    furi_hal_i2c_release(instance->i2c_handle);
-
-    if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
-        FURI_LOG_E(TAG, "Failed to write reg 0x%02X", reg);
-    } else {
-        PCAL6416_DEBUG(TAG, "Wrote reg 0x%02X: %016b", reg, data);
-    }
-
-    return ret;
-}
-
-static FURI_ALWAYS_INLINE int pcal6416_read_reg(Pcal6416* instance, Pcal6416Reg reg, uint16_t* data) {
-    furi_check(instance);
-    furi_check(data);
-
-    furi_hal_i2c_acquire(instance->i2c_handle);
-    int ret = furi_hal_i2c_master_tx_blocking(instance->i2c_handle, instance->address, (uint8_t*)&reg, 1, FURI_HAL_I2C_TIMEOUT_US);
-    if(!(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT)) {
-        uint8_t buffer[2] = {0};
-        ret = furi_hal_i2c_master_rx_blocking(instance->i2c_handle, instance->address, buffer, sizeof(buffer), FURI_HAL_I2C_TIMEOUT_US);
-        if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
-            FURI_LOG_E(TAG, "Failed to read reg 0x%02X", reg);
-        } else {
-            *data = buffer[0] | (buffer[1] << 8);
-        }
-    } else {
-        FURI_LOG_E(TAG, "Failed to write reg address 0x%02X for reading", reg);
-    }
-    furi_hal_i2c_release(instance->i2c_handle);
-
-    return ret;
-}
-
 bool pcal6416_write_mode(Pcal6416* instance, uint16_t port_mask) {
     furi_check(instance);
-    bool res = false;
-    int ret = PICO_ERROR_GENERIC;
+    Pcal6416Status ret = Pcal6416StatusUnknown;
     do {
         ret = pcal6416_write_reg(instance, Pcal6416RegInterruptMaskPort0, ~port_mask);
-        if(ret < PICO_OK) {
+        if(ret != Pcal6416StatusOk) {
             break;
         }
         ret = pcal6416_write_reg(instance, Pcal6416RegInputLatchPort0, port_mask);
-        if(ret < PICO_OK) {
+        if(ret != Pcal6416StatusOk) {
             break;
         }
         ret = pcal6416_write_reg(instance, Pcal6416RegConfigurationPort0, port_mask);
-        if(ret < PICO_OK) {
+        if(ret != Pcal6416StatusOk) {
             break;
         }
-        res = true;
     } while(0);
 
-    return res;
+    return ret == Pcal6416StatusOk;
 }
 
 uint16_t pcal6416_read_mode(Pcal6416* instance) {
     furi_check(instance);
     uint16_t port_mask = 0;
-    if(pcal6416_read_reg(instance, Pcal6416RegConfigurationPort0, &port_mask) != PICO_ERROR_GENERIC) {
+    if(pcal6416_read_reg(instance, Pcal6416RegConfigurationPort0, &port_mask) == Pcal6416StatusOk) {
         return port_mask;
     }
     return 0xFFFF; // Indicate error
@@ -147,13 +157,13 @@ uint16_t pcal6416_read_mode(Pcal6416* instance) {
 
 bool pcal6416_write_output(Pcal6416* instance, uint16_t output_mask) {
     furi_check(instance);
-    return pcal6416_write_reg(instance, Pcal6416RegOutputPort0, output_mask) != PICO_ERROR_GENERIC;
+    return pcal6416_write_reg(instance, Pcal6416RegOutputPort0, output_mask) == Pcal6416StatusOk;
 }
 
 uint16_t pcal6416_read_input(Pcal6416* instance) {
     furi_check(instance);
     uint16_t input_mask = 0;
-    if(pcal6416_read_reg(instance, Pcal6416RegInputPort0, &input_mask) != PICO_ERROR_GENERIC) {
+    if(pcal6416_read_reg(instance, Pcal6416RegInputPort0, &input_mask) == Pcal6416StatusOk) {
         return input_mask;
     }
     return 0xFFFF; // Indicate error

--- a/lib/drivers/pcal6416/pcal6416.h
+++ b/lib/drivers/pcal6416/pcal6416.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <furi_hal_i2c_types.h>
+#include <furi_hal_gpio.h>
+
+#define PCAL6416_ADDRESS_A0 0x20
+#define PCAL6416_ADDRESS_A1 0x21
+
+typedef struct Pcal6416 Pcal6416;
+typedef void (*Pcal6416CallbackInput)(void* context);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+Pcal6416* pcal6416_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pin_reset, const GpioPin* pin_interrupt, uint8_t address);
+void pcal6416_deinit(Pcal6416* instance);
+void pcal6416_set_input_callback(Pcal6416* instance, Pcal6416CallbackInput callback, void* context);
+bool pcal6416_write_output(Pcal6416* instance, uint16_t output_mask);
+uint16_t pcal6416_read_input(Pcal6416* instance);
+bool pcal6416_write_mode(Pcal6416* instance, uint16_t port_mask);
+uint16_t pcal6416_read_mode(Pcal6416* instance);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/drivers/pcal6416/pcal6416.h
+++ b/lib/drivers/pcal6416/pcal6416.h
@@ -9,6 +9,13 @@
 typedef struct Pcal6416 Pcal6416;
 typedef void (*Pcal6416CallbackInput)(void* context);
 
+typedef enum {
+    Pcal6416StatusUnknown = 0,
+    Pcal6416StatusOk = 1,
+    Pcal6416StatusError = -1,
+    Pcal6416StatusTimeout = -2,
+} Pcal6416Status;
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/drivers/pcal6416/pcal6416_reg.h
+++ b/lib/drivers/pcal6416/pcal6416_reg.h
@@ -1,0 +1,47 @@
+#pragma once
+
+/* clang-format off */
+//https://www.nxp.com/docs/en/data-sheet/PCAL6416A.pdf
+
+typedef enum {
+    Pcal6416RegInputPort0 = 0x00,                   /**< Input port 0, Default value: 0xXX */
+    Pcal6416RegInputPort1 = 0x01,                   /**< Input port 1, Default value: 0xXX */
+    Pcal6416RegOutputPort0 = 0x02,                  /**< Output port 0, Default value: 0xFF */
+    Pcal6416RegOutputPort1 = 0x03,                  /**< Output port 1, Default value: 0xFF */
+    Pcal6416RegPolarityInversionPort0 = 0x04,       /**< Polarity inversion port 0, Default value: 0x00 */
+    Pcal6416RegPolarityInversionPort1 = 0x05,       /**< Polarity inversion port 1, Default value: 0x00 */
+    Pcal6416RegConfigurationPort0 = 0x06,           /**< Configuration port 0, Default value: 0xFF */
+    Pcal6416RegConfigurationPort1 = 0x07,           /**< Configuration port 1, Default value: 0xFF */
+    Pcal6416RegOutputDriveStrength0_0 = 0x40,       /**< Output drive strength port 0 (gpio 0-3), Default value: 0xFF */
+    Pcal6416RegOutputDriveStrength0_1 = 0x41,       /**< Output drive strength port 0 (gpio 4-7), Default value: 0xFF */
+    Pcal6416RegOutputDriveStrength1_0 = 0x42,       /**< Output drive strength port 1 (gpio 0-3), Default value: 0xFF */
+    Pcal6416RegOutputDriveStrength1_1 = 0x43,       /**< Output drive strength port 1 (gpio 4-7), Default value: 0xFF */
+    Pcal6416RegInputLatchPort0 = 0x44,              /**< Input latch port 0, Default value: 0x00 */
+    Pcal6416RegInputLatchPort1 = 0x45,              /**< Input latch port 1, Default value: 0x00 */
+    Pcal6416RegPullupPulldownEnablePort0 = 0x46,    /**< Pull-up/pull-down enable port 0, Default value: 0x00 */
+    Pcal6416RegPullupPulldownEnablePort1 = 0x47,    /**< Pull-up/pull-down enable port 1, Default value: 0x00 */
+    Pcal6416RegPullupPulldownSelectionPort0 = 0x48, /**< Pull-up/pull-down selection port 0, Default value: 0xFF */
+    Pcal6416RegPullupPulldownSelectionPort1 = 0x49, /**< Pull-up/pull-down selection port 1, Default value: 0xFF */
+    Pcal6416RegInterruptMaskPort0 = 0x4A,           /**< Interrupt mask port 0, Default value: 0xFF */
+    Pcal6416RegInterruptMaskPort1 = 0x4B,           /**< Interrupt mask port 1, Default value: 0xFF */
+    Pcal6416RegInterruptStatusPort0 = 0x4C,         /**< Interrupt status port 0, Default value: 0x00 */
+    Pcal6416RegInterruptStatusPort1 = 0x4D,         /**< Interrupt status port 1, Default value: 0x00 */
+    Pcal6416RegOutputPortConfiguration = 0x4F,      /**< Output port configuration, Default value: 0x00 */
+
+} Pcal6416Reg;
+
+typedef struct {
+    uint8_t cc0 : 2;        // Output drive strength for GPIO 0, 00b = 0.25×, 01b = 0.5×, 10b = 0.75× or 11b = 1× of the drive capability of the I/O
+    uint8_t cc1 : 2;        // Output drive strength for GPIO 1, 00b = 0.25×, 01b = 0.5×, 10b = 0.75× or 11b = 1× of the drive capability of the I/O
+    uint8_t cc2 : 2;        // Output drive strength for GPIO 2, 00b = 0.25×, 01b = 0.5×, 10b = 0.75× or 11b = 1× of the drive capability of the I/O
+    uint8_t cc3 : 2;        // Output drive strength for GPIO 3, 00b = 0.25×, 01b = 0.5×, 10b = 0.75× or 11b = 1× of the drive capability of the I/O
+    uint8_t cc4 : 2;        // Output drive strength for GPIO 3, 00b = 0.25×, 01b = 0.5×, 10b = 0.75× or 11b = 1× of the drive capability of the I/O
+    uint8_t cc5 : 2;        // Output drive strength for GPIO 5, 00b = 0.25×, 01b = 0.5×, 10b = 0.75× or 11b = 1× of the drive capability of the I/O
+    uint8_t cc6 : 2;        // Output drive strength for GPIO 6, 00b = 0.25×, 01b = 0.5×, 10b = 0.75× or 11b = 1× of the drive capability of the I/O
+    uint8_t cc7 : 2;        // Output drive strength for GPIO 7, 00b = 0.25×, 01b = 0.5×, 10b = 0.75× or 11b = 1× of the drive capability of the I/O
+} Pcal6416RegOutputDriveStrengthRegBits;
+_Static_assert(
+    sizeof(Pcal6416RegOutputDriveStrengthRegBits) == 2,
+    "Size check for 'Pcal6416RegOutputDriveStrengthRegBits' failed.");
+
+/* clang-format on */

--- a/targets/f100/furi_bsp/furi_bsp_expander.c
+++ b/targets/f100/furi_bsp/furi_bsp_expander.c
@@ -1,5 +1,5 @@
 #include <furi_hal_i2c_config.h>
-#include <drivers/tca6416a/tca6416a.h>
+#include <drivers/pcal6416/pcal6416.h>
 #include <stdio.h>
 
 #include "furi_bsp_expander.h"
@@ -7,7 +7,7 @@
 #define TAG "BspExpander"
 
 typedef struct {
-    Tca6416a* handle;
+    Pcal6416* handle;
     FuriCallback callback;
 } ExpanderControl;
 
@@ -17,7 +17,7 @@ typedef struct {
 } ExpanderCallbackStorage;
 
 typedef struct {
-    Tca6416a* handle;
+    Pcal6416* handle;
     FuriThreadId thread_id;
     InputExpMain input_mask_old;
     FuriBspControlExpanderMain control_state;
@@ -64,11 +64,11 @@ static void furi_bsp_expander_control_init(void) {
     furi_check(expander_control == NULL);
 
     expander_control = malloc(sizeof(ExpanderControl));
-    expander_control->handle = tca6416a_init(&furi_hal_i2c_handle_control, &gpio_expander_reset, &gpio_expander_int, TCA6416A_ADDRESS_A0);
+    expander_control->handle = pcal6416_init(&furi_hal_i2c_handle_control, &gpio_expander_reset, &gpio_expander_int, PCAL6416_ADDRESS_A0);
     if(expander_control->handle) {
         FURI_LOG_I(TAG, "Initializing Control Expander");
-        tca6416a_write_output(expander_control->handle, 0x0000); // All outputs low by default
-        tca6416a_write_mode(expander_control->handle, InputKeyMask);
+        pcal6416_write_output(expander_control->handle, 0x0000); // All outputs low by default
+        pcal6416_write_mode(expander_control->handle, InputKeyMask);
     } else {
         FURI_LOG_E(TAG, "Failed to initialize Control Expander");
     }
@@ -86,7 +86,7 @@ static int32_t furi_bsp_expander_callback_thread(void* context) {
         furi_thread_flags_wait(EXPANDER_MAIN_THREAD_FLAG_ISR, FuriFlagWaitAny, FuriWaitForever);
 
         // Trigger on interrupts that changed and transitioned from high to low (active low)
-        InputExpMain input = ~tca6416a_read_input(instance->handle) & InputExpMainInputMask;
+        InputExpMain input = ~pcal6416_read_input(instance->handle) & InputExpMainInputMask;
         EXPANDER_DEBUG("Expander Main Input: 0x%02X", input);
         InputExpMain changed = (input ^ instance->input_mask_old) & input;
         instance->input_mask_old = input;
@@ -148,18 +148,18 @@ static void furi_bsp_expander_main_init(void) {
     furi_check(expander_main == NULL);
 
     expander_main = malloc(sizeof(ExpanderMain));
-    expander_main->handle = tca6416a_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, TCA6416A_ADDRESS_A0);
+    expander_main->handle = pcal6416_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, PCAL6416_ADDRESS_A0);
 
     if(expander_main->handle) {
         FURI_LOG_I(TAG, "Initializing Main Expander");
-        tca6416a_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+        pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
         expander_main->control_state = FuriBspControlExpanderMainMcu;
         // Todo: Errata lay the I2C line
         uint32_t output_mask = furi_bsp_expander_main_read_output();
         furi_bsp_expander_main_write_output(output_mask | OutputExpMainVcc5v0DevS0En);
-        tca6416a_write_mode(expander_main->handle, InputExpMainInputMask);
+        pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
 
-        expander_main->input_mask_old = ~tca6416a_read_input(expander_main->handle) & InputExpMainInputMask;
+        expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
         expander_main->thread_id = furi_thread_alloc_ex("ExpanderMainWorker", 1024, furi_bsp_expander_callback_thread, expander_main);
         furi_thread_start(expander_main->thread_id);
     } else {
@@ -170,19 +170,19 @@ static void furi_bsp_expander_main_init(void) {
 void furi_bsp_main_reset(void) {
     furi_check(expander_main != NULL);
     if(expander_main->handle) {
-        tca6416a_deinit(expander_main->handle);
+        pcal6416_deinit(expander_main->handle);
 
         furi_hal_gpio_write_open_drain(&gpio_main_board_reset, false);
         furi_delay_ms(50);
         furi_hal_gpio_write_open_drain(&gpio_main_board_reset, true);
         furi_delay_ms(10);
 
-        tca6416a_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, TCA6416A_ADDRESS_A0);
-        tca6416a_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+        pcal6416_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, PCAL6416_ADDRESS_A0);
+        pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
         expander_main->control_state = FuriBspControlExpanderMainMcu;
         // Todo: Errata lay the I2C line
         furi_bsp_expander_main_write_output(OutputExpMainVcc5v0DevS0En);
-        tca6416a_write_mode(expander_main->handle, InputExpMainInputMask);
+        pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
     } else {
         furi_bsp_show_error_message_main_expander();
     }
@@ -215,7 +215,7 @@ bool furi_bsp_expander_is_initialized(FuriBspDevice* device) {
 uint16_t furi_bsp_expander_control_read_buttons(void) {
     furi_assert(expander_control != NULL);
     if(expander_control->handle) {
-        return tca6416a_read_input(expander_control->handle) & InputKeyMask;
+        return pcal6416_read_input(expander_control->handle) & InputKeyMask;
     } else {
         furi_bsp_show_error_message_control_expander();
         return 0;
@@ -226,7 +226,7 @@ void furi_bsp_expander_control_attach_buttons_callback(FuriCallback callback, vo
     furi_check(callback != NULL);
     if(expander_control->handle) {
         furi_check(expander_control->callback == NULL);
-        tca6416a_set_input_callback(expander_control->handle, callback, context);
+        pcal6416_set_input_callback(expander_control->handle, callback, context);
     } else {
         furi_bsp_show_error_message_control_expander();
     }
@@ -235,7 +235,7 @@ void furi_bsp_expander_control_attach_buttons_callback(FuriCallback callback, vo
 void furi_bsp_expander_control_led_power(uint16_t led_mask) {
     furi_check(expander_control != NULL);
     if(expander_control->handle) {
-        tca6416a_write_output(expander_control->handle, led_mask & StatusLedPowerMask);
+        pcal6416_write_output(expander_control->handle, led_mask & StatusLedPowerMask);
     } else {
         furi_bsp_show_error_message_control_expander();
     }
@@ -244,7 +244,7 @@ void furi_bsp_expander_control_led_power(uint16_t led_mask) {
 void furi_bsp_expander_main_write_output(uint16_t output_mask) {
     furi_check(expander_main != NULL);
     if(expander_main->handle) {
-        tca6416a_write_output(expander_main->handle, output_mask & OutputExpMainMask);
+        pcal6416_write_output(expander_main->handle, output_mask & OutputExpMainMask);
     } else {
         furi_bsp_show_error_message_main_expander();
     }
@@ -253,7 +253,7 @@ void furi_bsp_expander_main_write_output(uint16_t output_mask) {
 uint16_t furi_bsp_expander_main_read_output(void) {
     furi_check(expander_main != NULL);
     if(expander_main->handle) {
-        return tca6416a_read_input(expander_main->handle) & OutputExpMainMask;
+        return pcal6416_read_input(expander_main->handle) & OutputExpMainMask;
     } else {
         furi_bsp_show_error_message_main_expander();
         return 0;
@@ -263,7 +263,7 @@ uint16_t furi_bsp_expander_main_read_output(void) {
 uint16_t furi_bsp_expander_main_read_input(void) {
     furi_assert(expander_main != NULL);
     if(expander_main->handle) {
-        return tca6416a_read_input(expander_main->handle) & InputExpMainInputMask;
+        return pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
     } else {
         furi_bsp_show_error_message_main_expander();
         return 0;
@@ -277,10 +277,10 @@ void furi_bsp_expander_main_set_control(FuriBspControlExpanderMain control) {
             return;
         }
         if(control == FuriBspControlExpanderMainMcu) {
-            tca6416a_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+            pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
             expander_main->control_state = FuriBspControlExpanderMainMcu;
         } else {
-            tca6416a_set_input_callback(expander_main->handle, NULL, NULL);
+            pcal6416_set_input_callback(expander_main->handle, NULL, NULL);
             expander_main->control_state = FuriBspControlExpanderMainCpu;
         }
     } else {


### PR DESCRIPTION
# What's new

- Lib: add PCAL6416 drv
- Furi_bsp: use PCAL6416 drv
- Cli: disable flickering when displaying output from the "power" command
- Cli: fix Ctrl+C

# Verification 

- It is necessary to replace the TCA6416A on the Control and Main boards with the PCAL6416.
- Flash the firmware and verify functionality.
- P.S. Backward compatibility of the current driver with the TCA6416 chip has been preserved.

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above
> still applies to you personally.
