### PR TITLE
PIO i2c master fix timeout, enable RTT

### DIFF
--- a/lib/drivers/i2c_master_pio/pio_i2c.c
+++ b/lib/drivers/i2c_master_pio/pio_i2c.c
@@ -124,14 +124,15 @@ void pio_i2c_repstart(I2cMasterPio* instance, absolute_time_t until) {
     pio_i2c_put_or_err(instance, pio_encode_mov(pio_isr, pio_null), until);
 }
 
-static void pio_i2c_wait_idle(I2cMasterPio* instance, absolute_time_t until) {
+static bool pio_i2c_wait_idle(I2cMasterPio* instance, absolute_time_t until) {
     furi_check(instance);
     // Finished when TX runs dry or SM hits an IRQ
     instance->pio->fdebug = 1u << (PIO_FDEBUG_TXSTALL_LSB + instance->sm);
     while(!(instance->pio->fdebug & 1u << (PIO_FDEBUG_TXSTALL_LSB + instance->sm) || pio_i2c_check_error(instance))) {
-        if(until != 0 && time_us_64() >= until) break;
+        if(until != 0 && time_us_64() >= until) return false;
         tight_loop_contents();
     }
+    return true;
 }
 
 int pio_i2c_write_blocking(I2cMasterPio* instance, uint8_t addr, const uint8_t* txbuf, uint len, bool nostop, absolute_time_t until) {
@@ -163,10 +164,14 @@ int pio_i2c_write_blocking(I2cMasterPio* instance, uint8_t addr, const uint8_t* 
     if(!nostop) {
         pio_i2c_stop(instance, until);
     }
-    pio_i2c_wait_idle(instance, until);
+    if(!pio_i2c_wait_idle(instance, until) && !err) {
+        err = PICO_ERROR_TIMEOUT;
+    }
 
     if(pio_i2c_check_error(instance) || err) {
-        err = PICO_ERROR_GENERIC;
+        if(pio_i2c_check_error(instance)) {
+            err = PICO_ERROR_GENERIC;
+        }
         pio_i2c_resume_after_error(instance);
         pio_i2c_stop(instance, until);
         instance->previous_nostop = false;
@@ -221,9 +226,13 @@ int pio_i2c_read_blocking(I2cMasterPio* instance, uint8_t addr, uint8_t* rxbuf, 
         pio_i2c_stop(instance, until);
     }
 
-    pio_i2c_wait_idle(instance, until);
+    if(!pio_i2c_wait_idle(instance, until) && !err) {
+        err = PICO_ERROR_TIMEOUT;
+    }
     if(pio_i2c_check_error(instance) || err) {
-        err = PICO_ERROR_GENERIC;
+        if(pio_i2c_check_error(instance)) {
+            err = PICO_ERROR_GENERIC;
+        }
         pio_i2c_resume_after_error(instance);
         pio_i2c_stop(instance, until);
         instance->previous_nostop = false;

--- a/targets/f100/src/main.c
+++ b/targets/f100/src/main.c
@@ -41,7 +41,7 @@ int main(void) {
     furi_init();
 
     // TODO: read log level and output from nvm
-    furi_hal_log_init(FuriLogLevelInfo, FuriHalLogOutputSerial);
+    furi_hal_log_init(FuriLogLevelInfo, FuriHalLogOutputAll);
 
     // Critical FURI HAL
     furi_hal_init_early();


### PR DESCRIPTION
# What's new

- PIO_i2c_master: added a timeout error when the slave device does not respond.
- Log: log output via the RTT interface is enabled.

# Verification 

To output logs via the RTT interface, a debugger is required: https://github.com/flipperdevices/flipperone-debug-probe
(you can make a dev board out of a standard Pico 2)

How to get logs:

Connect a debugger (CMSIS-DAP / flipperone-debug-probe) to the device
Start debugging: F5 → "Pico Debug" or "Pico Debug Attach" configuration
Logs will appear in the "Flipper One Logs" tab within the VS Code terminal panel (this is already configured in rttConfig.decoders with label: "Flipper One Logs")

<img width="3840" height="2100" alt="image" src="https://github.com/user-attachments/assets/6985b016-62cc-4a20-a409-e71890efdcaf" />


# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
