### PR TITLE
feat: Add I2C CLI Commands :rocket:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,6 @@ file(GLOB_RECURSE SOURCES
     "lib/tusb/*.c*"
     "applications/*.c"
     "applications/services/*.c"
-    "applications/services/cli/*.c"
     "applications/main/*.c"
     "targets/${TARGET_HARDWARE}/src/*.c*" 
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ file(GLOB_RECURSE SOURCES
     "lib/tusb/*.c*"
     "applications/*.c"
     "applications/services/*.c"
+    "applications/services/cli/*.c"
     "applications/main/*.c"
     "targets/${TARGET_HARDWARE}/src/*.c*" 
 )

--- a/applications/applications.c
+++ b/applications/applications.c
@@ -34,6 +34,7 @@ extern int32_t cli_on_system_start(void* p);
 extern void power_cli(PipeSide* pipe, FuriString* args, void* context);
 extern void power_consumption_cli(PipeSide* pipe, FuriString* args, void* context);
 extern void led_cli(PipeSide* pipe, FuriString* args, void* context);
+extern void cli_command_i2c(PipeSide* pipe, FuriString* args, void* context);
 
 const FlipperInternalApplication FLIPPER_SERVICES[] = {
     {
@@ -247,6 +248,12 @@ const FlipperInternalCommandApplication FLIPPER_CLI_COMMANDS[] = {
     {
         .callback = led_cli,
         .name = "led",
+        .stack_size = 1024,
+        .flags = CliCommandFlagParallelSafe,
+    },
+    {
+        .callback = cli_command_i2c,
+        .name = "i2c",
         .stack_size = 1024,
         .flags = CliCommandFlagParallelSafe,
     },

--- a/applications/services/cli/cli_command_i2c.c
+++ b/applications/services/cli/cli_command_i2c.c
@@ -25,7 +25,6 @@ static void cli_command_i2c_print_bus_list(void) {
 
 static void cli_command_i2c_help(void) {
     printf("Usage:\r\n");
-    printf("i2c\r\n");
     printf("i2c list\r\n");
     printf("i2c search <0|control|1|main>\r\n");
     printf("i2c write <0|control|1|main> <device_hex> <prefix_hex> <data_hex>\r\n");
@@ -104,6 +103,8 @@ static bool cli_command_i2c_parse_write_payload(FuriString* args, uint8_t** data
         return false;
     }
 
+    furi_string_right(args, hex_size);
+    furi_string_trim(args);
     return true;
 }
 
@@ -112,9 +113,7 @@ void cli_command_i2c(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(context);
 
     if(args_length(args) == 0) {
-        cli_command_i2c_scan_bus(&furi_hal_i2c_handle_control, "control");
-        printf("\r\n");
-        cli_command_i2c_scan_bus(&furi_hal_i2c_handle_main, "main");
+        cli_command_i2c_help();
         return;
     }
 

--- a/applications/services/cli/cli_command_i2c.c
+++ b/applications/services/cli/cli_command_i2c.c
@@ -1,0 +1,227 @@
+#include <cli/args.h>
+#include <containers/pipe.h>
+#include <furi.h>
+#include <furi_hal_i2c.h>
+#include <furi_hal_i2c_config.h>
+
+static const FuriHalI2cBusHandle* cli_command_i2c_resolve_bus(FuriString* bus_token) {
+    const char* bus_name = furi_string_get_cstr(bus_token);
+
+    if(strcmp(bus_name, "0") == 0 || strcmp(bus_name, "control") == 0) {
+        return &furi_hal_i2c_handle_control;
+    }
+
+    if(strcmp(bus_name, "1") == 0 || strcmp(bus_name, "main") == 0) {
+        return &furi_hal_i2c_handle_main;
+    }
+
+    return NULL;
+}
+
+static void cli_command_i2c_print_bus_list(void) {
+    printf("0 - control\r\n");
+    printf("1 - main\r\n");
+}
+
+static void cli_command_i2c_help(void) {
+    printf("Usage:\r\n");
+    printf("i2c\r\n");
+    printf("i2c list\r\n");
+    printf("i2c search <0|control|1|main>\r\n");
+    printf("i2c write <0|control|1|main> <device_hex> <prefix_hex> <data_hex>\r\n");
+    printf("i2c read <0|control|1|main> <device_hex> <prefix_hex> <length>\r\n");
+    printf("Examples:\r\n");
+    printf("i2c list\r\n");
+    printf("i2c read control 01 01 16\r\n");
+    printf("i2c write main 20 00 1010\r\n");
+}
+
+static void cli_command_i2c_scan_bus(const FuriHalI2cBusHandle* handle, const char* bus_name) {
+    furi_hal_i2c_acquire(handle);
+
+    printf("Scanning %s bus (%s):\r\n", bus_name, furi_hal_i2c_bus_name(handle));
+    printf("     0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F\r\n");
+    printf("    -----------------------------------------------\r\n");
+
+    for(uint8_t addr = 0; addr < 128; addr++) {
+        if(addr % 16 == 0) {
+            printf("%02x | ", addr);
+        }
+
+        bool is_ready = furi_hal_i2c_device_ready(handle, addr, FURI_HAL_I2C_TIMEOUT_US);
+        printf(is_ready ? "@" : ".");
+        printf(addr % 16 == 15 ? "\r\n" : "  ");
+    }
+
+    furi_hal_i2c_release(handle);
+}
+
+static bool cli_command_i2c_parse_bus(FuriString* args, const FuriHalI2cBusHandle** bus_handle) {
+    FuriString* bus_token = furi_string_alloc();
+    bool is_parsed = false;
+
+    do {
+        if(!args_read_string_and_trim(args, bus_token)) {
+            break;
+        }
+
+        *bus_handle = cli_command_i2c_resolve_bus(bus_token);
+        if(*bus_handle == NULL) {
+            break;
+        }
+
+        is_parsed = true;
+    } while(false);
+
+    furi_string_free(bus_token);
+    return is_parsed;
+}
+
+static bool cli_command_i2c_parse_hex_u8(FuriString* args, uint8_t* value) {
+    return args_read_hex_bytes(args, value, 1);
+}
+
+static bool cli_command_i2c_parse_write_payload(FuriString* args, uint8_t** data_buffer, size_t* data_size) {
+    const size_t hex_size = args_get_first_word_length(args);
+    if(hex_size == 0 || (hex_size % 2) != 0) {
+        return false;
+    }
+
+    *data_size = hex_size / 2;
+    *data_buffer = malloc(*data_size);
+
+    if(!args_read_hex_bytes(args, *data_buffer, *data_size)) {
+        free(*data_buffer);
+        *data_buffer = NULL;
+        *data_size = 0;
+        return false;
+    }
+
+    return true;
+}
+
+void cli_command_i2c(PipeSide* pipe, FuriString* args, void* context) {
+    UNUSED(pipe);
+    UNUSED(context);
+
+    if(args_length(args) == 0) {
+        cli_command_i2c_scan_bus(&furi_hal_i2c_handle_control, "control");
+        printf("\r\n");
+        cli_command_i2c_scan_bus(&furi_hal_i2c_handle_main, "main");
+        return;
+    }
+
+    FuriString* subcommand = furi_string_alloc();
+    if(!args_read_string_and_trim(args, subcommand)) {
+        furi_string_free(subcommand);
+        cli_command_i2c_help();
+        return;
+    }
+
+    if(strcmp(furi_string_get_cstr(subcommand), "list") == 0) {
+        cli_command_i2c_print_bus_list();
+        furi_string_free(subcommand);
+        return;
+    }
+
+    if(strcmp(furi_string_get_cstr(subcommand), "search") == 0) {
+        const FuriHalI2cBusHandle* bus_handle = NULL;
+        if(!cli_command_i2c_parse_bus(args, &bus_handle)) {
+            furi_string_free(subcommand);
+            cli_command_i2c_help();
+            return;
+        }
+
+        const char* bus_name = (bus_handle == &furi_hal_i2c_handle_control) ? "control" : "main";
+        cli_command_i2c_scan_bus(bus_handle, bus_name);
+        furi_string_free(subcommand);
+        return;
+    }
+
+    if(strcmp(furi_string_get_cstr(subcommand), "read") == 0) {
+        const FuriHalI2cBusHandle* bus_handle = NULL;
+        uint8_t device_address = 0;
+        uint8_t register_prefix = 0;
+        int read_length = 0;
+
+        if(!cli_command_i2c_parse_bus(args, &bus_handle) || !cli_command_i2c_parse_hex_u8(args, &device_address) ||
+           !cli_command_i2c_parse_hex_u8(args, &register_prefix) || !args_read_int_and_trim(args, &read_length) ||
+           read_length <= 0 || read_length > 255) {
+            furi_string_free(subcommand);
+            cli_command_i2c_help();
+            return;
+        }
+
+        uint8_t* read_buffer = malloc((size_t)read_length);
+
+        furi_hal_i2c_acquire(bus_handle);
+        int bytes_read = furi_hal_i2c_master_trx_blocking(
+            bus_handle,
+            device_address,
+            &register_prefix,
+            1,
+            read_buffer,
+            (size_t)read_length,
+            FURI_HAL_I2C_TIMEOUT_US);
+        furi_hal_i2c_release(bus_handle);
+
+        if(bytes_read <= 0) {
+            printf("Read failed\r\n");
+            free(read_buffer);
+            furi_string_free(subcommand);
+            return;
+        }
+
+        for(int i = 0; i < bytes_read; i++) {
+            printf("%02X", read_buffer[i]);
+            if(i + 1 < bytes_read) {
+                printf(" ");
+            }
+        }
+        printf("\r\n");
+
+        free(read_buffer);
+        furi_string_free(subcommand);
+        return;
+    }
+
+    if(strcmp(furi_string_get_cstr(subcommand), "write") == 0) {
+        const FuriHalI2cBusHandle* bus_handle = NULL;
+        uint8_t device_address = 0;
+        uint8_t register_prefix = 0;
+        uint8_t* write_payload = NULL;
+        size_t write_payload_size = 0;
+
+        if(!cli_command_i2c_parse_bus(args, &bus_handle) ||
+           !cli_command_i2c_parse_hex_u8(args, &device_address) ||
+           !cli_command_i2c_parse_hex_u8(args, &register_prefix) ||
+           !cli_command_i2c_parse_write_payload(args, &write_payload, &write_payload_size)) {
+            furi_string_free(subcommand);
+            cli_command_i2c_help();
+            return;
+        }
+
+        const size_t tx_size = write_payload_size + 1;
+        uint8_t* tx_buffer = malloc(tx_size);
+
+        tx_buffer[0] = register_prefix;
+        memcpy(&tx_buffer[1], write_payload, write_payload_size);
+
+        furi_hal_i2c_acquire(bus_handle);
+        int bytes_written =
+            furi_hal_i2c_master_tx_blocking(bus_handle, device_address, tx_buffer, tx_size, FURI_HAL_I2C_TIMEOUT_US);
+        furi_hal_i2c_release(bus_handle);
+
+        if(bytes_written != (int)tx_size) {
+            printf("Write failed\r\n");
+        }
+
+        free(tx_buffer);
+        free(write_payload);
+        furi_string_free(subcommand);
+        return;
+    }
+
+    furi_string_free(subcommand);
+    cli_command_i2c_help();
+}

--- a/applications/services/cli/cli_command_i2c.c
+++ b/applications/services/cli/cli_command_i2c.c
@@ -78,7 +78,14 @@ static bool cli_command_i2c_parse_bus(FuriString* args, const FuriHalI2cBusHandl
 }
 
 static bool cli_command_i2c_parse_hex_u8(FuriString* args, uint8_t* value) {
-    return args_read_hex_bytes(args, value, 1);
+    const size_t word_length = args_get_first_word_length(args);
+    if(!args_read_hex_bytes(args, value, 1)) {
+        return false;
+    }
+
+    furi_string_right(args, word_length);
+    furi_string_trim(args);
+    return true;
 }
 
 static bool cli_command_i2c_parse_write_payload(FuriString* args, uint8_t** data_buffer, size_t* data_size) {

--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -15,7 +15,6 @@ static void cli_commands_init(CliRegistry* registry) {
     cli_registry_add_command(registry, "top", CliCommandFlagParallelSafe, cli_command_top, NULL);
     cli_registry_add_command(registry, "free", CliCommandFlagParallelSafe, cli_command_free, NULL);
     cli_registry_add_command(registry, "free_blocks", CliCommandFlagParallelSafe, cli_command_free_blocks, NULL);
-    cli_registry_add_command(registry, "i2c", CliCommandFlagParallelSafe, cli_command_i2c, NULL);
     cli_registry_add_command(registry, "expander_ext", CliCommandFlagParallelSafe, cli_command_expander_ext, NULL);
     cli_registry_add_command(registry, "clock_out", CliCommandFlagParallelSafe, cli_command_clock_out, NULL);
     cli_registry_add_command(registry, "gpio", CliCommandFlagParallelSafe, cli_command_gpio, NULL);

--- a/applications/services/cli/cli_commands_common.c
+++ b/applications/services/cli/cli_commands_common.c
@@ -8,8 +8,6 @@
 #include <furi_bsp.h>
 #include <led/led.h>
 #include <furi_hal_clock.h>
-#include <furi_hal_i2c_types.h>
-#include <furi_hal_i2c_config.h>
 #include <furi_hal_otp.h>
 
 void cli_command_uptime(PipeSide* pipe, FuriString* args, void* context) {
@@ -176,41 +174,6 @@ void cli_command_free_blocks(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(context);
 
     memmgr_heap_printf_free_blocks();
-}
-
-static void cli_scan_i2c_bus(const FuriHalI2cBusHandle* handle, const char* bus_name) {
-    furi_hal_i2c_acquire(handle);
-    furi_check(handle);
-
-    printf("Scanning %s bus (%s):\r\n", bus_name, furi_hal_i2c_bus_name(handle));
-    printf("     0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F\r\n");
-    printf("    -----------------------------------------------\r\n");
-
-    for(uint8_t addr = 0; addr < 128; addr++) {
-        if(addr % 16 == 0) {
-            printf("%02x | ", addr);
-        }
-
-        // Perform a 1-byte dummy read from the probe address. If a slave
-        // acknowledges this address, the function returns the number of bytes
-        // transferred. If the address byte is ignored, the function returns
-        // -1.
-
-        // Skip over any reserved addresses.
-        bool ret = furi_hal_i2c_device_ready(handle, addr, FURI_HAL_I2C_TIMEOUT_US);
-        printf(ret ? "@" : ".");
-        printf(addr % 16 == 15 ? "\r\n" : "  ");
-    }
-    furi_hal_i2c_release(handle);
-}
-
-void cli_command_i2c(PipeSide* pipe, FuriString* args, void* context) {
-    UNUSED(pipe);
-    UNUSED(args);
-    UNUSED(context);
-    cli_scan_i2c_bus(&furi_hal_i2c_handle_control, "control");
-    printf("\r\n");
-    cli_scan_i2c_bus(&furi_hal_i2c_handle_main, "main");
 }
 
 static void cli_command_expander_ext_help(PipeSide* pipe, FuriString* args, void* context) {

--- a/applications/services/cli/cli_commands_common.h
+++ b/applications/services/cli/cli_commands_common.h
@@ -7,7 +7,6 @@ void cli_command_log(PipeSide* pipe, FuriString* args, void* context);
 void cli_command_top(PipeSide* pipe, FuriString* args, void* context);
 void cli_command_free(PipeSide* pipe, FuriString* args, void* context);
 void cli_command_free_blocks(PipeSide* pipe, FuriString* args, void* context);
-void cli_command_i2c(PipeSide* pipe, FuriString* args, void* context);
 void cli_command_expander_ext(PipeSide* pipe, FuriString* args, void* context);
 void cli_command_clock_out(PipeSide* pipe, FuriString* args, void* context);
 void cli_command_otp(PipeSide* pipe, FuriString* args, void* context);


### PR DESCRIPTION
# What's new

Added a dedicated CLI implementation for the `i2c` command, including bus listing, bus scanning, read, and write flows using the existing SDK argument parsing helpers.

## cli_command_i2c.c

In details:

The implementation exposes a single public entry point, `cli_command_i2c`, while the rest of the file is organized as small static helpers for bus resolution, argument parsing, bus scanning, and command-specific execution.

The first helper:

```c
static const FuriHalI2cBusHandle* cli_command_i2c_resolve_bus(FuriString* bus_token) {
    const char* bus_name = furi_string_get_cstr(bus_token);

    if(strcmp(bus_name, "0") == 0 || strcmp(bus_name, "control") == 0) {
        return &furi_hal_i2c_handle_control;
    }

    if(strcmp(bus_name, "1") == 0 || strcmp(bus_name, "main") == 0) {
        return &furi_hal_i2c_handle_main;
    }

    return NULL;
}
```

maps user-facing bus identifiers to the actual HAL bus handles. It accepts either numeric aliases (`0`, `1`) or textual names (`control`, `main`). If the input does not match one of the supported buses, the function returns `NULL`, and the caller treats that as invalid input.

Next:

```c
static void cli_command_i2c_print_bus_list(void) {
    printf("0 - control\r\n");
    printf("1 - main\r\n");
}
```

is a simple helper that prints the currently supported buses in a stable format:

- `0 - control`
- `1 - main`

This mirrors the intended UX from the issue and provides a discoverable way for users to learn which buses are available before attempting reads or writes.

Next:

```c
static void cli_command_i2c_help(void) {
    printf("Usage:\r\n");
    printf("i2c\r\n");
    printf("i2c list\r\n");
    printf("i2c search <0|control|1|main>\r\n");
    printf("i2c write <0|control|1|main> <device_hex> <prefix_hex> <data_hex>\r\n");
    printf("i2c read <0|control|1|main> <device_hex> <prefix_hex> <length>\r\n");
    printf("Examples:\r\n");
    printf("i2c list\r\n");
    printf("i2c read control 01 01 16\r\n");
    printf("i2c write main 20 00 1010\r\n");
}
```

prints the accepted command forms and example invocations.

Next:

```c
static void cli_command_i2c_scan_bus(const FuriHalI2cBusHandle* handle, const char* bus_name) {
    furi_hal_i2c_acquire(handle);

    printf("Scanning %s bus (%s):\r\n", bus_name, furi_hal_i2c_bus_name(handle));
    printf("     0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F\r\n");
    printf("    -----------------------------------------------\r\n");

    for(uint8_t addr = 0; addr < 128; addr++) {
        if(addr % 16 == 0) {
            printf("%02x | ", addr);
        }

        bool is_ready = furi_hal_i2c_device_ready(handle, addr, FURI_HAL_I2C_TIMEOUT_US);
        printf(is_ready ? "@" : ".");
        printf(addr % 16 == 15 ? "\r\n" : "  ");
    }

    furi_hal_i2c_release(handle);
}
```

performs a bus scan by iterating through all 7-bit addresses from `0x00` to `0x7F` and calling:

```c
bool furi_hal_i2c_device_ready(const FuriHalI2cBusHandle* handle, uint8_t device_address, uint32_t timeout_us) {
    int ret;
    uint8_t rxdata = 0;
    if((device_address & 0x78) == 0 || (device_address & 0x78) == 0x78)
        ret = PICO_ERROR_GENERIC;
    else
        ret = furi_hal_i2c_master_tx_blocking(handle, device_address, &rxdata, 1, timeout_us);

    return ret < PICO_OK ? false : true;
}
```

for each one. Before scanning, it acquires the bus with f`uri_hal_i2c_acquire`, and after the loop it releases it with:

```c
void furi_hal_i2c_release(const FuriHalI2cBusHandle* handle) {
    //TODO: TIME IS NEEDED TO COMPLETE THE TRANSACTION, Something needs to be done about this
    furi_delay_us(10);
    // Ensure that current handle is our handle
    furi_check(handle->bus->current_handle == handle);
    // Deactivate handle
    handle->callback(handle, FuriHalI2cBusHandleEventDeactivate);
    // Deactivate bus
    handle->bus->api.event(handle->bus, FuriHalI2cBusEventDeactivate);
    // Reset current handle
    handle->bus->current_handle = NULL;
    // Unlock bus
    handle->bus->api.event(handle->bus, FuriHalI2cBusEventUnlock);
    furi_hal_power_insomnia_exit();
}
```

The output is printed in a conventional matrix layout, where responsive devices are shown as `@` and non-responsive addresses as `.`.

Next:

```c
static bool cli_command_i2c_parse_bus(FuriString* args, const FuriHalI2cBusHandle** bus_handle) {
    FuriString* bus_token = furi_string_alloc();
    bool is_parsed = false;

    do {
        if(!args_read_string_and_trim(args, bus_token)) {
            break;
        }

        *bus_handle = cli_command_i2c_resolve_bus(bus_token);
        if(*bus_handle == NULL) {
            break;
        }

        is_parsed = true;
    } while(false);

    furi_string_free(bus_token);
    return is_parsed;
}
```

is a small parsing helper that reads the first argument token using the existing SDK function:

```c
bool args_read_string_and_trim(FuriString* args, FuriString* word) {
    size_t cmd_length = args_get_first_word_length(args);

    if(cmd_length == 0) {
        return false;
    }

    furi_string_set_n(word, args, 0, cmd_length);
    furi_string_right(args, cmd_length);
    furi_string_trim(args);

    return true;
}
```

resolves it through `cli_command_i2c_resolve_bus`, and returns success or failure.

Next:

```c
static bool cli_command_i2c_parse_hex_u8(FuriString* args, uint8_t* value) {
    return args_read_hex_bytes(args, value, 1);
}
```

is a thin wrapper over:

```c
bool args_read_hex_bytes(FuriString* args, uint8_t* bytes, size_t bytes_count) {
    const size_t expected_length = bytes_count * 2;
    const size_t word_length = args_get_first_word_length(args);

    if(word_length != expected_length) {
        return false;
    }

    if(bytes_count == 0) {
        return true;
    }

    FuriString* hex_word = furi_string_alloc();
    furi_string_set_n(hex_word, args, 0, word_length);

    size_t parsed = 0;
    bool success = hex_string_to_bytes(hex_word, bytes, bytes_count, &parsed);

    furi_string_free(hex_word);

    return success && (parsed == bytes_count);
}
```

Its purpose is mainly readability: at call sites, it makes it obvious that a single byte is expected for fields such as device address and register prefix.

Next:

```c
static bool cli_command_i2c_parse_write_payload(FuriString* args, uint8_t** data_buffer, size_t* data_size) {
    const size_t hex_size = args_get_first_word_length(args);
    if(hex_size == 0 || (hex_size % 2) != 0) {
        return false;
    }

    *data_size = hex_size / 2;
    *data_buffer = malloc(*data_size);

    if(!args_read_hex_bytes(args, *data_buffer, *data_size)) {
        free(*data_buffer);
        *data_buffer = NULL;
        *data_size = 0;
        return false;
    }

    return true;
}
```

handles the write data argument. It first checks the raw token length with:

```c
size_t args_get_first_word_length(FuriString* args) {
    size_t ws = furi_string_search_char(args, ' ');
    if(ws == FURI_STRING_FAILURE) {
        ws = furi_string_size(args);
    }

    return ws;
}
```

and rejects odd-length hex strings, since every byte must be represented by exactly two hex characters. Then it allocates a buffer of the required size and fills it through `args_read_hex_bytes`. This lets the command support arbitrary payload lengths without hardcoding a small fixed buffer.

Finally:

```c
void cli_command_i2c(PipeSide* pipe, FuriString* args, void* context) {
    UNUSED(pipe);
    UNUSED(context);

    if(args_length(args) == 0) {
        cli_command_i2c_scan_bus(&furi_hal_i2c_handle_control, "control");
        printf("\r\n");
        cli_command_i2c_scan_bus(&furi_hal_i2c_handle_main, "main");
        return;
    }

    FuriString* subcommand = furi_string_alloc();
    if(!args_read_string_and_trim(args, subcommand)) {
        furi_string_free(subcommand);
        cli_command_i2c_help();
        return;
    }

    if(strcmp(furi_string_get_cstr(subcommand), "list") == 0) {
        cli_command_i2c_print_bus_list();
        furi_string_free(subcommand);
        return;
    }

    if(strcmp(furi_string_get_cstr(subcommand), "search") == 0) {
        const FuriHalI2cBusHandle* bus_handle = NULL;
        if(!cli_command_i2c_parse_bus(args, &bus_handle)) {
            furi_string_free(subcommand);
            cli_command_i2c_help();
            return;
        }

        const char* bus_name = (bus_handle == &furi_hal_i2c_handle_control) ? "control" : "main";
        cli_command_i2c_scan_bus(bus_handle, bus_name);
        furi_string_free(subcommand);
        return;
    }

    if(strcmp(furi_string_get_cstr(subcommand), "read") == 0) {
        const FuriHalI2cBusHandle* bus_handle = NULL;
        uint8_t device_address = 0;
        uint8_t register_prefix = 0;
        int read_length = 0;

        if(!cli_command_i2c_parse_bus(args, &bus_handle) || !cli_command_i2c_parse_hex_u8(args, &device_address) ||
           !cli_command_i2c_parse_hex_u8(args, &register_prefix) || !args_read_int_and_trim(args, &read_length) ||
           read_length <= 0 || read_length > 255) {
            furi_string_free(subcommand);
            cli_command_i2c_help();
            return;
        }

        uint8_t* read_buffer = malloc((size_t)read_length);

        furi_hal_i2c_acquire(bus_handle);
        int bytes_read = furi_hal_i2c_master_trx_blocking(
            bus_handle,
            device_address,
            &register_prefix,
            1,
            read_buffer,
            (size_t)read_length,
            FURI_HAL_I2C_TIMEOUT_US);
        furi_hal_i2c_release(bus_handle);

        if(bytes_read <= 0) {
            printf("Read failed\r\n");
            free(read_buffer);
            furi_string_free(subcommand);
            return;
        }

        for(int i = 0; i < bytes_read; i++) {
            printf("%02X", read_buffer[i]);
            if(i + 1 < bytes_read) {
                printf(" ");
            }
        }
        printf("\r\n");

        free(read_buffer);
        furi_string_free(subcommand);
        return;
    }

    if(strcmp(furi_string_get_cstr(subcommand), "write") == 0) {
        const FuriHalI2cBusHandle* bus_handle = NULL;
        uint8_t device_address = 0;
        uint8_t register_prefix = 0;
        uint8_t* write_payload = NULL;
        size_t write_payload_size = 0;

        if(!cli_command_i2c_parse_bus(args, &bus_handle) ||
           !cli_command_i2c_parse_hex_u8(args, &device_address) ||
           !cli_command_i2c_parse_hex_u8(args, &register_prefix) ||
           !cli_command_i2c_parse_write_payload(args, &write_payload, &write_payload_size)) {
            furi_string_free(subcommand);
            cli_command_i2c_help();
            return;
        }

        const size_t tx_size = write_payload_size + 1;
        uint8_t* tx_buffer = malloc(tx_size);

        tx_buffer[0] = register_prefix;
        memcpy(&tx_buffer[1], write_payload, write_payload_size);

        furi_hal_i2c_acquire(bus_handle);
        int bytes_written =
            furi_hal_i2c_master_tx_blocking(bus_handle, device_address, tx_buffer, tx_size, FURI_HAL_I2C_TIMEOUT_US);
        furi_hal_i2c_release(bus_handle);

        if(bytes_written != (int)tx_size) {
            printf("Write failed\r\n");
        }

        free(tx_buffer);
        free(write_payload);
        furi_string_free(subcommand);
        return;
    }

    furi_string_free(subcommand);
    cli_command_i2c_help();
}
```

If the user simply types `i2c`, the function scans both `control` and `main` buses and returns. That behavior provides a useful default and preserves the old discovery-style usage.

After that, the function reads the first token into `subcommand` and dispatches based on its value.

1. For `list`, the behavior is straightforward: it prints the supported buses and exits.
2. For `search`, it parses a bus selector and runs `cli_command_i2c_scan_bus` only on that bus. The code also derives the human-readable bus name from the resolved handle so the scan output stays consistent regardless of whether the user typed `0` or `control`.
3. For `read`, the handler parses:
    - the target bus
    - a one-byte device address in hex
    - a one-byte register prefix in hex
    - a decimal read length
    
    The device address and prefix are parsed through SDK helpers, while the length is parsed through:
    
    ```c
    bool args_read_int_and_trim(FuriString* args, int* value) {
        size_t cmd_length = args_get_first_word_length(args);
    
        if(cmd_length == 0) {
            return false;
        }
    
        int32_t temp;
        if(strint_to_int32(furi_string_get_cstr(args), NULL, &temp, 10) == StrintParseNoError) {
            *value = temp;
            furi_string_right(args, cmd_length);
            furi_string_trim(args);
            return true;
        }
    
        return false;
    }
    ```
    
    The code also validates that the requested read length is within `1 - 255`, which avoids obviously invalid requests and keeps the buffer size bounded.
    
    Once the arguments are validated, the function allocates a read buffer and performs a combined write-then-read transaction via:
    
    ```c
    int furi_hal_i2c_master_trx_blocking(
        const FuriHalI2cBusHandle* handle,
        uint8_t device_address,
        const uint8_t* tx_buffer,
        size_t tx_size,
        uint8_t* rx_buffer,
        size_t rx_size,
        uint32_t timeout_us) {
        int status = furi_hal_i2c_master_tx_blocking_nostop(handle, device_address, tx_buffer, tx_size, timeout_us);
        if(status < 0) {
            return status;
        }
        return furi_hal_i2c_master_rx_blocking(handle, device_address, rx_buffer, rx_size, timeout_us);
    }
    ```
    
    The transmitted portion contains only the register prefix, and the receive portion contains the requested number of bytes. This is a common I2C register-read pattern for devices where you first write the register/index and then read back the data. If the transaction fails or returns no bytes, the function prints `Read failed`. Otherwise, it prints the returned bytes in uppercase hexadecimal separated by spaces.
4. For `write`, the handler parses:
    - the target bus
    - a one-byte device address in hex
    - a one-byte register prefix in hex
    - an arbitrary-length hex payload
    
    It then allocates a transmit buffer large enough to hold the prefix plus the payload, prepends the register prefix as the first byte, copies the payload after it, and sends everything through:
    
    ```c
    int furi_hal_i2c_master_tx_blocking(const FuriHalI2cBusHandle* handle, uint8_t device_address, const uint8_t* tx_buffer, size_t size, uint32_t timeout_us) {
        furi_hal_i2c_check_handle_is_acquired_master(handle);
        return handle->bus->api.master.write_blocking(handle->bus->data, device_address, tx_buffer, size, false, make_timeout_time_us(timeout_us));
    }
    ```
    
    That makes the command suitable for simple register writes as well as longer sequential writes. If the number of written bytes does not match the expected transmit size, it prints `Write failed`.

## cli_commands.c

Removed direct registration of the`i2c` command from the local/common CLI registration path.

## cli_commands_common.c

Removed the previous built-in `i2c` command implementation from the common CLI command file.

## cli_commands_common.h

Removed the `cli_command_i2c` declaration from the common CLI header.

## applications.c

Registered the `i2c` command through `FLIPPER_CLI_COMMANDS[]`.

## CMakeLists.txt

Added the CLI subdirectory source glob so the dedicated `i2c` command source file is included in the build.

# Verification 

The project builds successfully locally.

I don't have RP2350 hardware available, so I could not run or validate the command on the target device.
I only have RP2040 hardware, which is not sufficient to verify this RP2350-specific firmware behavior end to end.

I don't currently know a reliable way to test this functionality without the target hardware.

Suggestions for hardware-free verification, partial validation, or recommended test procedure are welcome.

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [ ] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.

Closes #156