### PR TITLE
feat: battery power bank screen (closes #46)

### DIFF
--- a/applications/applications.c
+++ b/applications/applications.c
@@ -27,6 +27,7 @@ extern int32_t keypad_test_app(void* p);
 extern int32_t touchpad_test_app(void* p);
 extern int32_t cpu_app(void* p);
 extern int32_t haptic_test_app(void* p);
+extern int32_t battery_bank_app(void* p);
 extern int32_t self_check_app(void* p);
 extern int32_t cli_on_system_start(void* p);
 
@@ -209,6 +210,13 @@ const FlipperInternalApplication FLIPPER_APPS[] = {
         .appid = "haptic_test",
         .stack_size = 2048,
         .flags = FlipperInternalApplicationFlagDefault,
+    },
+    {
+        .app        = battery_bank_app,
+        .name       = "Battery",
+        .appid      = "battery_bank",
+        .stack_size = 2048,
+        .flags      = FlipperInternalApplicationFlagDefault,
     },
 };
 const size_t FLIPPER_APPS_COUNT = COUNT_OF(FLIPPER_APPS);

--- a/applications/applications.h
+++ b/applications/applications.h
@@ -31,6 +31,8 @@ typedef struct {
     const CliCommandFlag flags;
 } FlipperInternalCommandApplication;
 
+extern int32_t battery_bank_app(void* p);
+
 extern const char* FLIPPER_AUTORUN_APP_NAME;
 
 /* Services list

--- a/applications/main/battery_bank/battery_bank_app.c
+++ b/applications/main/battery_bank/battery_bank_app.c
@@ -208,6 +208,7 @@ static BatteryBankApp* battery_bank_app_alloc(void) {
 }
 
 static void battery_bank_app_free(BatteryBankApp* app) {
+    furi_event_loop_timer_stop(app->timer);
     furi_event_loop_timer_free(app->timer);
     gui_remove_view(app->gui, app->view);
     view_free(app->view);

--- a/applications/main/battery_bank/battery_bank_app.c
+++ b/applications/main/battery_bank/battery_bank_app.c
@@ -12,6 +12,10 @@ typedef struct {
     uint16_t vbus_mv;
     uint16_t time_to_empty_min;
     bool     data_valid;
+    char     soc_buf[8];
+    char     vbus_buf[12];
+    char     ibus_buf[12];
+    char     tte_buf[12];
 } BatteryBankModel;
 
 typedef struct {
@@ -73,13 +77,11 @@ static bool battery_bank_layout(void* _model) {
                     CLAY_STRING("Reading..."),
                     CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_BLACK}));
             } else {
-                char soc_buf[8];
-                snprintf(soc_buf, sizeof(soc_buf), "%u%%", model->soc_pct);
                 CLAY(
                     CLAY_APP_ID("SocLabel"),
                     {.layout = {.childAlignment = {.x = CLAY_ALIGN_X_CENTER}}}) {
                     CLAY_TEXT(
-                        clay_helper_string_from_chars(soc_buf),
+                        clay_helper_string_from_chars(model->soc_buf),
                         CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_BLACK}));
                 }
 
@@ -118,16 +120,9 @@ static bool battery_bank_layout(void* _model) {
              }}) {
 
             if(model->data_valid) {
-                char vbus_buf[12], ibus_buf[12], tte_buf[12];
-                snprintf(
-                    vbus_buf, sizeof(vbus_buf), "%u.%02uV",
-                    model->vbus_mv / 1000u, (model->vbus_mv % 1000u) / 10u);
-                snprintf(ibus_buf, sizeof(ibus_buf), "%dmA", model->ibus_ma);
-                battery_bank_format_time(tte_buf, sizeof(tte_buf), model->time_to_empty_min);
-
-                CLAY_TEXT(clay_helper_string_from_chars(vbus_buf), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
-                CLAY_TEXT(clay_helper_string_from_chars(ibus_buf), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
-                CLAY_TEXT(clay_helper_string_from_chars(tte_buf),  CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
+                CLAY_TEXT(clay_helper_string_from_chars(model->vbus_buf), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
+                CLAY_TEXT(clay_helper_string_from_chars(model->ibus_buf), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
+                CLAY_TEXT(clay_helper_string_from_chars(model->tte_buf),  CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
             }
         }
     }
@@ -136,7 +131,7 @@ static bool battery_bank_layout(void* _model) {
 }
 
 static void battery_bank_poll(void* context) {
-    furi_assert(context);
+    furi_check(context);
     BatteryBankApp* app = context;
 
     uint8_t  soc  = 0;
@@ -160,13 +155,18 @@ static void battery_bank_poll(void* context) {
                 model->vbus_mv           = vbus;
                 model->time_to_empty_min = tte;
                 model->data_valid        = true;
+                snprintf(model->soc_buf, sizeof(model->soc_buf), "%u%%", soc);
+                snprintf(model->vbus_buf, sizeof(model->vbus_buf), "%u.%02uV",
+                    vbus / 1000u, (vbus % 1000u) / 10u);
+                snprintf(model->ibus_buf, sizeof(model->ibus_buf), "%dmA", ibus);
+                battery_bank_format_time(model->tte_buf, sizeof(model->tte_buf), tte);
             }
         },
         true);
 }
 
 static bool battery_bank_input(InputEvent* event, void* context) {
-    furi_assert(context);
+    furi_check(context);
     BatteryBankApp* app = context;
 
     if(event->type == InputTypePress && event->key == InputKeyBack) {
@@ -177,6 +177,7 @@ static bool battery_bank_input(InputEvent* event, void* context) {
 }
 
 static bool battery_bank_input_touch(InputTouchEvent* event, void* context) {
+    furi_check(context);
     UNUSED(event);
     UNUSED(context);
     return false;

--- a/applications/main/battery_bank/battery_bank_app.c
+++ b/applications/main/battery_bank/battery_bank_app.c
@@ -1,0 +1,225 @@
+#include <furi.h>
+#include <gui/gui.h>
+#include <gui/clay_helper.h>
+#include <power/power.h>
+
+#define TAG "BatteryBankApp"
+#define POLL_INTERVAL_MS 2000
+
+typedef struct {
+    uint8_t  soc_pct;
+    int16_t  ibus_ma;
+    uint16_t vbus_mv;
+    uint16_t time_to_empty_min;
+    bool     data_valid;
+} BatteryBankModel;
+
+typedef struct {
+    Gui*                gui;
+    View*               view;
+    FuriEventLoop*      event_loop;
+    FuriThread*         thread;
+    Power*              power;
+    FuriEventLoopTimer* timer;
+} BatteryBankApp;
+
+static void battery_bank_format_time(char* buf, size_t len, uint16_t minutes) {
+    if(minutes == 0xFFFF) {
+        snprintf(buf, len, "--");
+    } else {
+        snprintf(buf, len, "%uh%02um", minutes / 60, minutes % 60);
+    }
+}
+
+static bool battery_bank_layout(void* _model) {
+    furi_assert(_model);
+    BatteryBankModel* model = _model;
+
+    Clay_Sizing expand = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)};
+
+    CLAY(
+        CLAY_APP_ID("Root"),
+        {.backgroundColor = COLOR_WHITE,
+         .layout = {
+             .layoutDirection = CLAY_TOP_TO_BOTTOM,
+             .sizing = expand,
+         }}) {
+
+        /* Header */
+        CLAY(
+            CLAY_APP_ID("Header"),
+            {.backgroundColor = COLOR_BLACK,
+             .layout = {
+                 .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(16)},
+                 .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+             }}) {
+            CLAY_TEXT(
+                CLAY_STRING("Power Bank"),
+                CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_WHITE}));
+        }
+
+        /* SoC area */
+        CLAY(
+            CLAY_APP_ID("SocArea"),
+            {.layout = {
+                 .sizing = expand,
+                 .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                 .layoutDirection = CLAY_TOP_TO_BOTTOM,
+                 .childGap = 6,
+             }}) {
+
+            if(!model->data_valid) {
+                CLAY_TEXT(
+                    CLAY_STRING("Reading..."),
+                    CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_BLACK}));
+            } else {
+                char soc_buf[8];
+                snprintf(soc_buf, sizeof(soc_buf), "%u%%", model->soc_pct);
+                CLAY(
+                    CLAY_APP_ID("SocLabel"),
+                    {.layout = {.childAlignment = {.x = CLAY_ALIGN_X_CENTER}}}) {
+                    CLAY_TEXT(
+                        clay_helper_string_from_chars(soc_buf),
+                        CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_BLACK}));
+                }
+
+                /* Progress bar */
+                CLAY(
+                    CLAY_APP_ID("BarOuter"),
+                    {.backgroundColor = COLOR_BLACK,
+                     .cornerRadius = CLAY_CORNER_RADIUS(3),
+                     .layout = {
+                         .sizing = {.width = CLAY_SIZING_FIXED(200), .height = CLAY_SIZING_FIXED(10)},
+                         .padding = {1, 1, 1, 1},
+                     }}) {
+                    uint16_t fill = (uint16_t)(model->soc_pct * 196u / 100u);
+                    CLAY(
+                        CLAY_APP_ID("BarFill"),
+                        {.backgroundColor = COLOR_WHITE,
+                         .cornerRadius = CLAY_CORNER_RADIUS(2),
+                         .layout = {
+                             .sizing = {
+                                 .width = CLAY_SIZING_FIXED(fill),
+                                 .height = CLAY_SIZING_GROW(0),
+                             },
+                         }}) {}
+                }
+            }
+        }
+
+        /* Footer stats */
+        CLAY(
+            CLAY_APP_ID("Footer"),
+            {.backgroundColor = COLOR_BLACK,
+             .layout = {
+                 .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(20)},
+                 .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                 .childGap = 20,
+             }}) {
+
+            if(model->data_valid) {
+                char vbus_buf[12], ibus_buf[12], tte_buf[12];
+                snprintf(
+                    vbus_buf, sizeof(vbus_buf), "%u.%02uV",
+                    model->vbus_mv / 1000u, (model->vbus_mv % 1000u) / 10u);
+                snprintf(ibus_buf, sizeof(ibus_buf), "%dmA", model->ibus_ma);
+                battery_bank_format_time(tte_buf, sizeof(tte_buf), model->time_to_empty_min);
+
+                CLAY_TEXT(clay_helper_string_from_chars(vbus_buf), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
+                CLAY_TEXT(clay_helper_string_from_chars(ibus_buf), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
+                CLAY_TEXT(clay_helper_string_from_chars(tte_buf),  CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
+            }
+        }
+    }
+
+    return false;
+}
+
+static void battery_bank_poll(void* context) {
+    furi_assert(context);
+    BatteryBankApp* app = context;
+
+    uint8_t  soc  = 0;
+    int16_t  ibus = 0;
+    uint16_t vbus = 0;
+    uint16_t tte  = 0xFFFF;
+
+    bool ok = true;
+    ok &= power_bq28z620_get_relative_state_of_charge(app->power, &soc);
+    ok &= power_bq25792_get_ibus_ma(app->power, &ibus);
+    ok &= power_bq25792_get_vbus_mv(app->power, &vbus);
+    power_bq28z620_get_average_time_to_empty(app->power, &tte);
+
+    with_view_model(
+        app->view,
+        BatteryBankModel * model,
+        {
+            if(ok) {
+                model->soc_pct           = soc;
+                model->ibus_ma           = ibus;
+                model->vbus_mv           = vbus;
+                model->time_to_empty_min = tte;
+                model->data_valid        = true;
+            }
+        },
+        true);
+}
+
+static bool battery_bank_input(InputEvent* event, void* context) {
+    furi_assert(context);
+    BatteryBankApp* app = context;
+
+    if(event->type == InputTypePress && event->key == InputKeyBack) {
+        furi_thread_signal(app->thread, FuriSignalExit, NULL);
+        return true;
+    }
+    return false;
+}
+
+static bool battery_bank_input_touch(InputTouchEvent* event, void* context) {
+    UNUSED(event);
+    UNUSED(context);
+    return false;
+}
+
+static BatteryBankApp* battery_bank_app_alloc(void) {
+    BatteryBankApp* app = malloc(sizeof(BatteryBankApp));
+
+    app->gui        = furi_record_open(RECORD_GUI);
+    app->power      = furi_record_open(RECORD_POWER);
+    app->event_loop = furi_event_loop_alloc();
+    app->thread     = furi_thread_get_current();
+
+    app->view = view_alloc();
+    view_allocate_model(app->view, ViewModelTypeLockFree, sizeof(BatteryBankModel));
+    view_set_layout_callback(app->view, battery_bank_layout);
+    view_set_input_callback(app->view, battery_bank_input, app);
+    view_set_input_touch_callback(app->view, battery_bank_input_touch, app);
+    gui_add_view(app->gui, app->view, GuiViewPriorityApplication);
+
+    app->timer = furi_event_loop_timer_alloc(
+        app->event_loop, battery_bank_poll, FuriEventLoopTimerTypePeriodic, app);
+    furi_event_loop_timer_start(app->timer, furi_ms_to_ticks(POLL_INTERVAL_MS));
+
+    battery_bank_poll(app);
+
+    return app;
+}
+
+static void battery_bank_app_free(BatteryBankApp* app) {
+    furi_event_loop_timer_free(app->timer);
+    gui_remove_view(app->gui, app->view);
+    view_free(app->view);
+    furi_event_loop_free(app->event_loop);
+    furi_record_close(RECORD_POWER);
+    furi_record_close(RECORD_GUI);
+    free(app);
+}
+
+int32_t battery_bank_app(void* p) {
+    UNUSED(p);
+    BatteryBankApp* app = battery_bank_app_alloc();
+    furi_event_loop_run(app->event_loop);
+    battery_bank_app_free(app);
+    return 0;
+}

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -1,6 +1,8 @@
 #include <applications.h>
 #include <gui/clay_helper.h>
 #include <gui/gui.h>
+#include <power/power.h>
+#include <string.h>
 
 #define DESKTOP_INPUT_QUEUE_SIZE       16
 #define DESKTOP_INPUT_TOUCH_QUEUE_SIZE 16
@@ -13,6 +15,8 @@
 typedef enum {
     DesktopMessageTypeAppStart,
     DesktopMessageTypeAppClosed,
+    DesktopMessageTypeOtgEnabled,
+    DesktopMessageTypeOtgDisabled,
 } DesktopMessageType;
 
 typedef struct {
@@ -200,6 +204,13 @@ static void desktop_do_app_closed(Desktop* desktop) {
     FURI_LOG_I(TAG, "Application stopped. Free heap: %zu", memmgr_get_free_heap());
 }
 
+static const FlipperInternalApplication* desktop_find_app(const char* appid) {
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
+        if(strcmp(FLIPPER_APPS[i].appid, appid) == 0) return &FLIPPER_APPS[i];
+    }
+    return NULL;
+}
+
 static void desktop_app_message_logic(FuriEventLoopObject* object, void* context) {
     furi_check(context);
     Desktop* desktop = context;
@@ -222,10 +233,39 @@ static void desktop_app_message_logic(FuriEventLoopObject* object, void* context
         desktop_do_app_closed(desktop);
         desktop->app.running = false;
         break;
+    case DesktopMessageTypeOtgEnabled: {
+        const FlipperInternalApplication* app = desktop_find_app("battery_bank");
+        if(app && !desktop->app.running) {
+            desktop->app.running = true;
+            desktop_start_internal_app(desktop, app, NULL);
+        }
+        break;
+    }
+    case DesktopMessageTypeOtgDisabled:
+        if(desktop->app.running && desktop->app.thread) {
+            furi_thread_signal(desktop->app.thread, FuriSignalExit, NULL);
+        }
+        break;
     default:
         furi_assert(false);
         break;
     }
+}
+
+static void desktop_power_pubsub_glue(const void* message, void* context) {
+    furi_assert(context);
+    Desktop* desktop = context;
+    const PowerPubSubEvent* event = message;
+
+    DesktopMessage msg = {0};
+    if(event->type == PowerPubSubEventOtgEnabled) {
+        msg.type = DesktopMessageTypeOtgEnabled;
+    } else if(event->type == PowerPubSubEventOtgDisabled) {
+        msg.type = DesktopMessageTypeOtgDisabled;
+    } else {
+        return;
+    }
+    furi_message_queue_put(desktop->app_message_queue, &msg, 0);
 }
 
 static Desktop* desktop_alloc(void) {
@@ -242,6 +282,10 @@ static Desktop* desktop_alloc(void) {
     furi_event_loop_subscribe_message_queue(desktop->event_loop, desktop->app_message_queue, FuriEventLoopEventIn, desktop_app_message_logic, desktop);
 
     gui_add_view(desktop->gui, desktop->view, GuiViewPriorityDesktop);
+
+    Power* power = furi_record_open(RECORD_POWER);
+    furi_pubsub_subscribe(power_get_pubsub(power), desktop_power_pubsub_glue, desktop);
+    furi_record_close(RECORD_POWER);
 
     return desktop;
 }

--- a/applications/services/power/power.c
+++ b/applications/services/power/power.c
@@ -263,6 +263,7 @@ static Power* power_alloc(void) {
     instance->event_loop = furi_event_loop_alloc();
     instance->message_queue = furi_message_queue_alloc(POWER_MAX_MESSAGES, sizeof(PowerMessage));
     instance->devices = 0;
+    instance->otg_active = false;
 
     // init bq25792
     instance->bq25792_header = bq25792_init(&furi_hal_i2c_handle_main, BQ25792_ADDRESS, NULL);

--- a/applications/services/power/power.c
+++ b/applications/services/power/power.c
@@ -33,6 +33,7 @@ struct Power {
     Bq28z620* bq28z620_header;
     FuriMessageQueue* message_queue;
     PowerDevice devices;
+    bool otg_active;
 };
 
 static Bq25792Status power_bq25792_reset_and_load_config(Power* instance) {
@@ -233,6 +234,19 @@ static void power_custom_event_callback(uint32_t events, void* context) {
     Power* instance = (Power*)context;
 
     if(events & PowerEventTypeIsr) {
+        if(!instance->bq25792_header) return;
+
+        Bq25792ChargerStatusReg status = {0};
+        if(bq25792_get_charger_status(instance->bq25792_header, &status) != Bq25792StatusOk) return;
+
+        bool otg_now = (status.stat1.vbus_stat == Bq25792ChargerStatus1VbusOtg);
+        if(otg_now == instance->otg_active) return;
+
+        instance->otg_active = otg_now;
+        PowerPubSubEvent event = {
+            .type = otg_now ? PowerPubSubEventOtgEnabled : PowerPubSubEventOtgDisabled,
+        };
+        furi_pubsub_publish(instance->event_pubsub, &event);
     }
 }
 

--- a/applications/services/power/power.h
+++ b/applications/services/power/power.h
@@ -18,6 +18,16 @@ typedef enum {
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef enum {
+    PowerPubSubEventOtgEnabled,
+    PowerPubSubEventOtgDisabled,
+} PowerPubSubEventType;
+
+typedef struct {
+    PowerPubSubEventType type;
+} PowerPubSubEvent;
+
 FuriPubSub* power_get_pubsub(Power* power);
 
 bool power_is_device_initialized(Power* instance, PowerDevice* device);

--- a/docs/superpowers/plans/2026-06-04-battery-power-bank-screen.md
+++ b/docs/superpowers/plans/2026-06-04-battery-power-bank-screen.md
@@ -1,0 +1,598 @@
+# Battery (Power Bank) Screen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-show a live battery/power-bank stats screen whenever the BQ25792 charger IC enters OTG mode, and dismiss it when OTG stops.
+
+**Architecture:** The power service detects OTG state transitions via its existing ISR callback and publishes `PowerPubSubEvent` events through its pubsub. The desktop subscribes to those events and auto-launches/stops the `battery_bank_app`, which polls the power API on a 2-second timer and renders stats using Clay on the 256×144 display.
+
+**Tech Stack:** C11, FreeRTOS/Furi, Clay UI, BQ25792 (charger), BQ28Z620 (battery gauge), Pico SDK (RP2350), CMake + Ninja
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `applications/services/power/power.h` | Modify | Add `PowerPubSubEventType` + `PowerPubSubEvent` types |
+| `applications/services/power/power.c` | Modify | Track `otg_active`; detect transitions in ISR callback; publish events |
+| `applications/main/battery_bank/battery_bank_app.c` | Create | The screen — model, Clay layout, poll timer, input handler |
+| `applications/applications.h` | Modify | Declare `battery_bank_app` entry point |
+| `applications/applications.c` | Modify | Register `battery_bank_app` in `FLIPPER_APPS[]` |
+| `applications/services/desktop/desktop.c` | Modify | Subscribe to power pubsub; add OTG message types; auto-launch/stop app |
+
+---
+
+## Task 1: Add pubsub event types to `power.h`
+
+**Files:**
+- Modify: `applications/services/power/power.h`
+
+- [ ] **Step 1: Add the event types**
+
+Open `applications/services/power/power.h`. After the existing `#ifdef __cplusplus extern "C" {` block (around line 10), add before `FuriPubSub* power_get_pubsub`:
+
+```c
+typedef enum {
+    PowerPubSubEventOtgEnabled,
+    PowerPubSubEventOtgDisabled,
+} PowerPubSubEventType;
+
+typedef struct {
+    PowerPubSubEventType type;
+} PowerPubSubEvent;
+```
+
+- [ ] **Step 2: Verify it builds**
+
+```bash
+cd ~/source/repos/flipperone-mcu-firmware
+cmake -B build -DFIRMWARE_TARGET=100 2>&1 | tail -5
+ninja -C build 2>&1 | tail -10
+```
+
+Expected: no errors. (The build system is cmake+ninja; the first cmake invocation sets up the build dir.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/source/repos/flipperone-mcu-firmware
+git add applications/services/power/power.h
+git commit -m "feat(power): add OTG pubsub event types"
+```
+
+---
+
+## Task 2: Publish OTG events from the power service
+
+**Files:**
+- Modify: `applications/services/power/power.c`
+
+The `power_custom_event_callback` fires whenever `power_bq25792_event_isr` fires (BQ25792 interrupt). We add OTG state tracking here. We call `bq25792_get_charger_status` directly on the driver — NOT `power_bq25792_get_charger_status` — because we're already on the power service event loop and the public wrapper re-enqueues a message that would deadlock.
+
+- [ ] **Step 1: Add `otg_active` to the `Power` struct**
+
+In `power.c`, find `struct Power {` (around line 28) and add one field:
+
+```c
+struct Power {
+    FuriEventLoop* event_loop;
+    FuriPubSub* event_pubsub;
+    Bq25792* bq25792_header;
+    Ina219* ina219_header;
+    Bq28z620* bq28z620_header;
+    FuriMessageQueue* message_queue;
+    PowerDevice devices;
+    bool otg_active;   /* tracks previous OTG state for transition detection */
+};
+```
+
+- [ ] **Step 2: Update `power_custom_event_callback`**
+
+Find `power_custom_event_callback` (around line 231). Replace the empty `if(events & PowerEventTypeIsr)` block:
+
+```c
+static void power_custom_event_callback(uint32_t events, void* context) {
+    furi_assert(context);
+    Power* instance = (Power*)context;
+
+    if(events & PowerEventTypeIsr) {
+        if(!instance->bq25792_header) return;
+
+        Bq25792ChargerStatusReg status = {0};
+        if(bq25792_get_charger_status(instance->bq25792_header, &status) != Bq25792StatusOk) return;
+
+        bool otg_now = (status.stat1.vbus_stat == Bq25792ChargerStatus1VbusOtg);
+        if(otg_now == instance->otg_active) return;
+
+        instance->otg_active = otg_now;
+        PowerPubSubEvent event = {
+            .type = otg_now ? PowerPubSubEventOtgEnabled : PowerPubSubEventOtgDisabled,
+        };
+        furi_pubsub_publish(instance->event_pubsub, &event);
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+ninja -C build 2>&1 | tail -10
+```
+
+Expected: builds cleanly. Watch for any "undeclared" errors — if `bq25792_get_charger_status` is not in scope, verify the `#include <drivers/bq25792/bq25792.h>` include is already present at the top of `power.c` (it is, at line 8).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add applications/services/power/power.c
+git commit -m "feat(power): detect OTG transitions and publish pubsub events"
+```
+
+---
+
+## Task 3: Create `battery_bank_app.c`
+
+**Files:**
+- Create: `applications/main/battery_bank/battery_bank_app.c`
+
+The app is a single `View` + `FuriEventLoop`. A periodic timer fires every 2 s, reads five values from the power API, updates the model, triggers a redraw. Clay renders the layout. Back exits.
+
+- [ ] **Step 1: Create the directory and file**
+
+```bash
+mkdir -p ~/source/repos/flipperone-mcu-firmware/applications/main/battery_bank
+```
+
+Create `applications/main/battery_bank/battery_bank_app.c` with this full content:
+
+```c
+#include <furi.h>
+#include <gui/gui.h>
+#include <gui/clay_helper.h>
+#include <power/power.h>
+
+#define TAG "BatteryBankApp"
+#define POLL_INTERVAL_MS 2000
+
+typedef struct {
+    uint8_t  soc_pct;
+    int16_t  ibus_ma;
+    uint16_t vbus_mv;
+    uint16_t time_to_empty_min;
+    bool     data_valid;
+} BatteryBankModel;
+
+typedef struct {
+    Gui*              gui;
+    View*             view;
+    FuriEventLoop*    event_loop;
+    FuriThread*       thread;
+    Power*            power;
+    FuriEventLoopTimer* timer;
+} BatteryBankApp;
+
+static void battery_bank_format_time(char* buf, size_t len, uint16_t minutes) {
+    if(minutes == 0xFFFF) {
+        snprintf(buf, len, "--");
+    } else {
+        snprintf(buf, len, "%uh%02um", minutes / 60, minutes % 60);
+    }
+}
+
+static bool battery_bank_layout(void* _model) {
+    furi_assert(_model);
+    BatteryBankModel* model = _model;
+
+    Clay_Sizing expand = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)};
+
+    CLAY(
+        CLAY_APP_ID("Root"),
+        {.backgroundColor = COLOR_WHITE,
+         .layout = {
+             .layoutDirection = CLAY_TOP_TO_BOTTOM,
+             .sizing = expand,
+         }}) {
+
+        /* Header */
+        CLAY(
+            CLAY_APP_ID("Header"),
+            {.backgroundColor = COLOR_BLACK,
+             .layout = {
+                 .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(16)},
+                 .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+             }}) {
+            CLAY_TEXT(
+                CLAY_STRING("Power Bank"),
+                CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_WHITE}));
+        }
+
+        /* SoC percentage — center */
+        CLAY(
+            CLAY_APP_ID("SocArea"),
+            {.layout = {
+                 .sizing = expand,
+                 .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                 .layoutDirection = CLAY_TOP_TO_BOTTOM,
+                 .childGap = 6,
+             }}) {
+
+            if(!model->data_valid) {
+                CLAY_TEXT(
+                    CLAY_STRING("Reading..."),
+                    CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_BLACK}));
+            } else {
+                /* SoC number */
+                char soc_buf[8];
+                snprintf(soc_buf, sizeof(soc_buf), "%u%%", model->soc_pct);
+                CLAY_AUTO_ID({.layout = {.childAlignment = {.x = CLAY_ALIGN_X_CENTER}}}) {
+                    CLAY_TEXT(
+                        clay_helper_string_from_chars(soc_buf),
+                        CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_BLACK}));
+                }
+
+                /* Progress bar */
+                CLAY(
+                    CLAY_APP_ID("BarOuter"),
+                    {.backgroundColor = COLOR_BLACK,
+                     .cornerRadius = CLAY_CORNER_RADIUS(3),
+                     .layout = {
+                         .sizing = {.width = CLAY_SIZING_FIXED(200), .height = CLAY_SIZING_FIXED(10)},
+                         .padding = {1, 1, 1, 1},
+                     }}) {
+                    uint16_t fill = (uint16_t)(model->soc_pct * 196 / 100);
+                    CLAY(
+                        CLAY_APP_ID("BarFill"),
+                        {.backgroundColor = COLOR_WHITE,
+                         .cornerRadius = CLAY_CORNER_RADIUS(2),
+                         .layout = {
+                             .sizing = {
+                                 .width = CLAY_SIZING_FIXED(fill),
+                                 .height = CLAY_SIZING_GROW(0),
+                             },
+                         }}) {}
+                }
+            }
+        }
+
+        /* Footer stats row */
+        CLAY(
+            CLAY_APP_ID("Footer"),
+            {.backgroundColor = COLOR_BLACK,
+             .layout = {
+                 .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(20)},
+                 .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                 .childGap = 20,
+             }}) {
+
+            if(model->data_valid) {
+                char vbus_buf[12], ibus_buf[12], tte_buf[12];
+                snprintf(vbus_buf, sizeof(vbus_buf), "%u.%02uV", model->vbus_mv / 1000, (model->vbus_mv % 1000) / 10);
+                snprintf(ibus_buf, sizeof(ibus_buf), "%dmA", model->ibus_ma);
+                battery_bank_format_time(tte_buf, sizeof(tte_buf), model->time_to_empty_min);
+
+                CLAY_TEXT(clay_helper_string_from_chars(vbus_buf), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
+                CLAY_TEXT(clay_helper_string_from_chars(ibus_buf), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
+                CLAY_TEXT(clay_helper_string_from_chars(tte_buf),  CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_WHITE}));
+            }
+        }
+    }
+
+    return false;
+}
+
+static void battery_bank_poll(void* context) {
+    furi_assert(context);
+    BatteryBankApp* app = context;
+
+    uint8_t  soc  = 0;
+    int16_t  ibus = 0;
+    uint16_t vbus = 0;
+    uint16_t tte  = 0xFFFF;
+
+    bool ok = true;
+    ok &= power_bq28z620_get_relative_state_of_charge(app->power, &soc);
+    ok &= power_bq25792_get_ibus_ma(app->power, &ibus);
+    ok &= power_bq25792_get_vbus_mv(app->power, &vbus);
+    power_bq28z620_get_average_time_to_empty(app->power, &tte); /* best-effort */
+
+    with_view_model(
+        app->view,
+        BatteryBankModel * model,
+        {
+            if(ok) {
+                model->soc_pct           = soc;
+                model->ibus_ma           = ibus;
+                model->vbus_mv           = vbus;
+                model->time_to_empty_min = tte;
+                model->data_valid        = true;
+            }
+        },
+        true);
+}
+
+static bool battery_bank_input(InputEvent* event, void* context) {
+    furi_assert(context);
+    BatteryBankApp* app = context;
+
+    if(event->type == InputTypePress && event->key == InputKeyBack) {
+        furi_thread_signal(app->thread, FuriSignalExit, NULL);
+        return true;
+    }
+    return false;
+}
+
+static bool battery_bank_input_touch(InputTouchEvent* event, void* context) {
+    UNUSED(event);
+    UNUSED(context);
+    return false;
+}
+
+static BatteryBankApp* battery_bank_app_alloc(void) {
+    BatteryBankApp* app = malloc(sizeof(BatteryBankApp));
+
+    app->gui        = furi_record_open(RECORD_GUI);
+    app->power      = furi_record_open(RECORD_POWER);
+    app->event_loop = furi_event_loop_alloc();
+    app->thread     = furi_thread_get_current();
+
+    app->view = view_alloc();
+    view_allocate_model(app->view, ViewModelTypeLockFree, sizeof(BatteryBankModel));
+    view_set_layout_callback(app->view, battery_bank_layout);
+    view_set_input_callback(app->view, battery_bank_input, app);
+    view_set_input_touch_callback(app->view, battery_bank_input_touch, app);
+    gui_add_view(app->gui, app->view, GuiViewPriorityApplication);
+
+    app->timer = furi_event_loop_timer_alloc(
+        app->event_loop, battery_bank_poll, FuriEventLoopTimerTypePeriodic, app);
+    furi_event_loop_timer_start(app->timer, furi_ms_to_ticks(POLL_INTERVAL_MS));
+
+    /* kick off an immediate poll */
+    battery_bank_poll(app);
+
+    return app;
+}
+
+static void battery_bank_app_free(BatteryBankApp* app) {
+    furi_event_loop_timer_free(app->timer);
+    gui_remove_view(app->gui, app->view);
+    view_free(app->view);
+    furi_event_loop_free(app->event_loop);
+    furi_record_close(RECORD_POWER);
+    furi_record_close(RECORD_GUI);
+    free(app);
+}
+
+int32_t battery_bank_app(void* p) {
+    UNUSED(p);
+    BatteryBankApp* app = battery_bank_app_alloc();
+    furi_event_loop_run(app->event_loop);
+    battery_bank_app_free(app);
+    return 0;
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+ninja -C build 2>&1 | tail -20
+```
+
+Expected: compiles cleanly. Common errors to fix:
+- `clay_helper_string_from_chars` not declared: verify `#include <gui/clay_helper.h>` is present.
+- `CLAY_AUTO_ID` usage: if it doesn't compile, replace with `CLAY_APP_ID("SocLabel")`.
+- `furi_ms_to_ticks` not found: check it's in `<furi.h>`; if not, use `pdMS_TO_TICKS(POLL_INTERVAL_MS)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add applications/main/battery_bank/battery_bank_app.c
+git commit -m "feat(battery-bank): add battery power bank screen app"
+```
+
+---
+
+## Task 4: Register the app
+
+**Files:**
+- Modify: `applications/applications.h`
+- Modify: `applications/applications.c`
+
+- [ ] **Step 1: Declare in `applications.h`**
+
+In `applications/applications.h`, add next to the other `extern` declarations:
+
+```c
+extern int32_t battery_bank_app(void* p);
+```
+
+- [ ] **Step 2: Register in `applications.c`**
+
+In `applications/applications.c`, add to `FLIPPER_APPS[]` (after `haptic_test_app`):
+
+```c
+{
+    .app        = battery_bank_app,
+    .name       = "Battery",
+    .appid      = "battery_bank",
+    .stack_size = 2048,
+    .flags      = FlipperInternalApplicationFlagDefault,
+},
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+ninja -C build 2>&1 | tail -10
+```
+
+Expected: builds cleanly. The app is now launchable from the desktop menu.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add applications/applications.h applications/applications.c
+git commit -m "feat(battery-bank): register battery_bank_app in app list"
+```
+
+---
+
+## Task 5: Desktop auto-launch on OTG
+
+**Files:**
+- Modify: `applications/services/desktop/desktop.c`
+
+The desktop needs to (a) handle two new message types, and (b) subscribe to the power pubsub. The pubsub callback runs on the power service's thread — it must only enqueue a message into the desktop's existing `app_message_queue` (thread-safe), never call desktop functions directly.
+
+- [ ] **Step 1: Add new message types to the `DesktopMessageType` enum**
+
+Find:
+```c
+typedef enum {
+    DesktopMessageTypeAppStart,
+    DesktopMessageTypeAppClosed,
+} DesktopMessageType;
+```
+
+Replace with:
+```c
+typedef enum {
+    DesktopMessageTypeAppStart,
+    DesktopMessageTypeAppClosed,
+    DesktopMessageTypeOtgEnabled,
+    DesktopMessageTypeOtgDisabled,
+} DesktopMessageType;
+```
+
+- [ ] **Step 2: Add the power pubsub glue callback**
+
+Add this function before `desktop_alloc`:
+
+```c
+static void desktop_power_pubsub_glue(const void* message, void* context) {
+    furi_assert(context);
+    Desktop* desktop = context;
+    const PowerPubSubEvent* event = message;
+
+    DesktopMessage msg = {0};
+    if(event->type == PowerPubSubEventOtgEnabled) {
+        msg.type = DesktopMessageTypeOtgEnabled;
+    } else if(event->type == PowerPubSubEventOtgDisabled) {
+        msg.type = DesktopMessageTypeOtgDisabled;
+    } else {
+        return;
+    }
+    furi_message_queue_put(desktop->app_message_queue, &msg, 0);
+}
+```
+
+- [ ] **Step 3: Subscribe to power pubsub in `desktop_alloc`**
+
+You need `<power/power.h>` at the top of the file. Add the include if not present:
+
+```c
+#include <power/power.h>
+```
+
+At the end of `desktop_alloc`, before `return desktop;`, add:
+
+```c
+    Power* power = furi_record_open(RECORD_POWER);
+    furi_pubsub_subscribe(power_get_pubsub(power), desktop_power_pubsub_glue, desktop);
+    furi_record_close(RECORD_POWER);
+```
+
+- [ ] **Step 4: Handle OTG messages in `desktop_app_message_logic`**
+
+Find the `switch(message.type)` in `desktop_app_message_logic`. Add two cases:
+
+```c
+    case DesktopMessageTypeOtgEnabled:
+        if(!desktop->app.running) {
+            desktop->app.running = true;
+            desktop_start_internal_app(desktop, &FLIPPER_APPS[/* battery_bank index */], NULL);
+        }
+        break;
+    case DesktopMessageTypeOtgDisabled:
+        if(desktop->app.running && desktop->app.thread) {
+            furi_thread_signal(desktop->app.thread, FuriSignalExit, NULL);
+        }
+        break;
+```
+
+For the `battery_bank` index: count the entries in `FLIPPER_APPS[]` in `applications.c`. If `battery_bank_app` is the 6th entry (0-indexed: 5), use `&FLIPPER_APPS[5]`. To avoid fragility, add a named lookup. The safer approach: define a helper at the top of `desktop.c`:
+
+```c
+static const FlipperInternalApplication* desktop_find_app(const char* appid) {
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
+        if(strcmp(FLIPPER_APPS[i].appid, appid) == 0) return &FLIPPER_APPS[i];
+    }
+    return NULL;
+}
+```
+
+Then use:
+```c
+    case DesktopMessageTypeOtgEnabled: {
+        const FlipperInternalApplication* app = desktop_find_app("battery_bank");
+        if(app && !desktop->app.running) {
+            desktop->app.running = true;
+            desktop_start_internal_app(desktop, app, NULL);
+        }
+        break;
+    }
+```
+
+- [ ] **Step 5: Build**
+
+```bash
+ninja -C build 2>&1 | tail -20
+```
+
+Expected: full clean build. Common issues:
+- `desktop_start_internal_app` not declared in this scope: look for it declared as `static` earlier in `desktop.c`; ensure the new function is placed after it, or move `desktop_power_pubsub_glue` after it.
+- `strcmp` not in scope: add `#include <string.h>`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add applications/services/desktop/desktop.c
+git commit -m "feat(desktop): auto-launch battery bank screen on OTG enable/disable"
+```
+
+---
+
+## Task 6: Push and open PR
+
+- [ ] **Step 1: Push to fork**
+
+```bash
+cd ~/source/repos/flipperone-mcu-firmware
+git push origin dev
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create \
+  --repo githouson/flipperone-mcu-firmware \
+  --base dev \
+  --title "feat: battery power bank screen (closes #46)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `PowerPubSubEvent` (OTG enabled/disabled) published from BQ25792 ISR callback
+- Adds `battery_bank_app`: live screen showing SoC%, VBUS, IBUS, time-to-empty, refreshed every 2 s
+- Desktop auto-launches the screen when OTG mode starts; dismisses it when OTG stops
+
+## Test plan
+- [ ] Build passes with `ninja -C build`
+- [ ] With device in OTG mode, battery bank screen appears automatically
+- [ ] Stats update every ~2 seconds
+- [ ] Back button dismisses screen while OTG is still active
+- [ ] Disconnecting OTG source dismisses screen automatically
+- [ ] No crash when power service devices are partially initialized (shows "Reading...")
+
+Closes #46
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-06-04-battery-power-bank-screen-design.md
+++ b/docs/superpowers/specs/2026-06-04-battery-power-bank-screen-design.md
@@ -1,0 +1,178 @@
+# Battery (Power Bank) Screen — Design Spec
+
+**Issue:** flipperdevices/flipperone-mcu-firmware#46  
+**Date:** 2026-06-04
+
+---
+
+## Overview
+
+When the Flipper One enters OTG/power-bank mode (detected via BQ25792 charger IC), the device automatically shows a dedicated full-screen display with live battery and output stats. The screen dismisses when OTG mode ends or when the user presses Back.
+
+---
+
+## Architecture
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `applications/services/power/power.h` | Add `PowerPubSubEventType` enum and `PowerPubSubEvent` struct |
+| `applications/services/power/power.c` | Track OTG state in ISR callback; publish events via existing pubsub |
+| `applications/main/battery_bank/battery_bank_app.c` | New app — the screen |
+| `applications/services/desktop/desktop.c` | Subscribe to power pubsub; auto-launch/stop battery_bank_app |
+| `applications/applications.c` | Register `battery_bank_app` in `FLIPPER_APPS[]` |
+| `applications/applications.h` | Declare `battery_bank_app` entry point |
+
+---
+
+## Component Design
+
+### 1. Power Service — OTG event publishing
+
+Add to `power.h`:
+
+```c
+typedef enum {
+    PowerPubSubEventOtgEnabled,
+    PowerPubSubEventOtgDisabled,
+} PowerPubSubEventType;
+
+typedef struct {
+    PowerPubSubEventType type;
+} PowerPubSubEvent;
+```
+
+Extend `power.c`:
+
+- Add `bool otg_active` field to the `Power` struct to track previous state.
+- In `power_custom_event_callback` (which fires on every BQ25792 ISR): read `Bq25792ChargerStatusReg` synchronously (already on the power service's event loop — no locking needed), extract the `vbus_status` field, compare against `Bq25792ChargerStatus1VbusOtg`.
+- On transition `false → true`: publish `PowerPubSubEventOtgEnabled`.
+- On transition `true → false`: publish `PowerPubSubEventOtgDisabled`.
+
+No new API functions needed — `power_get_pubsub()` already exposes the pubsub to subscribers.
+
+### 2. Battery Bank App
+
+**Location:** `applications/main/battery_bank/battery_bank_app.c`
+
+**Pattern:** identical to the app template — single `View`, `FuriEventLoop`, no ViewDispatcher.
+
+**AppModel fields:**
+
+```c
+typedef struct {
+    uint8_t  soc_pct;        // BQ28Z620 relative state of charge
+    float    vbat_v;         // BQ28Z620 voltage (V)
+    int16_t  ibus_ma;        // BQ25792 IBUS (output current, mA)
+    uint16_t vbus_mv;        // BQ25792 VBUS (output voltage, mV)
+    uint16_t time_to_empty;  // BQ28Z620 average time-to-empty (minutes)
+    bool     data_valid;     // false until first successful poll
+} BatteryBankModel;
+```
+
+**Polling:** A `FuriTimer` fires every 2000 ms. The callback calls `power_bq28z620_get_relative_state_of_charge`, `power_bq28z620_get_voltage`, `power_bq25792_get_ibus_ma`, `power_bq25792_get_vbus_mv`, `power_bq28z620_get_average_time_to_empty` via the public power API. Updates model with `with_view_model(..., true)` to trigger redraw.
+
+**Layout (Clay, 256×144):**
+
+```
++--------------------------------------------------+
+|  Power Bank                                      |  <- header row, FontBody
+|--------------------------------------------------|
+|                                                  |
+|                    87%                           |  <- SoC, large FontTitle
+|              ████████████░░░░                   |  <- progress bar
+|                                                  |
+|--------------------------------------------------|
+|  5.12V    1350mA    2h 14m                       |  <- footer: VBUS | IBUS | TTE
++--------------------------------------------------+
+```
+
+- Header: "Power Bank" left-aligned, FontBody, black on white.
+- SoC%: centered, large font (FontTitle or largest available).
+- Progress bar: full-width, filled proportional to SoC, 8px tall, rounded corners.
+- Footer row: three evenly-spaced stat cells — VBUS (V), IBUS (mA), time-to-empty. FontBody.
+- Background: white. Bar fill: black. Text: black.
+- `data_valid = false`: show "—" placeholders until first poll completes.
+
+**Input:** Back key (press) → `furi_thread_signal(FuriSignalExit)`. No other keys consumed.
+
+**Lifecycle:**
+
+```c
+int32_t battery_bank_app(void* p) {
+    App* app = battery_bank_app_alloc();   // opens RECORD_POWER, starts timer
+    furi_event_loop_run(app->event_loop);
+    battery_bank_app_free(app);            // stops timer, closes RECORD_POWER
+    return 0;
+}
+```
+
+### 3. Desktop — Auto-launch
+
+**Subscribe** to power pubsub during `desktop_alloc()`:
+
+```c
+Power* power = furi_record_open(RECORD_POWER);
+FuriPubSub* power_pubsub = power_get_pubsub(power);
+furi_pubsub_subscribe(power_pubsub, desktop_power_event_callback, desktop);
+furi_record_close(RECORD_POWER);
+```
+
+**Callback** (`desktop_power_event_callback`):
+- Receives `PowerPubSubEvent*`.
+- On `PowerPubSubEventOtgEnabled`: enqueue a `DesktopMessageTypeAppStart` with `battery_bank_app` into `app_message_queue` (same path user-launched apps use).
+- On `PowerPubSubEventOtgDisabled`: if `desktop->app.running && desktop->app.thread`, call `furi_thread_signal(desktop->app.thread, FuriSignalExit, NULL)`.
+
+The existing `desktop_app_message_logic` and `desktop_do_app_closed` handle the rest — no new code paths needed.
+
+### 4. Registration
+
+`applications.c` — add to `FLIPPER_APPS[]`:
+
+```c
+{
+    .app = battery_bank_app,
+    .name = "Battery",
+    .appid = "battery_bank",
+    .stack_size = 2048,
+    .flags = FlipperInternalApplicationFlagDefault,
+},
+```
+
+`applications.h` — add `extern int32_t battery_bank_app(void* p);`
+
+---
+
+## Data Flow
+
+```
+BQ25792 HW IRQ
+    → power_bq25792_event_isr (ISR context)
+        → furi_event_loop_set_custom_event(PowerEventTypeIsr)
+            → power_custom_event_callback (power service event loop)
+                → read charger status, compare OTG bit
+                    → furi_pubsub_publish(PowerPubSubEvent)
+                        → desktop_power_event_callback (desktop event loop)
+                            → enqueue DesktopMessageTypeAppStart
+                                → desktop_app_message_logic
+                                    → battery_bank_app starts in new thread
+                                        → FuriTimer polls power API every 2s
+                                        → Clay layout renders live stats
+```
+
+---
+
+## Error Handling
+
+- If power service devices are not fully initialized (`power_is_device_initialized` returns false), individual `power_*` API calls return `false`; the model retains previous values (or `data_valid` stays false on first poll). The screen shows "—" for any field that fails.
+- If OTG mode ends while the screen is showing, the desktop signals exit — the app's Back-key path and the forced-exit path are identical (`furi_thread_signal(FuriSignalExit)`), so no special teardown is needed.
+- If an app is already running when OTG starts, the desktop logs a warning and does not launch the battery screen (existing behavior — mirrors the current "app already running" guard).
+
+---
+
+## Out of Scope
+
+- OTG enable/disable control (issue #41).
+- Persistent history or logging of power-bank sessions.
+- Haptic or LED feedback on OTG state change.

--- a/docs/superpowers/specs/2026-06-04-battery-power-bank-screen-design.md
+++ b/docs/superpowers/specs/2026-06-04-battery-power-bank-screen-design.md
@@ -46,7 +46,7 @@ typedef struct {
 Extend `power.c`:
 
 - Add `bool otg_active` field to the `Power` struct to track previous state.
-- In `power_custom_event_callback` (which fires on every BQ25792 ISR): read `Bq25792ChargerStatusReg` synchronously (already on the power service's event loop — no locking needed), extract the `vbus_status` field, compare against `Bq25792ChargerStatus1VbusOtg`.
+- In `power_custom_event_callback` (which fires on every BQ25792 ISR): call `bq25792_get_charger_status(instance->bq25792_header, &status)` directly on the driver (not the public `power_bq25792_get_charger_status` wrapper, which would deadlock by re-enqueuing a message onto the same event loop). Extract the `vbus_status` field, compare against `Bq25792ChargerStatus1VbusOtg`.
 - On transition `false → true`: publish `PowerPubSubEventOtgEnabled`.
 - On transition `true → false`: publish `PowerPubSubEventOtgDisabled`.
 


### PR DESCRIPTION
## Summary
- Adds `PowerPubSubEvent` (OTG enabled/disabled) published from BQ25792 ISR callback in `power_custom_event_callback` — direct driver call to avoid message-queue deadlock
- Adds `battery_bank_app`: live screen showing SoC%, progress bar, VBUS, IBUS, time-to-empty, refreshed every 2 s via periodic event-loop timer
- Desktop auto-launches the screen when OTG mode starts; dismisses it when OTG stops
- Format string buffers live in the model (not the layout stack) to satisfy Clay's pointer-lifetime requirement

## Files changed
- `applications/services/power/power.h` — `PowerPubSubEventType` + `PowerPubSubEvent`
- `applications/services/power/power.c` — OTG state tracking + pubsub publish
- `applications/main/battery_bank/battery_bank_app.c` — new app
- `applications/applications.h` / `applications.c` — registration
- `applications/services/desktop/desktop.c` — auto-launch on OTG

## Test plan
- [ ] Build passes with `ninja -C build`
- [ ] With device in OTG mode, battery bank screen appears automatically
- [ ] Stats update every ~2 seconds
- [ ] Back button dismisses screen while OTG is still active
- [ ] Disconnecting OTG source dismisses screen automatically
- [ ] No crash when power service devices are partially initialized (shows "Reading...")

Closes #46