### PR TITLE
fix(i2c_multi): add synchronization and volatile

### DIFF
--- a/lib/drivers/i2c_multi_slave/i2c_multi.c
+++ b/lib/drivers/i2c_multi_slave/i2c_multi.c
@@ -1,6 +1,7 @@
 #include "i2c_multi.h"
 
 #include "hardware/irq.h"
+#include "hardware/sync.h"
 
 #define CLK_DIV 16
 
@@ -53,8 +54,10 @@ void i2c_multi_init(PIO pio, uint pin) {
 }
 
 void i2c_multi_set_write_buffer(uint8_t* buffer) {
+    uint32_t __save = save_and_disable_interrupts();
     i2c_multi->buffer = buffer;
     i2c_multi->buffer_start = buffer;
+    restore_interrupts(__save);
 }
 
 void i2c_multi_set_receive_handler(i2c_multi_receive_handler_t handler) {
@@ -70,23 +73,31 @@ void i2c_multi_set_stop_handler(i2c_multi_stop_handler_t handler) {
 }
 
 void i2c_multi_enable_address(uint8_t address) {
+    uint32_t __save = save_and_disable_interrupts();
     i2c_multi->address[address / 32] |= 1 << (address % 32);
+    restore_interrupts(__save);
 }
 
 void i2c_multi_disable_address(uint8_t address) {
+    uint32_t __save = save_and_disable_interrupts();
     i2c_multi->address[address / 32] &= ~(1 << (address % 32));
+    restore_interrupts(__save);
 }
 
 void i2c_multi_enable_all_addresses() {
+    uint32_t __save = save_and_disable_interrupts();
     for(size_t i = 0; i < I2C_MULTI_COUNT_ADDRESS; i++) {
         i2c_multi->address[i] = 0xFFFFFFFF;
     }
+    restore_interrupts(__save);
 }
 
 void i2c_multi_disable_all_addresses() {
+    uint32_t __save = save_and_disable_interrupts();
     for(size_t i = 0; i < I2C_MULTI_COUNT_ADDRESS; i++) {
         i2c_multi->address[i] = 0;
     }
+    restore_interrupts(__save);
 }
 
 bool i2c_multi_is_address_enabled(uint8_t address) {
@@ -94,6 +105,7 @@ bool i2c_multi_is_address_enabled(uint8_t address) {
 }
 
 void i2c_multi_disable(void) {
+    uint32_t __save = save_and_disable_interrupts();
     pio_sm_set_enabled(i2c_multi->pio, i2c_multi->sm_read, false);
     pio_sm_set_enabled(i2c_multi->pio, i2c_multi->sm_write, false);
     pio_sm_set_enabled(i2c_multi->pio, i2c_multi->sm_start, false);
@@ -105,9 +117,11 @@ void i2c_multi_disable(void) {
     i2c_multi->bytes_count = 0;
     i2c_multi->status = I2C_IDLE;
     i2c_multi->buffer = i2c_multi->buffer_start;
+    restore_interrupts(__save);
 }
 
 void i2c_multi_restart(void) {
+    uint32_t __save = save_and_disable_interrupts();
     i2c_multi_disable();
     pio_sm_restart(i2c_multi->pio, i2c_multi->sm_start);
     pio_sm_restart(i2c_multi->pio, i2c_multi->sm_stop);
@@ -119,6 +133,7 @@ void i2c_multi_restart(void) {
     pio_sm_set_enabled(i2c_multi->pio, i2c_multi->sm_write, true);
     pio_sm_set_enabled(i2c_multi->pio, i2c_multi->sm_start, true);
     pio_sm_set_enabled(i2c_multi->pio, i2c_multi->sm_stop, true);
+    restore_interrupts(__save);
 }
 
 void i2c_multi_remove(void) {
@@ -132,17 +147,23 @@ void i2c_multi_remove(void) {
     pio_sm_unclaim(i2c_multi->pio, i2c_multi->sm_stop);
     pio_sm_unclaim(i2c_multi->pio, i2c_multi->sm_read);
     pio_sm_unclaim(i2c_multi->pio, i2c_multi->sm_write);
-    i2c_multi->buffer = NULL;
-    i2c_multi->buffer_start = NULL;
-    i2c_multi->bytes_count = 0;
-    i2c_multi->status = I2C_IDLE;
+    {
+        uint32_t __save = save_and_disable_interrupts();
+        i2c_multi->buffer = NULL;
+        i2c_multi->buffer_start = NULL;
+        i2c_multi->bytes_count = 0;
+        i2c_multi->status = I2C_IDLE;
+        restore_interrupts(__save);
+    }
     gpio_set_input_enabled(i2c_multi->pin, true);
     gpio_set_input_enabled(i2c_multi->pin + 1, true);
     free(i2c_multi);
 }
 
 void i2c_multi_fixed_length(int16_t length) {
+    uint32_t __save = save_and_disable_interrupts();
     i2c_multi->length = length;
+    restore_interrupts(__save);
 }
 
 static inline void start_condition_program_init(PIO pio, uint sm, uint offset, uint pin) {

--- a/lib/drivers/i2c_multi_slave/i2c_multi.h
+++ b/lib/drivers/i2c_multi_slave/i2c_multi.h
@@ -25,11 +25,12 @@ typedef void (*i2c_multi_stop_handler_t)(uint8_t length);
 typedef struct i2c_multi_t {
     PIO pio;
     uint offset_read, offset_write, sm_read, sm_write, offset_start, offset_stop, sm_start, sm_stop, pin;
-    i2c_multi_status_t status;
-    uint8_t *buffer, *buffer_start;
-    uint8_t bytes_count;
-    int16_t length;
-    uint address[I2C_MULTI_COUNT_ADDRESS];
+    volatile i2c_multi_status_t status;
+    uint8_t* volatile buffer;
+    uint8_t* volatile buffer_start;
+    volatile uint8_t bytes_count;
+    volatile int16_t length;
+    volatile uint address[I2C_MULTI_COUNT_ADDRESS];
 } i2c_multi_t;
 
 void i2c_multi_init(PIO pio, uint pin);


### PR DESCRIPTION
## Changelog
```
The global `i2c_multi` pointer and its struct fields (`status`, `buffer`, `buffer_start`, 
`bytes_count`, `length`, `address[]`) are accessed from both PIO IRQ handlers 
(`byte_handler_pio`, `stop_handler_pio`) and task- context functions 
(`i2c_multi_set_write_buffer`, `i2c_multi_disable`, etc.) with no synchronization and no 
`volatile` qualifiers. The compiler may cache shared values in registers, leading to stale 
reads and state corruption. PIO IRQ handlers are not wrapped in critical sections (unlike the 
hardware I2C slave ISR), so task-context access can race with ISR execution.

The fix:
- Add `volatile` to all ISR-accessed struct fields in `i2c_multi_t`
- Add `#include "hardware/sync.h"` and wrap all task-context functions that access shared state 
with `save_and_disable_interrupts()` / `restore_interrupts()` to prevent ISR preemption during 
critical sections
- Functions protected: `i2c_multi_set_write_buffer`, `i2c_multi_enable_address`, 
`i2c_multi_disable_address`, `i2c_multi_enable_all_addresses`, 
`i2c_multi_disable_all_addresses`, `i2c_multi_disable`, `i2c_multi_restart`, 
`i2c_multi_remove`, `i2c_multi_fixed_length`

Note: The `buffer` and `buffer_start` pointers themselves are declared `uint8_t* volatile` 
(volatile pointer to non-volatile data) because the ISR modifies the pointer value via `buffer+
+` while the task sets it. The data the buffer points to is caller-owned and not volatile.

Build: cmake build succeeds with no warnings.
Test: Since it is a synchronization fix, I could not prepare a reproducer to validate the 
problem mentioned. Only verified via build, flashing it to Pico 2 and having the shell access.
```

# What's New

I see that i2c_multi driver has `i2c_multi_t` struct type. It stores a shared state accessed by both task contexts and ISRs (`byte_handler_pio`, `stop_handler_pio`). It does not have `volatile` keyword, therefore is quite unprotected for race conditions. Imagine a scenario where `i2c_multi_set_write_buffer` assigns `buffer` then `buffer_start` non-atomically. If the ISR fires between the two assignments, it reads a stale `buffer_start` while `buffer` already points to the new location, causing the slave to send data from the wrong memory. It creates an inconsistent state. The same pattern applies to all shared fields: `address[]` is written by `*_enable_address()` and read by the address‑matching ISR; `status`, `bytes_count`, `length` are written/read across contexts.

I wrapped every function that writes a shared field with `save_and_disable_interrupts()` / `restore_interrupts()` from Pico SDK. [Find the reference for the functions.](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html) This creates an atomic critical section that prevents ISRs from observing a partial update, acts as a compiler barrier, guaranteeing the stores are visible to the ISR before interrupts are re‑enabled.

# Verification 

I have no idea how to test it, even. I tried to make a reproducer with AI that tries to fire ISR while the task is exactly at that stage, with a sleep condition on the task, and by connecting two I2C ports to each other to trigger an ISR. Although what I have is a valid concern (IMO) and the setup should give me some data points, I could not reproduce it. Therefore, it is totally up to maintainers to see the value from the patch, and think if its reasonable.

To be clearer, of course, I built the firmware, flashed it to Pico 2, and saw that we have shell running. But that's all.

# Contributor Checklist

- [X] I have read the changes in this PR and understand what they do
- [X] I can explain the approach taken and why alternatives were not chosen
- [X] I have tested these changes myself (on hardware or in simulation)
- [X] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above
> still applies to you personally.
