### PR TITLE
Licensing

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,11 @@
+# Flipper One MCU firmware license information
+
+Source code in this repository is covered by several licenses.
+
+Most of the first-party code is licensed under MIT. A small subset of files ported from the [Flipper Zero firmware](https://github.com/flipperdevices/flipperzero-firmware) is GPL-3.0-or-later.
+
+Graphical assets and documentation (`assets/`, `docs/`, `*.md`) are licensed under CC-BY-SA-4.0.
+
+Third-party libraries and individual files keep their original licenses. In-file SPDX headers take precedence over everything else.
+
+For full details see [REUSE.toml](REUSE.toml), which precisely describes the license of every file. See https://reuse.software/ for more info on interpreting this file.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,6 +6,6 @@ Most of the first-party code is licensed under MIT. A small subset of files port
 
 Graphical assets and documentation (`assets/`, `docs/`, `*.md`) are licensed under CC-BY-SA-4.0.
 
-Third-party libraries and individual files keep their original licenses. In-file SPDX headers take precedence over everything else.
+Third-party libraries and individual files are distributed under their respective upstream licenses. In-file SPDX headers take precedence over everything else.
 
 For full details see [REUSE.toml](REUSE.toml), which precisely describes the license of every file. See https://reuse.software/ for more info on interpreting this file.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,6 +6,6 @@ Most of the first-party code is licensed under MIT. A small subset of files port
 
 Graphical assets and documentation (`assets/`, `docs/`, `*.md`) are licensed under CC-BY-SA-4.0.
 
-Third-party libraries and individual files are distributed under their respective upstream licenses. In-file SPDX headers take precedence over everything else.
+Third-party libraries and individual files are distributed under their respective original licenses. In-file SPDX headers take precedence over everything else.
 
 For full details see [REUSE.toml](REUSE.toml), which precisely describes the license of every file. See https://reuse.software/ for more info on interpreting this file.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,70 @@
+version = 1
+
+# Default: everything in the repo is MIT, copyright Flipper FZCO.
+# `precedence = "closest"` means an in-file SPDX header (if any) wins over this TOML entry.
+[[annotations]]
+path = "**"
+precedence = "closest"
+SPDX-FileCopyrightText = "2024-2026 Flipper FZCO"
+SPDX-License-Identifier = "MIT"
+
+# GPL-3.0-or-later: files ported from the Flipper Zero firmware
+# (https://github.com/flipperdevices/flipperzero-firmware).
+[[annotations]]
+path = [
+    "applications/services/cli/cli_command_gpio.c",
+    "applications/services/cli/cli_command_gpio.h",
+    "applications/services/cli/cli_commands_common.c",
+    "applications/services/cli/cli_commands_common.h",
+    "applications/services/cli/cli_main_shell.c",
+    "applications/services/input/input.c",
+    "applications/services/input/input.h",
+    "lib/toolbox/hex.c",
+    "lib/toolbox/hex.h",
+    "lib/toolbox/m_cstr_dup.h",
+]
+precedence = "closest"
+SPDX-FileCopyrightText = "2024-2026 Flipper FZCO"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+# Assets (artwork, icons, fonts, etc.) and documentation.
+[[annotations]]
+path = [
+    "assets/**",
+    "docs/**",
+    "**.md",
+]
+precedence = "closest"
+SPDX-FileCopyrightText = "2024-2026 Flipper FZCO"
+SPDX-License-Identifier = "CC-BY-SA-4.0"
+
+# Third-party: Clay immediate-mode UI library by Nic Barker
+# (https://github.com/nicbarker/clay).
+[[annotations]]
+path = [
+    "applications/services/gui/clay.c",
+    "applications/services/gui/clay.h",
+]
+precedence = "closest"
+SPDX-FileCopyrightText = "2024 Nic Barker"
+SPDX-License-Identifier = "Zlib"
+
+# Third-party: Raspberry Pi pico-examples (PIO programs and SDK import helper).
+# The three .pio files already carry their own SPDX header — kept here for clarity.
+[[annotations]]
+path = [
+    "lib/drivers/i2c_master_pio/i2c.pio",
+    "lib/drivers/ws2812/ws2812.pio",
+    "lib/uart_pio/uart_tx.pio",
+    "lib/sdk/pico_sdk_import.cmake",
+]
+precedence = "closest"
+SPDX-FileCopyrightText = "2020 Raspberry Pi (Trading) Ltd."
+SPDX-License-Identifier = "BSD-3-Clause"
+
+# Third-party: TinyUSB descriptors
+[[annotations]]
+path = "lib/tusb/usb_descriptors.c"
+precedence = "closest"
+SPDX-FileCopyrightText = "2019 Ha Thach (tinyusb.org)"
+SPDX-License-Identifier = "MIT"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -9,9 +9,11 @@ SPDX-FileCopyrightText = "2024-2026 Flipper FZCO"
 SPDX-License-Identifier = "MIT"
 
 # GPL-3.0-or-later: files ported from the Flipper Zero firmware
-# (https://github.com/flipperdevices/flipperzero-firmware).
+# (https://github.com/flipperdevices/flipperzero-firmware)
+# plus the top-level application entry points.
 [[annotations]]
 path = [
+    "applications/main/**",
     "applications/services/cli/cli_command_gpio.c",
     "applications/services/cli/cli_command_gpio.h",
     "applications/services/cli/cli_commands_common.c",


### PR DESCRIPTION
# What's new

- Added top-level REUSE.toml describing licensing for the whole repo: `MIT` by default, `GPL-3.0-or-later` for the iles ported from flipperzero-firmware, `CC-BY-SA-4.0` for assets/, docs/ and *.md, plus correct third-party tags. Submodules are left untouched.
- Closes #122

# Verification 

- Run `reuse download MIT GPL-3.0-or-later CC-BY-SA-4.0 BSD-3-Clause Zlib` then `reuse lint` — should report the project as REUSE-compliant.

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
