### PR TITLE
docs: add manual build and flashing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,27 @@ Builds run automatically on every push to the `dev` branch, on tag pushes, and o
 
 ## Manual build
 
-### Prerequisites
+### Quick setup (recommended)
+
+Install the [Raspberry Pi Pico VS Code Extension](https://marketplace.visualstudio.com/items?itemName=raspberry-pi.raspberry-pi-pico). It installs CMake, the ARM GCC toolchain, the Pico SDK, and picotool under `~/.pico-sdk/` and is picked up automatically by CMake. No further setup required.
+
+### Manual setup
+
+If you prefer not to use VS Code, install the following manually:
 
 - [CMake](https://cmake.org/) >= 3.13
 - ARM GCC toolchain (arm-none-eabi), version 14.2 recommended  
   Download: [Arm GNU Toolchain Downloads](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
-- [Pico SDK](https://github.com/raspberrypi/pico-sdk) 2.2.0
-- [picotool](https://github.com/raspberrypi/picotool) 2.2.0 (required for flashing)
-
-The quickest setup is the [Raspberry Pi Pico VS Code Extension](https://marketplace.visualstudio.com/items?itemName=raspberry-pi.raspberry-pi-pico), which installs the SDK and toolchain under `~/.pico-sdk/` and is picked up automatically by CMake. For a manual SDK install, set the `PICO_SDK_PATH` environment variable to the SDK root before building.
+- [Pico SDK](https://github.com/raspberrypi/pico-sdk) 2.2.0  
+  Set the `PICO_SDK_PATH` environment variable to the SDK root before building.
+- [picotool](https://github.com/raspberrypi/picotool) 2.2.0 (required for flashing)  
+  See the [picotool README](https://github.com/raspberrypi/picotool#building-picotool) for build and install instructions.
 
 ### Build steps
 
 ```bash
-git clone https://github.com/flipperdevices/flipperone-mcu-firmware
+git clone --recursive https://github.com/flipperdevices/flipperone-mcu-firmware
 cd flipperone-mcu-firmware
-git submodule update --init --recursive
 
 mkdir build && cd build
 cmake .. -DFIRMWARE_TARGET=100
@@ -54,7 +59,7 @@ The build produces `flipperone-mcu-firmware.uf2` in the `build/` directory.
 ### Option 1: UF2 drag-and-drop
 
 1. Hold the BOOTSEL button on the MCU board and connect it via USB.
-2. It mounts as a USB mass storage device (`RPI-RP2`).
+2. It mounts as a USB mass storage device (`RP2350`).
 3. Copy `flipperone-mcu-firmware.uf2` to the drive.
 4. The device reboots automatically when the copy finishes.
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,51 @@ Builds run automatically on every push to the `dev` branch, on tag pushes, and o
 ### [`📥 Download latest dev firmware →`](https://update.flipperzero.one/builds/flipper-one-mcu/dev/)
 **⚠️ TODO:** make a proper build server address and folder structure instead of using `flipperzero.one`
 
-## Manual build 
+## Manual build
 
-**⚠️ TODO:** how to build manually? 
+### Prerequisites
+
+- [CMake](https://cmake.org/) >= 3.13
+- ARM GCC toolchain (arm-none-eabi), version 14.2 recommended  
+  Download: [Arm GNU Toolchain Downloads](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- [Pico SDK](https://github.com/raspberrypi/pico-sdk) 2.2.0
+- [picotool](https://github.com/raspberrypi/picotool) 2.2.0 (required for flashing)
+
+The quickest setup is the [Raspberry Pi Pico VS Code Extension](https://marketplace.visualstudio.com/items?itemName=raspberry-pi.raspberry-pi-pico), which installs the SDK and toolchain under `~/.pico-sdk/` and is picked up automatically by CMake. For a manual SDK install, set the `PICO_SDK_PATH` environment variable to the SDK root before building.
+
+### Build steps
+
+```bash
+git clone https://github.com/flipperdevices/flipperone-mcu-firmware
+cd flipperone-mcu-firmware
+git submodule update --init --recursive
+
+mkdir build && cd build
+cmake .. -DFIRMWARE_TARGET=100
+cmake --build . --parallel
+```
+
+The build produces `flipperone-mcu-firmware.uf2` in the `build/` directory.
+
+## Flashing
+
+### Option 1: UF2 drag-and-drop
+
+1. Hold the BOOTSEL button on the MCU board and connect it via USB.
+2. It mounts as a USB mass storage device (`RPI-RP2`).
+3. Copy `flipperone-mcu-firmware.uf2` to the drive.
+4. The device reboots automatically when the copy finishes.
+
+### Option 2: picotool
+
+```bash
+picotool load build/flipperone-mcu-firmware.uf2 --force
+picotool reboot
+```
+
+### Option 3: Pre-built firmware
+
+Download the latest firmware from [Automated builds](#automated-builds) and flash using either method above.
 
 ## Join development
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,11 @@ The build produces `flipperone-mcu-firmware.uf2` in the `build/` directory.
 
 ## Flashing
 
+For the procedure to put the device into firmware update mode and flash the MCU, see the [official firmware update documentation](https://docs.flipper.net/one/mcu-firmware/firmware-update). The exact steps depend on the hardware revision and are expected to change as the bootloader entry process is hardened. The mass storage label also depends on the target: on the standalone development board the disk mounts as `RP2350` (stock Raspberry Pi bootloader), and on the real Flipper One it is renamed to `FlipOneMCU` via [OTP white labeling](https://github.com/flipperdevices/flipperone-mcu-firmware/blob/dev/targets/f100/furi_hal/furi_hal_otp.c#L37).
+
 ### Option 1: UF2 drag-and-drop
 
-1. Hold the BOOTSEL button on the MCU board and connect it via USB.
-2. It mounts as a USB mass storage device (`RP2350`).
-3. Copy `flipperone-mcu-firmware.uf2` to the drive.
-4. The device reboots automatically when the copy finishes.
+Once the device is in firmware update mode and mounted as a mass storage device, copy `flipperone-mcu-firmware.uf2` to the drive. The device reboots automatically when the copy finishes.
 
 ### Option 2: picotool
 


### PR DESCRIPTION
Replaces the TODO placeholder in the Manual build section with step-by-step instructions.

**What this adds:**

Prerequisites section listing CMake >= 3.13, ARM GCC 14.2 (arm-none-eabi), Pico SDK 2.2.0, and picotool 2.2.0. Notes that the Raspberry Pi Pico VS Code Extension handles the SDK and toolchain setup automatically via `~/.pico-sdk/`, and documents the `PICO_SDK_PATH` fallback for manual installs.

Build steps covering `git submodule update --init --recursive`, the `cmake` configure command with `FIRMWARE_TARGET=100`, and `cmake --build . --parallel`.

A new Flashing section with three options: UF2 drag-and-drop via BOOTSEL, picotool command-line flashing, and downloading pre-built firmware from CI.

Closes #59