### PR TITLE
Power: USB port state - Sink/source, overcurrent

### DIFF
--- a/applications/services/pd/pd.c
+++ b/applications/services/pd/pd.c
@@ -85,31 +85,39 @@ static void pd_custom_event_callback(uint32_t events, void* context) {
     Pd* instance = (Pd*)context;
 
     if(events & PdEventTypeIsr) {
-        // fusb302_read_role(instance->fusb302_header);
+        if(instance->mode == PdModeOff) {
+            return;
+        }
 
-        // fusb302_pd_reset_hard(instance->fusb302_header);
+        Fusb302ReadRoleResult role_result = fusb302_read_role(instance->fusb302_header);
 
-        // fusb302_cc_orientation_set(instance->fusb302_header, PdTypeCcOrientationNormal);
-        // fusb302_pd_reset_logic(instance->fusb302_header);
-        // fusb302_pd_autogoodcrc_set(instance->fusb302_header, true);
-        // fusb302_pd_autoretry_set(instance->fusb302_header, 3);
-        // fusb302_pd_rx_flush(instance->fusb302_header);
+        if(role_result == Fusb302ReadRoleResultToggleDone) {
+            Fusb302PortState fusb302_port_state = Fusb302PortStateUndefined;
+            Fusb302Status res = fusb302_get_port_state(instance->fusb302_header, &fusb302_port_state);
+            if(res != Fusb302StatusOk) {
+                FURI_LOG_E(TAG, "Failed to get port state");
+                return;
+            }
 
-        // for(uint8_t i = 0;i<10; i++) {
-        //     PdPdMsg msg;
-        //     PdStatus res = fusb302_pd_message_receive(instance->fusb302_header, &msg);
-
-        //     if(res == PdStatusOk) {
-        //         FURI_LOG_W(TAG, "Received PD message: SOP=%d, Header=0x%04X, Objects=%d", msg.sop_type, msg.header, msg.object_count);
-        //     } else if(res == PdStatusRxEmpty) {
-        //         FURI_LOG_W(TAG, "No PD message received (Rx FIFO empty)");
-        //         break;
-        //     } else {
-        //         FURI_LOG_W(TAG, "Error receiving PD message");
-        //         break;
-        //     }
-        //     furi_delay_ms(50);
-        // }
+            PdPortState pd_state = PdPortStateUndefined;
+            switch(fusb302_port_state) {
+            case Fusb302PortStateToggling: pd_state = PdPortStateToggling; break;
+            case Fusb302PortStateSourceCC1: pd_state = PdPortStateSourceCC1; break;
+            case Fusb302PortStateSourceCC2: pd_state = PdPortStateSourceCC2; break;
+            case Fusb302PortStateSinkCC1: pd_state = PdPortStateSinkCC1; break;
+            case Fusb302PortStateSinkCC2: pd_state = PdPortStateSinkCC2; break;
+            case Fusb302PortStateAudioAccessory: pd_state = PdPortStateAudioAccessory; break;
+            case Fusb302PortStateOvercurrent: pd_state = PdPortStateUndefined; break; // not a TOGSS value, can never be returned by fusb302_get_port_state
+            case Fusb302PortStateUndefined: pd_state = PdPortStateUndefined; break;
+            }
+            PdEvent event = {.port_state = pd_state};
+            furi_pubsub_publish(instance->event_pubsub, &event);
+        }
+        else if (role_result == Fusb302ReadRoleResultOvercurrent) {
+            PdPortState pd_state = PdPortStateOvercurrent;
+            PdEvent event = {.port_state = pd_state};
+            furi_pubsub_publish(instance->event_pubsub, &event);
+        }
     }
 }
 

--- a/applications/services/pd/pd.h
+++ b/applications/services/pd/pd.h
@@ -9,6 +9,20 @@ typedef enum {
    PdDeviceFusb302 = (1 << 0),
 } PdDevice;
 
+typedef enum {
+    PdPortStateToggling,       // DRP toggle in progress, no role determined yet
+    PdPortStateSourceCC1,      // Flipper is power source, cable on CC1
+    PdPortStateSourceCC2,      // Flipper is power source, cable on CC2
+    PdPortStateSinkCC1,        // Flipper is charging (sink), cable on CC1
+    PdPortStateSinkCC2,        // Flipper is charging (sink), cable on CC2
+    PdPortStateAudioAccessory, // Audio adapter detected
+    PdPortStateOvercurrent,    // VCONN over-current or over-temperature event
+    PdPortStateUndefined,      // Unknown or undetected state
+} PdPortState;
+
+typedef struct {
+    PdPortState port_state;
+} PdEvent;
 
 typedef enum {
     PdModeOff,

--- a/lib/drivers/fusb302/fusb302.c
+++ b/lib/drivers/fusb302/fusb302.c
@@ -170,7 +170,7 @@ Fusb302Status fusb302_start_drp_logic(Fusb302* instance) {
         mask_a.m_retryfail = 1; // Mask retry fail interrupts
         mask_a.m_softfail = 1; // Mask soft reset fail interrupts
         mask_a.m_togdone = 0; // Mask toggle done interrupts
-        mask_a.m_ocp_temp = 1; // Mask over-current/temperature interrupts
+        mask_a.m_ocp_temp = 0; // Mask over-current/temperature interrupts
         res = fusb302_write_reg(instance, Fusb302RegMaskA, *(uint8_t*)&mask_a);
         if(res != Fusb302StatusOk) {
             break;
@@ -282,11 +282,11 @@ Fusb302Status fusb302_pd_reset(Fusb302* instance) {
     return res;
 }
 
-bool fusb302_read_role(Fusb302* instance) {
+Fusb302ReadRoleResult fusb302_read_role(Fusb302* instance) {
     // Read interrupts to determine what happened
     Fusb302InterruptRegBits irq_bits = {0};
     Fusb302InterruptARegBits irq_a_bits = {0};
-    bool ret = false;
+    Fusb302ReadRoleResult ret = Fusb302ReadRoleResultNothing;
     fusb302_read_reg(instance, Fusb302RegInterruptA, (uint8_t*)&irq_a_bits);
     fusb302_read_reg(instance, Fusb302RegInterrupt, (uint8_t*)&irq_bits);
     FUSB302_DEBUG(TAG, "Interrupt A: %02X", *(uint8_t*)&irq_a_bits);
@@ -326,7 +326,7 @@ bool fusb302_read_role(Fusb302* instance) {
             FUSB302_DEBUG(TAG, "Toggling still in progress or unknown...\n");
             break;
         }
-        ret = true;
+        ret = Fusb302ReadRoleResultToggleDone;
 
     } else if(irq_bits.i_comp_chng) { // Checking I_COMP_CHNG bit (bit 5)
         FUSB302_DEBUG(TAG, "FUSB302_INTERRUPT_MASK_COMP_CHNG\n");
@@ -336,6 +336,9 @@ bool fusb302_read_role(Fusb302* instance) {
         FUSB302_DEBUG(TAG, "FUSB302_INTERRUPT_MASK_VBUSOK\n");
         fusb302_start_drp_logic(instance);
 
+    } else if (irq_a_bits.i_ocp_temp) { // Checking I_OCP_TEMP bit (bit 7)
+        FUSB302_DEBUG(TAG, "FUSB302_INTERRUPT_MASK_OCP_TEMP\n");
+        return Fusb302ReadRoleResultOvercurrent;
     } else {
         // FUSB302_DEBUG(TAG, "Toggle not completed yet...\n");
     }
@@ -410,6 +413,49 @@ Fusb302Status fusb302_cc_orientation_set(Fusb302* instance, Fusb302TypeCcOrienta
         FURI_LOG_E(TAG, "Failed to set CC orientation!");
     }
     return res;
+}
+
+Fusb302Status fusb302_get_port_state(Fusb302* instance, Fusb302PortState* state) {
+    furi_check(instance);
+    furi_check(state);
+
+    Fusb302Status1ARegBits status1a = {0};
+    Fusb302Status res = fusb302_read_reg(instance, Fusb302RegStatus1A, (uint8_t*)&status1a);
+    if (res != Fusb302StatusOk) {
+        return res;
+    }
+
+    switch(status1a.togss) {
+    case FUSB302_STATUS1A_TOGSS_TOGGLE_LOGIC_RUNNING: // 000 - Toggle logic running
+        *state = Fusb302PortStateToggling;
+        FUSB302_DEBUG(TAG, "Toggling\n");
+        break;
+    case FUSB302_STATUS1A_TOGSS_SRCON_CC1: // 001 - Source on CC1
+        *state = Fusb302PortStateSourceCC1;
+        FUSB302_DEBUG(TAG, "Source CC1\n");
+        break;
+    case FUSB302_STATUS1A_TOGSS_SRCON_CC2: // 010 - Source on CC2
+        *state = Fusb302PortStateSourceCC2;
+        FUSB302_DEBUG(TAG, "Source CC2\n");
+        break;
+    case FUSB302_STATUS1A_TOGSS_SNKON_CC1: // 101 - Sink on CC1
+        *state = Fusb302PortStateSinkCC1;
+        FUSB302_DEBUG(TAG, "Sink CC1\n");
+        break;
+    case FUSB302_STATUS1A_TOGSS_SNKON_CC2: // 110 - Sink on CC2
+        *state = Fusb302PortStateSinkCC2;
+        FUSB302_DEBUG(TAG, "Sink CC2\n");
+        break;
+    case FUSB302_STATUS1A_TOGSS_AUDIO_ACCESSORY: // 111 - Audio Accessory
+        *state = Fusb302PortStateAudioAccessory;
+        FUSB302_DEBUG(TAG, "Audio Accessory\n");
+        break;
+    default:
+        *state = Fusb302PortStateUndefined;
+        FUSB302_DEBUG(TAG, "Undefined\n");
+        break;
+    }
+    return Fusb302StatusOk;
 }
 
 //////////////////////PD//////////////////////

--- a/lib/drivers/fusb302/fusb302.h
+++ b/lib/drivers/fusb302/fusb302.h
@@ -36,6 +36,24 @@ typedef enum {
     Fusb302TypeCcOrientationReverse, //!< Cable is plugged in upside-down (CC2 active)
 } Fusb302TypeCcOrientation;
 
+typedef enum {
+    Fusb302PortStateToggling,     // TOGSS=000: DRP toggle still running, no role yet
+    Fusb302PortStateSourceCC1,    // TOGSS=001: Flipper is source, CC1
+    Fusb302PortStateSourceCC2,    // TOGSS=010: Flipper is source, CC2
+    Fusb302PortStateSinkCC1,      // TOGSS=101: Flipper is sink (charging), cable on CC1
+    Fusb302PortStateSinkCC2,      // TOGSS=110: Flipper is sink (charging), cable on CC2
+    Fusb302PortStateAudioAccessory, // TOGSS=111: audio adapter detected, not a power role
+    Fusb302PortStateOvercurrent,    // I_OCP_TEMP: VCONN switch over-current or over-temperature
+    Fusb302PortStateUndefined,    // TOGSS=other: datasheet says do not interpret
+} Fusb302PortState;
+
+typedef enum {
+    Fusb302ReadRoleResultNothing,
+    Fusb302ReadRoleResultToggleDone,
+    Fusb302ReadRoleResultOvercurrent,
+} Fusb302ReadRoleResult;
+
+
 /**
  * USB Power Delivery message structure.
  *
@@ -60,12 +78,13 @@ extern "C" {
 Fusb302* fusb302_init(const FuriHalI2cBusHandle* i2c_handle, uint8_t address, const GpioPin* pin_interrupt);
 void fusb302_read_cc_status(Fusb302* instance, uint8_t cc);
 void fusb302_deinit(Fusb302* instance);
-bool fusb302_read_role(Fusb302* instance);
+Fusb302ReadRoleResult fusb302_read_role(Fusb302* instance);
 void fusb302_set_input_callback(Fusb302* instance, Fusb302Callback callback, void* context);
 Fusb302Status fusb302_start_drp_logic(Fusb302* instance);
 Fusb302Status fusb302_sw_reset(Fusb302* instance);
 
 Fusb302Status fusb302_cc_orientation_set(Fusb302* instance, Fusb302TypeCcOrientation orientation);
+Fusb302Status fusb302_get_port_state(Fusb302* instance, Fusb302PortState* state);
 // pd
 Fusb302Status fusb302_pd_reset_logic(Fusb302* instance);
 Fusb302Status fusb302_pd_reset_hard(Fusb302* instance);


### PR DESCRIPTION
Closes #40
# What's new
- FUSB302 driver: new `fusb302_get_port_state()` reads the `TOGSS` bitfield from `STATUS1A` and maps it to a `Fusb302PortState` enum (source/sink on CC1/CC2, audio accessory, or still toggling).
- FUSB302 driver: `fusb302_read_role()` now returns `Fusb302ReadRoleResult` (`Nothing` / `ToggleDone` / `Overcurrent`) instead of `bool`, so faults are distinguishable from no-ops.
- FUSB302 driver: unmasked the `I_OCP_TEMP` interrupt (`m_ocp_temp = 0`) to enable VCONN overcurrent / overtemperature reporting.
- PD service: added `PdPortState` enum and `PdEvent` struct to `pd.h` as a driver-agnostic public API, including `PdPortStateOvercurrent` (sourced only from the interrupt path, never from TOGSS).
- PD service: rewrote the ISR callback (previously a commented-out polling stub). On `ToggleDone` it reads port state and publishes a `PdEvent`; on `Overcurrent` it publishes an overcurrent event. Early-returns when `PdModeOff`.
- Events are delivered via the existing PD `furi_pubsub`, so subscribers can react without polling or coupling to PD internals.

# Verification
- Build the firmware and flash to the device.
- Plug in a USB-C source with the cable in one orientation; confirm a `PdEvent` is published with the expected sink-on-CC1 or sink-on-CC2 state. Flip the cable and confirm the opposite CC line is reported.
- Plug into a sink (e.g. another device acting as a consumer); confirm the source-on-CC1 / source-on-CC2 states are reported correctly.
- Plug in an audio accessory adapter; confirm the audio accessory state is reported.
- Trigger a VCONN overcurrent (e.g. short VCONN to GND through a current-limited path); confirm a `PdPortStateOvercurrent` event is published and that it arrives via the interrupt path.
- Set PD mode to off and repeat a plug event; confirm no events are published (early return path).
- Subscribe to the PD pubsub from a simple test consumer and confirm exactly one event fires per state change.

**Note:** The firmware builds successfully locally. I don't have hardware for on-device verification - someone with hardware testing against the steps above is requested! 

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [ ] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI
