### PR TITLE
i2c reg cpu state, sw key and start applications from menu

### DIFF
--- a/applications/applications.c
+++ b/applications/applications.c
@@ -167,22 +167,22 @@ const FlipperInternalApplication FLIPPER_SERVICES[] = {
 const size_t FLIPPER_SERVICES_COUNT = COUNT_OF(FLIPPER_SERVICES);
 
 const FlipperInternalApplication FLIPPER_APPS[] = {
-    {
-        .app = cpu_app,
-        .name = "CPU Start",
-        .appid = "cpu",
-        .stack_size = 4096,
-        .flags = FlipperInternalApplicationFlagDefault,
-        .args = "CPU Start",
-    },
-        {
-        .app = cpu_app,
-        .name = "CPU Maskrom",
-        .appid = "cpu",
-        .stack_size = 4096,
-        .flags = FlipperInternalApplicationFlagDefault,
-        .args = "CPU Maskrom",
-    },
+    // {
+    //     .app = cpu_app,
+    //     .name = "CPU Start",
+    //     .appid = "cpu",
+    //     .stack_size = 4096,
+    //     .flags = FlipperInternalApplicationFlagDefault,
+    //     .args = "CPU Start",
+    // },
+    //     {
+    //     .app = cpu_app,
+    //     .name = "CPU Maskrom",
+    //     .appid = "cpu",
+    //     .stack_size = 4096,
+    //     .flags = FlipperInternalApplicationFlagDefault,
+    //     .args = "CPU Maskrom",
+    // },
     {
         .app = self_check_app,
         .name = "Self Check",

--- a/applications/main/cpu/cpu_app.c
+++ b/applications/main/cpu/cpu_app.c
@@ -8,6 +8,7 @@
 #include <pd/pd.h>
 #include <power/power.h>
 #include <power_menu/power_menu.h>
+#include <i2c_negotiator/i2c_negotiator.h>
 
 #define TAG "CpuApp"
 
@@ -18,7 +19,8 @@
 #define CPU_APP_MENU_START   "CPU Start"
 #define CPU_APP_MENU_REBOOT  "CPU Reboot"
 #define CPU_APP_MENU_MASKROM "CPU Maskrom"
-#define CPU_APP_MENU_CLOSE   "CPU Shutdown"
+#define CPU_APP_MENU_CLOSE   "CPU Power Off"
+#define CPU_APP_MENU_SHUTDOWN   "CPU Shutdown"
 
 typedef struct {
     Image frame;
@@ -207,16 +209,26 @@ static void cpu_app_message_logic(FuriEventLoopObject* object, void* context) {
     }
 }
 
-void cpu_app_menu_close_click_callback(void* context) {
+void cpu_app_menu_close_click_callback(bool pressed, void* context) {
     furi_check(context);
     CpuApp* instance = context;
-    cpu_app_send_message(instance, CpuAppMessageTypeClose);
+    if(pressed) {
+        cpu_app_send_message(instance, CpuAppMessageTypeClose);
+    }
 }
 
-void cpu_app_menu_restart_click_callback(void* context) {
+void cpu_app_menu_restart_click_callback(bool pressed, void* context) {
     furi_check(context);
     CpuApp* instance = context;
-    cpu_app_send_message(instance, CpuAppMessageTypeReset);
+    if(pressed) {
+        cpu_app_send_message(instance, CpuAppMessageTypeReset);
+    }
+}
+
+void cpu_app_menu_shutdown_click_callback(bool pressed, void* context) {
+    furi_check(context);
+    CpuApp* instance = context;
+    i2c_negotiator_input_sw_button_event(SwPowerKey, pressed, NULL);
 }
 
 static CpuApp* cpu_app_alloc(void) {
@@ -238,14 +250,17 @@ static CpuApp* cpu_app_alloc(void) {
     gui_add_view(instance->gui, instance->view, GuiViewPriorityApplication);
 
     //add some test menu items
-    power_menu_add_menu_item(CPU_APP_MENU_CLOSE, (FuriCallbackWithContext){.callback = cpu_app_menu_close_click_callback, .context = instance});
-    power_menu_add_menu_item(CPU_APP_MENU_REBOOT, (FuriCallbackWithContext){.callback = cpu_app_menu_restart_click_callback, .context = instance});
+    power_menu_add_menu_item(CPU_APP_MENU_SHUTDOWN, (PowerMenuClickWithContext){.callback = cpu_app_menu_shutdown_click_callback, .context = instance});
+    power_menu_add_menu_item(CPU_APP_MENU_REBOOT, (PowerMenuClickWithContext){.callback = cpu_app_menu_restart_click_callback, .context = instance});
+    power_menu_add_menu_item(CPU_APP_MENU_CLOSE, (PowerMenuClickWithContext){.callback = cpu_app_menu_close_click_callback, .context = instance});
+
     return instance;
 }
 
 static void cpu_app_free(CpuApp* instance) {
-    power_menu_remove_menu_item(CPU_APP_MENU_CLOSE);
+    power_menu_remove_menu_item(CPU_APP_MENU_SHUTDOWN);
     power_menu_remove_menu_item(CPU_APP_MENU_REBOOT);
+    power_menu_remove_menu_item(CPU_APP_MENU_CLOSE);
 
     gui_remove_view(instance->gui, instance->view);
     furi_record_close(RECORD_GUI);

--- a/applications/main/cpu/cpu_app.c
+++ b/applications/main/cpu/cpu_app.c
@@ -1,3 +1,4 @@
+#include "cpu_app.h"
 #include <furi.h>
 #include <furi_bsp.h>
 #include <gui/gui.h>

--- a/applications/main/cpu/cpu_app.c
+++ b/applications/main/cpu/cpu_app.c
@@ -213,7 +213,7 @@ static void cpu_app_message_logic(FuriEventLoopObject* object, void* context) {
 void cpu_app_menu_close_click_callback(bool pressed, void* context) {
     furi_check(context);
     CpuApp* instance = context;
-    if(pressed) {
+    if(!pressed) {
         cpu_app_send_message(instance, CpuAppMessageTypeClose);
     }
 }
@@ -221,7 +221,7 @@ void cpu_app_menu_close_click_callback(bool pressed, void* context) {
 void cpu_app_menu_restart_click_callback(bool pressed, void* context) {
     furi_check(context);
     CpuApp* instance = context;
-    if(pressed) {
+    if(!pressed) {
         cpu_app_send_message(instance, CpuAppMessageTypeReset);
     }
 }

--- a/applications/main/cpu/cpu_app.h
+++ b/applications/main/cpu/cpu_app.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <furi.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int32_t cpu_app(void* p);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -1,3 +1,4 @@
+#include "desktop.h"
 #include <applications.h>
 #include <gui/clay_helper.h>
 #include <gui/gui.h>
@@ -243,6 +244,8 @@ static Desktop* desktop_alloc(void) {
 
     gui_add_view(desktop->gui, desktop->view, GuiViewPriorityDesktop);
 
+    furi_record_create(RECORD_DESKTOP, desktop);
+
     return desktop;
 }
 
@@ -251,4 +254,20 @@ int32_t desktop_srv(void* p) {
     Desktop* desktop = desktop_alloc();
     furi_event_loop_run(desktop->event_loop);
     return 0;
+}
+
+bool desktop_start_app(const FlipperInternalApplication* app) {
+    furi_assert(app);
+
+    Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+    DesktopMessage message = {
+        .type = DesktopMessageTypeAppStart,
+        .app = app,
+        .args = app->args,
+    };
+
+    furi_message_queue_put(desktop->app_message_queue, &message, FuriWaitForever);
+    furi_record_close(RECORD_DESKTOP);
+
+    return true;
 }

--- a/applications/services/desktop/desktop.h
+++ b/applications/services/desktop/desktop.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <applications.h>
+
+#define RECORD_DESKTOP "desktop"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool desktop_start_app(const FlipperInternalApplication* app);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/services/i2c_intercom/i2c_registers_map.h
+++ b/applications/services/i2c_intercom/i2c_registers_map.h
@@ -1,25 +1,56 @@
 #pragma once
 
-/**
+// Device address
+/*
  * Device address: 0x69
- * 
- * Register map:
+*/
+#define I2C_DEVICE_ADDRESS (0x69)
+
+// Status register
+/*
  * 0x0000   Status register             (read)
  *          Bit 0: Input interrupt flag (cleared when input interrupt register is cleared)
  *          Bit 1-15: Reserved
+*/
+#define I2C_STATUS_REG_ADDRESS   (0x0000)
+#define I2C_STATUS_REG_BIT_INPUT (0)
+
+// CPU state registers
+/*
+ * 0x0040   CPU state register          (read)
+ *          ToDo: add ENUM: state register values
+*/
+#define I2C_CPU_STATUS_REG_ADDRESS   (0x0040) 
+
+// Intercom version register
+/*
  * 0x0080   Intercom version register   (read)
+*/
+#define I2C_INTERCOM_VERSION_REG_ADDRESS (0x0080)
+#define I2C_INTERCOM_VERSION             (0x0001)
+
+// Input interrupt register and mask
+/*
  * 0x0100+0 Input interrupt register    (read, read to clear)
  *          Bit 0: Buttons input happened
  *          Bit 1: Touchpad input happened
  *          Bit 2: Headphones input happened
  *          Bit 3-15: Reserved
- * 
  * All mask registers work the same way: writing 1 to a bit will mask the corresponding interrupt and writing 0 will unmask it.
  * 0x0180+0 Input interrupt mask        (read, write)
  *          Bit 0: Buttons input interrupt masked
  *          Bit 1: Touchpad input interrupt masked
  *          Bit 2: Headphones input interrupt masked
  *          Bit 3-15: Reserved
+*/
+#define I2C_INPUT_INTERRUPT_REG_ADDRESS        (0x0100 + 0)
+#define I2C_INPUT_INTERRUPT_MASK_REG_ADDRESS   (0x0180 + 0)
+#define I2C_INPUT_INTERRUPT_REG_BIT_BUTTONS    (0)
+#define I2C_INPUT_INTERRUPT_REG_BIT_TOUCHPAD   (1)
+#define I2C_INPUT_INTERRUPT_REG_BIT_HEADPHONES (2)
+
+// Buttons state register
+/*
  * 0x0200+0 Buttons state register      (read)
  *          Bit 0: InputKey2 state
  *          Bit 1: InputKey1 state
@@ -35,41 +66,7 @@
  *          Bit 11: InputKeyUp state
  *          Bit 12: InputKeyPtt state
  *          Bit 13-15: Reserved
- * 0x0200+2 Touchpad X position         (read)
- * 0x0200+4 Touchpad Y position         (read)
- * 0x0200+6 Touchpad press state        (read)
- * 0x0200+8 Headphones state            (read)
- * 
- * 0x0300+0 Link LED group brightness      (read, write), 0 is off, 255 is max brightness. This value stored in the flash. Can be changed from the MCU state.
- * 0x0300+2 Power LED group brightness     (read, write), 0 is off, 255 is max brightness. This value stored in the flash. Can be changed from the MCU state.
- * 0x0300+4 Wattmeter LED group brightness (read, write), 0 is off, 255 is max brightness. This value stored in the flash. Can be changed from the MCU state.
- * 
- * All LED colors are in RGB 565 format
- * 0x0310+0 Link1 LED color (read, write)
- * 0x0310+2 Link2 LED color (read, write)
- * 0x0310+4 Link3 LED color (read, write)
- * 0x0310+6 Link4 LED color (read, write)
- */
-
-// Device address
-#define I2C_DEVICE_ADDRESS (0x69)
-
-// Status register
-#define I2C_STATUS_REG_ADDRESS   (0x0000)
-#define I2C_STATUS_REG_BIT_INPUT (0)
-
-// Intercom version register
-#define I2C_INTERCOM_VERSION_REG_ADDRESS (0x0080)
-#define I2C_INTERCOM_VERSION             (0x0001)
-
-// Input interrupt register and mask
-#define I2C_INPUT_INTERRUPT_REG_ADDRESS        (0x0100 + 0)
-#define I2C_INPUT_INTERRUPT_MASK_REG_ADDRESS   (0x0180 + 0)
-#define I2C_INPUT_INTERRUPT_REG_BIT_BUTTONS    (0)
-#define I2C_INPUT_INTERRUPT_REG_BIT_TOUCHPAD   (1)
-#define I2C_INPUT_INTERRUPT_REG_BIT_HEADPHONES (2)
-
-// Buttons state register
+*/
 #define I2C_BUTTONS_STATE_REG_ADDRESS      (0x0200 + 0)
 #define I2C_BUTTONS_STATE_REG_BIT_KEY2     (0)
 #define I2C_BUTTONS_STATE_REG_BIT_KEY1     (1)
@@ -86,11 +83,26 @@
 #define I2C_BUTTONS_STATE_REG_BIT_KEYPTT   (12)
 
 // Touchpad state registers
+/*
+ * 0x0200+2 Touchpad X position         (read)
+ * 0x0200+4 Touchpad Y position         (read)
+ * 0x0200+6 Touchpad press state        (read)
+*/
 #define I2C_TOUCHPAD_X_REG_ADDRESS     (0x0200 + 2)
 #define I2C_TOUCHPAD_Y_REG_ADDRESS     (0x0200 + 4)
 #define I2C_TOUCHPAD_PRESS_REG_ADDRESS (0x0200 + 6)
 
 // Headphones state register
+/*
+ * 0x0200+8 Headphones state            (read)
+ *          Bit 0: Headphones present
+ *          Bit 1: Microphone present
+ *          Bit 2: Button A pressed
+ *          Bit 3: Button B pressed
+ *          Bit 4: Button C pressed
+ *          Bit 5: Button D pressed
+ *          Bit 6-15: Reserved
+ */
 #define I2C_HEADPHONES_STATE_REG_ADDRESS                (0x0200 + 8)
 #define I2C_HEADPHONES_STATE_REG_HEADPHONES_PRESENT_BIT (0)
 #define I2C_HEADPHONES_STATE_REG_MIC_PRESENT_BIT        (1)
@@ -100,11 +112,23 @@
 #define I2C_HEADPHONES_STATE_REG_BUTTON_D_PRESSED_BIT   (5)
 
 // Led brightness registers
+/* 
+ * 0x0300+0 Link LED group brightness      (read, write), 0 is off, 255 is max brightness. This value stored in the flash. Can be changed from the MCU state.
+ * 0x0300+2 Power LED group brightness     (read, write), 0 is off, 255 is max brightness. This value stored in the flash. Can be changed from the MCU state.
+ * 0x0300+4 Wattmeter LED group brightness (read, write), 0 is off, 255 is max brightness. This value stored in the flash. Can be changed from the MCU state.
+*/
 #define I2C_LED_BRIGHTNESS_LINK_REG_ADDRESS      (0x0300 + 0)
 #define I2C_LED_BRIGHTNESS_POWER_REG_ADDRESS     (0x0300 + 2)
 #define I2C_LED_BRIGHTNESS_WATTMETER_REG_ADDRESS (0x0300 + 4)
 
 // Led color registers
+/*
+ * All LED colors are in RGB 565 format
+ * 0x0310+0 Link1 LED color (read, write)
+ * 0x0310+2 Link2 LED color (read, write)
+ * 0x0310+4 Link3 LED color (read, write)
+ * 0x0310+6 Link4 LED color (read, write)
+ */
 #define I2C_LED_LINK1_COLOR_REG_ADDRESS (0x0310 + 0)
 #define I2C_LED_LINK2_COLOR_REG_ADDRESS (0x0310 + 2)
 #define I2C_LED_LINK3_COLOR_REG_ADDRESS (0x0310 + 4)

--- a/applications/services/i2c_intercom/i2c_registers_map.h
+++ b/applications/services/i2c_intercom/i2c_registers_map.h
@@ -41,13 +41,15 @@
  *          Bit 0: Buttons input interrupt masked
  *          Bit 1: Touchpad input interrupt masked
  *          Bit 2: Headphones input interrupt masked
- *          Bit 3-15: Reserved
+ *          Bit 3: SW buttons input interrupt masked
+ *          Bit 4-15: Reserved
 */
 #define I2C_INPUT_INTERRUPT_REG_ADDRESS        (0x0100 + 0)
 #define I2C_INPUT_INTERRUPT_MASK_REG_ADDRESS   (0x0180 + 0)
 #define I2C_INPUT_INTERRUPT_REG_BIT_BUTTONS    (0)
 #define I2C_INPUT_INTERRUPT_REG_BIT_TOUCHPAD   (1)
 #define I2C_INPUT_INTERRUPT_REG_BIT_HEADPHONES (2)
+#define I2C_INPUT_INTERRUPT_REG_BIT_SW_BUTTONS (3)
 
 // Buttons state register
 /*
@@ -91,6 +93,15 @@
 #define I2C_TOUCHPAD_X_REG_ADDRESS     (0x0200 + 2)
 #define I2C_TOUCHPAD_Y_REG_ADDRESS     (0x0200 + 4)
 #define I2C_TOUCHPAD_PRESS_REG_ADDRESS (0x0200 + 6)
+
+// Software buttons state register
+/*
+ * 0x0200+0xA   Software buttons state    (read)
+ *              Bit 0: Power button state
+ *              Bit 1-15: Reserved
+*/
+#define I2C_SW_BUTTONS_STATE_REG_ADDRESS                  (0x0200 + 0xA)
+#define I2C_SW_BUTTONS_STATE_REG_BIT_POWER                (0)
 
 // Headphones state register
 /*

--- a/applications/services/i2c_negotiator/i2c_negotiator.c
+++ b/applications/services/i2c_negotiator/i2c_negotiator.c
@@ -94,6 +94,12 @@ static bool i2c_negotiator_input_touch_event_glue(InputTouchEvent* event, void* 
     return false;
 }
 
+//Cpu state register
+void i2c_negotiator_cpu_state(I2CNegotiator* instance, uint16_t value) {
+    FURI_LOG_I(TAG, "CPU state register write: 0x%04X", value);
+}
+I2C_NEGOTIATOR_REGISTER_MESSAGE_FROM_IRQ(i2c_negotiator_cpu_state);
+
 // Headphones event
 static void i2c_negotiator_headphones_event_glue(const void* value, void* ctx) {
     UNUSED(ctx);
@@ -210,6 +216,9 @@ I2CNegotiator* i2c_negotiator_alloc() {
         // Interrupt register
         i2c_register_add_interrupt(I2C_INPUT_INTERRUPT_REG_ADDRESS, I2C_INPUT_INTERRUPT_MASK_REG_ADDRESS, I2C_STATUS_REG_BIT_INPUT);
 
+        //Cpu state register
+        i2c_register_add_writable(I2C_CPU_STATUS_REG_ADDRESS, 0, i2c_negotiator_cpu_state_message, instance->negotiator_queue);
+        
         // Buttons state
         i2c_register_add_readable(I2C_BUTTONS_STATE_REG_ADDRESS, 0);
 

--- a/applications/services/i2c_negotiator/i2c_negotiator.c
+++ b/applications/services/i2c_negotiator/i2c_negotiator.c
@@ -94,6 +94,30 @@ static bool i2c_negotiator_input_touch_event_glue(InputTouchEvent* event, void* 
     return false;
 }
 
+// Sw button event
+bool i2c_negotiator_input_sw_button_event(SwInputKey key, bool pressed, void* context) {
+    UNUSED(context);
+    furi_check(key & SwKeyMask);
+    FURI_LOG_I(TAG, "SW button event: key=0x%04X pressed=%d", key, pressed);
+
+    with_i2c_register({
+        if(pressed) {
+            if(i2c_register_update(I2C_SW_BUTTONS_STATE_REG_ADDRESS, key, key)) {
+                // issue interrupt if button state is changed
+                i2c_register_set_interrupt(I2C_INPUT_INTERRUPT_REG_ADDRESS, 1 << I2C_INPUT_INTERRUPT_REG_BIT_SW_BUTTONS);
+            }
+        } else {
+            if(i2c_register_update(I2C_SW_BUTTONS_STATE_REG_ADDRESS, 0, key)) {
+                // issue interrupt if button state is changed
+                i2c_register_set_interrupt(I2C_INPUT_INTERRUPT_REG_ADDRESS, 1 << I2C_INPUT_INTERRUPT_REG_BIT_SW_BUTTONS);
+            }
+        }
+    });
+
+    // we dont consume the event in any case
+    return false;
+}
+
 //Cpu state register
 void i2c_negotiator_cpu_state(I2CNegotiator* instance, uint16_t value) {
     FURI_LOG_I(TAG, "CPU state register write: 0x%04X", value);
@@ -226,6 +250,9 @@ I2CNegotiator* i2c_negotiator_alloc() {
         i2c_register_add_readable(I2C_TOUCHPAD_X_REG_ADDRESS, 0);
         i2c_register_add_readable(I2C_TOUCHPAD_Y_REG_ADDRESS, 0);
         i2c_register_add_readable(I2C_TOUCHPAD_PRESS_REG_ADDRESS, 0);
+
+        // SW buttons state
+        i2c_register_add_readable(I2C_SW_BUTTONS_STATE_REG_ADDRESS, 0);
 
         // Headphones
         i2c_register_add_readable(I2C_HEADPHONES_STATE_REG_ADDRESS, 0);

--- a/applications/services/i2c_negotiator/i2c_negotiator.h
+++ b/applications/services/i2c_negotiator/i2c_negotiator.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <furi.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool i2c_negotiator_input_sw_button_event(SwInputKey key, bool pressed, void* context);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/services/power_menu/power_menu.c
+++ b/applications/services/power_menu/power_menu.c
@@ -1,4 +1,5 @@
 #include "power_menu.h"
+#include "input/input.h"
 #include <furi.h>
 #include <furi_hal_i2c_config.h>
 #include <gui/gui.h>
@@ -36,7 +37,7 @@ static const char* power_menu_items[] = {
 
 typedef struct {
     const char* text;
-    FuriCallbackWithContext on_click;
+    PowerMenuClickWithContext on_click;
 } PowerMenuCallbacks;
 
 ARRAY_DEF(PowerMenuArray, PowerMenuCallbacks, M_POD_OPLIST);
@@ -58,7 +59,7 @@ typedef struct {
     union {
         struct {
             const char* text;
-            FuriCallbackWithContext on_click;
+            PowerMenuClickWithContext on_click;
         } add_item;
         struct {
             const char* text;
@@ -308,7 +309,7 @@ static bool power_menu_model_init(PowerMenuModel* model, void* context) {
     return false;
 }
 
-static void power_menu_add_item(PowerMenuModel* model, const char* text, FuriCallbackWithContext on_click) {
+static void power_menu_add_item(PowerMenuModel* model, const char* text, PowerMenuClickWithContext on_click) {
     PowerMenuCallbacks* item = PowerMenuArray_push_raw(model->menu_items->data);
     item->text = text;
     item->on_click = on_click;
@@ -483,27 +484,29 @@ static void power_menu_input_right(PowerMenu* instance, int selected_index) {
     }
 }
 
-static void power_menu_input_menu(PowerMenu* instance, int selected_index) {
+static void power_menu_input_menu(PowerMenu* instance, int selected_index, bool pressed) {
     // OK on menu does the same thing as right
     if(selected_index >= 0) {
-        power_menu_input_right(instance, selected_index);
+        if(pressed) {
+            power_menu_input_right(instance, selected_index);
 
-        switch(selected_index) {
-        case PowerMenuActionPowerOff:
-            Power* power_off = furi_record_open(RECORD_POWER);
-            power_bq25792_set_power_switch(power_off, Bq25792PowerShipMode);
-            furi_record_close(RECORD_POWER);
-            break;
-        case PowerMenuActionReboot:
-            Power* power_reset = furi_record_open(RECORD_POWER);
-            power_bq25792_set_power_switch(power_reset, Bq25792PowerReset);
-            furi_record_close(RECORD_POWER);
-            break;
-        case PowerMenuActionCancel:
-            power_menu_model_apply(instance, power_menu_input_menu_hide, NULL);
-            break;
-        default:
-            break;
+            switch(selected_index) {
+            case PowerMenuActionPowerOff:
+                Power* power_off = furi_record_open(RECORD_POWER);
+                power_bq25792_set_power_switch(power_off, Bq25792PowerShipMode);
+                furi_record_close(RECORD_POWER);
+                break;
+            case PowerMenuActionReboot:
+                Power* power_reset = furi_record_open(RECORD_POWER);
+                power_bq25792_set_power_switch(power_reset, Bq25792PowerReset);
+                furi_record_close(RECORD_POWER);
+                break;
+            case PowerMenuActionCancel:
+                power_menu_model_apply(instance, power_menu_input_menu_hide, NULL);
+                break;
+            default:
+                break;
+            }
         }
     } else {
         size_t custom_index = selected_index * -1 - 1;
@@ -514,11 +517,13 @@ static void power_menu_input_menu(PowerMenu* instance, int selected_index) {
             {
                 PowerMenuCallbacks* item = PowerMenuArray_get(model->menu_items->data, custom_index);
                 if(item && item->on_click.callback) {
-                    item->on_click.callback(item->on_click.context);
+                    item->on_click.callback(pressed, item->on_click.context);
                 }
             },
             true);
-        power_menu_model_apply(instance, power_menu_input_menu_hide, NULL);
+        if(!pressed) {
+            power_menu_model_apply(instance, power_menu_input_menu_hide, NULL);
+        }
     }
 }
 
@@ -546,12 +551,16 @@ static bool power_menu_input(InputEvent* event, void* context) {
             } else if(event->key == InputKeyOk) {
                 int selected_index;
                 power_menu_model_apply(instance, power_menu_input_menu_get_selected_index, &selected_index);
-                power_menu_input_menu(instance, selected_index);
+                power_menu_input_menu(instance, selected_index, true);
             } else if(event->key == InputKeyBack) {
                 power_menu_model_apply(instance, power_menu_input_menu_hide, NULL);
             } else if(event->key == InputKey3) {
                 power_menu_model_apply(instance, power_menu_input_menu_hide, NULL);
             }
+        } else if(event->type == InputTypeRelease && event->key == InputKeyOk) {
+            int selected_index;
+            power_menu_model_apply(instance, power_menu_input_menu_get_selected_index, &selected_index);
+            power_menu_input_menu(instance, selected_index, false);
         }
 
         // Consume all events when visible, except for release events
@@ -671,7 +680,7 @@ static void power_menu_send_message(PowerMenu* instance, const PowerMenuMessage*
     }
 }
 
-bool power_menu_add_menu_item(const char* text, FuriCallbackWithContext on_click) {
+bool power_menu_add_menu_item(const char* text, PowerMenuClickWithContext on_click) {
     furi_assert(text);
     bool result;
     PowerMenuMessage msg = {

--- a/applications/services/power_menu/power_menu.c
+++ b/applications/services/power_menu/power_menu.c
@@ -9,9 +9,43 @@
 #include <m-array.h>
 #include <api_lock.h>
 
+#include <desktop/desktop.h>
+
+extern int32_t cpu_app(void* p);
+
 #define TAG                     "PowerMenu"
 #define POWER_MENU_MAX_MESSAGES (8)
 #define POWER_MENU_ID(x)        CLAY_SIDI(CLAY_STRING("PowerMenu"), x)
+
+#define POWER_MENU_CPU_APP_START   "CPU Start"
+#define POWER_MENU_CPU_APP_MASKROM "CPU Maskrom"
+
+typedef enum {
+    PowerMenuCpuAppStart,
+    PowerMenuCpuAppMaskrom,
+    PowerMenuCpuAppCount
+} PowerMenuCpuApp;
+
+static const FlipperInternalApplication app[] = {
+    [PowerMenuCpuAppStart] =
+        {
+            .app = cpu_app,
+            .name = "CPU Start",
+            .appid = "cpu",
+            .stack_size = 4096,
+            .flags = FlipperInternalApplicationFlagDefault,
+            .args = "CPU Start",
+        },
+    [PowerMenuCpuAppMaskrom] =
+        {
+            .app = cpu_app,
+            .name = "CPU Maskrom",
+            .appid = "cpu",
+            .stack_size = 4096,
+            .flags = FlipperInternalApplicationFlagDefault,
+            .args = "CPU Maskrom",
+        },
+};
 
 typedef enum {
     PowerMenuActionLeds,
@@ -90,6 +124,8 @@ typedef struct {
     size_t selected_power_led_brightness_index;
     size_t selected_wattmeter_led_brightness_index;
     FuriMessageQueue* message_queue;
+    bool app_running;
+    bool app_add_item;
 } PowerMenu;
 
 static const LedBatch* items[] = {
@@ -106,7 +142,7 @@ static const char* led_batch_names[] = {
     " White",
 };
 
-static_assert(COUNT_OF(items) == COUNT_OF(led_batch_names));
+static_assert(COUNT_OF(items) == COUNT_OF(led_batch_names), "items and led_batch_names count mismatch");
 
 static const size_t led_batch_count = COUNT_OF(items);
 
@@ -491,16 +527,18 @@ static void power_menu_input_menu(PowerMenu* instance, int selected_index, bool 
             power_menu_input_right(instance, selected_index);
 
             switch(selected_index) {
-            case PowerMenuActionPowerOff:
+            case PowerMenuActionPowerOff: {
                 Power* power_off = furi_record_open(RECORD_POWER);
                 power_bq25792_set_power_switch(power_off, Bq25792PowerShipMode);
                 furi_record_close(RECORD_POWER);
                 break;
-            case PowerMenuActionReboot:
+            }
+            case PowerMenuActionReboot: {
                 Power* power_reset = furi_record_open(RECORD_POWER);
                 power_bq25792_set_power_switch(power_reset, Bq25792PowerReset);
                 furi_record_close(RECORD_POWER);
                 break;
+            }
             case PowerMenuActionCancel:
                 power_menu_model_apply(instance, power_menu_input_menu_hide, NULL);
                 break;
@@ -526,6 +564,32 @@ static void power_menu_input_menu(PowerMenu* instance, int selected_index, bool 
         }
     }
 }
+
+// #### app
+// static void power_menu_remove_app_menu_items(PowerMenu* instance) {
+//     power_menu_remove_menu_item(POWER_MENU_CPU_APP_START);
+//     power_menu_remove_menu_item(POWER_MENU_CPU_APP_MASKROM);
+//     instance->app_running = false;
+// }
+
+static void power_menu_cpu_app_start_callback(bool pressed, void* context) {
+    PowerMenu* instance = context;
+    furi_check(instance);
+    if(pressed) {
+        instance->app_running = true;
+        desktop_start_app(&app[PowerMenuCpuAppStart]);
+       // power_menu_remove_app_menu_items(instance);
+    }
+}
+
+static void power_menu_add_app_menu_items(PowerMenu* instance) {
+    if(!instance->app_running && !instance->app_add_item) {
+        power_menu_add_menu_item(POWER_MENU_CPU_APP_START, (PowerMenuClickWithContext){.callback = power_menu_cpu_app_start_callback, .context = instance});
+        power_menu_add_menu_item(POWER_MENU_CPU_APP_MASKROM, (PowerMenuClickWithContext){.callback = power_menu_cpu_app_start_callback, .context = instance});
+        instance->app_add_item = true;
+    }
+}
+// ####
 
 static bool power_menu_input(InputEvent* event, void* context) {
     furi_check(context);
@@ -571,6 +635,7 @@ static bool power_menu_input(InputEvent* event, void* context) {
         if(event->type == InputTypePress) {
             if(event->key == InputKey3) {
                 power_menu_model_apply(instance, power_menu_input_menu_show, NULL);
+                power_menu_add_app_menu_items(instance);
                 consumed = true;
             }
         }

--- a/applications/services/power_menu/power_menu.h
+++ b/applications/services/power_menu/power_menu.h
@@ -1,14 +1,19 @@
 #pragma once
 #include <furi.h>
-#include <toolbox/furi_callback.h>
 
 #define RECORD_POWER_MENU "power_menu"
+
+typedef void (*PowerMenuClickCallback)(bool pressed, void* context);
+typedef struct {
+    PowerMenuClickCallback callback;
+    void* context;
+} PowerMenuClickWithContext;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-bool power_menu_add_menu_item(const char* text, FuriCallbackWithContext on_click);
+bool power_menu_add_menu_item(const char* text, PowerMenuClickWithContext on_click);
 bool power_menu_remove_menu_item(const char* text);
 
 #ifdef __cplusplus

--- a/targets/f100/furi_hal/furi_hal_resources.h
+++ b/targets/f100/furi_hal/furi_hal_resources.h
@@ -33,6 +33,11 @@ typedef enum {
 } InputKey;
 
 typedef enum {
+    SwPowerKey = (1 << 0),
+    SwKeyMask = (0b0000000000000001),
+} SwInputKey;
+
+typedef enum {
     StatusLedPowerLine3 = (1 << 13),
     StatusLedPowerLine2 = (1 << 14),
     StatusLedPowerLine1 = (1 << 15),


### PR DESCRIPTION
# What's new

- i2c_negotiator: add cpu state register
- i2c_negotiator: add sw key register
- desktop: start applications from menu

# Verification 

- [ Describe how to verify changes ]

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
