### PR TITLE
fix(cli): resolve CLI hang on RP2350 due to priority inversion

### DIFF
--- a/targets/f100/src/main.c
+++ b/targets/f100/src/main.c
@@ -47,7 +47,7 @@ int main(void) {
     furi_hal_init_early();
 
     FuriThread* main_thread = furi_thread_alloc_ex("Init", 4096, init_task, NULL);
-    furi_thread_set_priority(main_thread, FuriThreadPriorityInit);
+    furi_thread_set_priority(main_thread, FuriThreadPriorityNormal);
     furi_thread_start(main_thread);
 
     // somehow openocd fucks up the multicore reset


### PR DESCRIPTION
# What's new

This changeset fixes CLI hang on RP2350 (dual-core) where `furi_thread_join()` loops forever after a command thread exits. Root cause was a priority inversion — the Init task that runs thread cleanup couldn't preempt GuiSrv on dual-core SMP. The problem already is tracked on issue #170.

To resolve the explained problem, I had to change `FuriThreadPriorityInit` (4) to `FuriThreadPriorityNormal` (16) for the Init task, so that it runs at the same priority as service threads. I assume it's safe because Init only runs briefly during boot, then blocks forever on the (normally empty) scrub queue.

Something I'm not sure: This repo only has one target (`targets/f100/`), so changing its `main.c` affects all builds — including those running on plain Pico 2 dev boards for testing. If the project ever adds separate targets, the Init task priority should probably live in a shared init path rather than a board-specific target.

# Verification

- Before the fix, run any CLI tool and send CTRL+C with USB CDC. Validated that the issue exists and the CPU hangs.
- Apply the fix, build and flash to the RPi Pico 2. Run any CLI tool and send CTRL+C with USB CDC. Validated that the shell comes back and we're online with the CPU.

# Contributor checklist

- [X] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [X] I have tested these changes myself (on hardware or in simulation)
- [X] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
