### PR TITLE
Display backlight timeout

### DIFF
--- a/applications/services/gui/gui.c
+++ b/applications/services/gui/gui.c
@@ -336,11 +336,6 @@ static void gui_redraw_logic(FuriEventLoopObject* object, void* context) {
     gui_redraw(gui);
 }
 
-void gui_set_backlight(Gui* gui, int8_t brightness) {
-    furi_check(gui);
-    display_jd9853_qspi_set_brightness(gui->display, brightness);
-}
-
 static Gui* gui_alloc(void) {
     canvas_init();
 
@@ -360,7 +355,6 @@ static Gui* gui_alloc(void) {
 
     // Display and buffer
     gui->display = display_jd9853_qspi_init();
-    gui_set_backlight(gui, 20);
     gui->render_canvas = canvas_alloc(JD9853_WIDTH, JD9853_HEIGHT);
 
     // Clay initialization

--- a/applications/services/gui/gui.h
+++ b/applications/services/gui/gui.h
@@ -21,9 +21,6 @@ void gui_add_view(Gui* gui, View* view, GuiViewPriority priority);
 
 void gui_remove_view(Gui* gui, View* view);
 
-// TODO: This is a temporary API, as backlight should be controlled by a dedicated service
-void gui_set_backlight(Gui* gui, int8_t brightness);
-
 void gui_add_unhandled_input_callback(Gui* gui, ViewInputCallback callback, void* context);
 void gui_add_unhandled_touch_input_callback(Gui* gui, ViewInputTouchCallback callback, void* context);
 

--- a/applications/services/i2c_intercom/i2c_registers_map.h
+++ b/applications/services/i2c_intercom/i2c_registers_map.h
@@ -20,7 +20,7 @@
  * 0x0040   CPU state register          (read)
  *          ToDo: add ENUM: state register values
 */
-#define I2C_CPU_STATUS_REG_ADDRESS   (0x0040) 
+#define I2C_CPU_STATUS_REG_ADDRESS (0x0040)
 
 // Intercom version register
 /*
@@ -100,8 +100,8 @@
  *              Bit 0: Power button state
  *              Bit 1-15: Reserved
 */
-#define I2C_SW_BUTTONS_STATE_REG_ADDRESS                  (0x0200 + 0xA)
-#define I2C_SW_BUTTONS_STATE_REG_BIT_POWER                (0)
+#define I2C_SW_BUTTONS_STATE_REG_ADDRESS   (0x0200 + 0xA)
+#define I2C_SW_BUTTONS_STATE_REG_BIT_POWER (0)
 
 // Headphones state register
 /*
@@ -144,6 +144,18 @@
 #define I2C_LED_LINK2_COLOR_REG_ADDRESS (0x0310 + 2)
 #define I2C_LED_LINK3_COLOR_REG_ADDRESS (0x0310 + 4)
 #define I2C_LED_LINK4_COLOR_REG_ADDRESS (0x0310 + 6)
+
+// Backlight control registers
+/*
+ * 0x0350+0 Backlight level register (read, write), 0 is off, 255 is max brightness. This value stored in the flash. Can be changed from the MCU state.
+ * 0x0350+2 Backlight time register (read, write), in 100ms intervals, should be greater than 0
+ * 0x0350+4 Backlight control register (read, write)
+*/
+#define I2C_BACKLIGHT_LEVEL                    (0x0350 + 0)
+#define I2C_BACKLIGHT_TIMEOUT                  (0x0350 + 2) // * 100 ms, 10 = 1s
+#define I2C_BACKLIGHT_CONTROL                  (0x0350 + 4) // bit 0 - override backlight timeout, bit 1 - ping backlight
+#define I2C_BACKLIGHT_CONTROL_REG_BIT_OVERRIDE (0)
+#define I2C_BACKLIGHT_CONTROL_REG_BIT_PING     (1)
 
 // Haptic registers
 /*

--- a/applications/services/i2c_negotiator/i2c_negotiator.c
+++ b/applications/services/i2c_negotiator/i2c_negotiator.c
@@ -151,6 +151,21 @@ void i2c_negotiator_wattmeter_led_brightness_set(I2CNegotiator* instance, uint16
 }
 I2C_NEGOTIATOR_REGISTER_MESSAGE_FROM_IRQ(i2c_negotiator_wattmeter_led_brightness_set);
 
+void i2c_negotiator_backlight_led_brightness_set(I2CNegotiator* instance, uint16_t value) {
+    led_set_brightness(instance->led, LedGroupDisplayBacklight, value & 0xFF);
+}
+I2C_NEGOTIATOR_REGISTER_MESSAGE_FROM_IRQ(i2c_negotiator_backlight_led_brightness_set);
+
+void i2c_negotiator_backlight_time_set(I2CNegotiator* instance, uint16_t value) {
+    led_backlight_set_time(instance->led, value * 100);
+}
+I2C_NEGOTIATOR_REGISTER_MESSAGE_FROM_IRQ(i2c_negotiator_backlight_time_set);
+
+void i2c_negotiator_backlight_control_set(I2CNegotiator* instance, uint16_t value) {
+    led_backlight_timeout_control(instance->led, value & (1 << I2C_BACKLIGHT_CONTROL_REG_BIT_PING), value & (1 << I2C_BACKLIGHT_CONTROL_REG_BIT_OVERRIDE));
+}
+I2C_NEGOTIATOR_REGISTER_MESSAGE_FROM_IRQ(i2c_negotiator_backlight_control_set);
+
 void i2c_negotiator_led_link1(I2CNegotiator* instance, uint16_t value) {
     LedColor color = LED_COLOR_RGB565(value);
     led_set_color_single(instance->led, LedTypeNet, color);
@@ -222,6 +237,18 @@ static void i2c_negotiator_wattmeter_led_brightness_callback(const void* item, v
     with_i2c_register({ i2c_register_update(I2C_LED_BRIGHTNESS_WATTMETER_REG_ADDRESS, *brightness, 0xFF); });
 }
 
+static void i2c_negotiator_backlight_led_brightness_callback(const void* item, void* context) {
+    UNUSED(context);
+    uint8_t* brightness = (uint8_t*)item;
+    with_i2c_register({ i2c_register_update(I2C_BACKLIGHT_LEVEL, *brightness, 0xFF); });
+}
+
+static void i2c_negotiator_backlight_timeout_callback(const void* item, void* context) {
+    UNUSED(context);
+    uint32_t* timeout = (uint32_t*)item;
+    with_i2c_register({ i2c_register_update(I2C_BACKLIGHT_TIMEOUT, *timeout / 100, 0xFFFF); });
+}
+
 I2CNegotiator* i2c_negotiator_alloc() {
     I2CNegotiator* instance = malloc(sizeof(I2CNegotiator));
     instance->gui = furi_record_open(RECORD_GUI);
@@ -271,7 +298,13 @@ I2CNegotiator* i2c_negotiator_alloc() {
         furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupLink), i2c_negotiator_link_led_brightness_callback, NULL);
         furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupPower), i2c_negotiator_power_led_brightness_callback, NULL);
         furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupWattmeter), i2c_negotiator_wattmeter_led_brightness_callback, NULL);
-        // TODO: backlight
+
+        // Backlight
+        i2c_register_add_writable(I2C_BACKLIGHT_LEVEL, 0, i2c_negotiator_backlight_led_brightness_set_message, instance->negotiator_queue);
+        i2c_register_add_writable(I2C_BACKLIGHT_TIMEOUT, 0, i2c_negotiator_backlight_time_set_message, instance->negotiator_queue);
+        i2c_register_add_writable(I2C_BACKLIGHT_CONTROL, 0, i2c_negotiator_backlight_control_set_message, instance->negotiator_queue);
+        furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupDisplayBacklight), i2c_negotiator_backlight_led_brightness_callback, NULL);
+        furi_state_subscribe(led_get_backlight_time_state(instance->led), i2c_negotiator_backlight_timeout_callback, NULL);
 
         // Haptic
         i2c_register_add_writable(I2C_HAPTIC_PLAY_EFFECT_REG_ADDRESS, 0, i2c_negotiator_haptic_play_effect_message, instance->negotiator_queue);

--- a/applications/services/i2c_negotiator/i2c_negotiator.c
+++ b/applications/services/i2c_negotiator/i2c_negotiator.c
@@ -242,7 +242,7 @@ I2CNegotiator* i2c_negotiator_alloc() {
 
         //Cpu state register
         i2c_register_add_writable(I2C_CPU_STATUS_REG_ADDRESS, 0, i2c_negotiator_cpu_state_message, instance->negotiator_queue);
-        
+
         // Buttons state
         i2c_register_add_readable(I2C_BUTTONS_STATE_REG_ADDRESS, 0);
 
@@ -268,9 +268,10 @@ I2CNegotiator* i2c_negotiator_alloc() {
         i2c_register_add_writable(I2C_LED_BRIGHTNESS_POWER_REG_ADDRESS, 0, i2c_negotiator_power_led_brightness_set_message, instance->negotiator_queue);
         i2c_register_add_writable(I2C_LED_BRIGHTNESS_WATTMETER_REG_ADDRESS, 0, i2c_negotiator_wattmeter_led_brightness_set_message, instance->negotiator_queue);
 
-        furi_state_subscribe(led_get_link_brightness_state(instance->led), i2c_negotiator_link_led_brightness_callback, NULL);
-        furi_state_subscribe(led_get_power_brightness_state(instance->led), i2c_negotiator_power_led_brightness_callback, NULL);
-        furi_state_subscribe(led_get_wattmeter_brightness_state(instance->led), i2c_negotiator_wattmeter_led_brightness_callback, NULL);
+        furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupLink), i2c_negotiator_link_led_brightness_callback, NULL);
+        furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupPower), i2c_negotiator_power_led_brightness_callback, NULL);
+        furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupWattmeter), i2c_negotiator_wattmeter_led_brightness_callback, NULL);
+        // TODO: backlight
 
         // Haptic
         i2c_register_add_writable(I2C_HAPTIC_PLAY_EFFECT_REG_ADDRESS, 0, i2c_negotiator_haptic_play_effect_message, instance->negotiator_queue);

--- a/applications/services/led/led.h
+++ b/applications/services/led/led.h
@@ -70,6 +70,7 @@ typedef enum {
     LedGroupLink,
     LedGroupPower,
     LedGroupWattmeter,
+    LedGroupDisplayBacklight,
 
     LedGroupMax, // internal use only, keep it last
 } LedGroup;
@@ -84,11 +85,13 @@ void led_set_color_batch(Led* instance, const LedBatch* items);
 
 void led_set_brightness(Led* instance, LedGroup group, uint8_t brightness);
 
-FuriState* led_get_link_brightness_state(Led* instance);
+bool led_backlight_set_time(Led* instance, uint32_t timeout_seconds);
 
-FuriState* led_get_power_brightness_state(Led* instance);
+void led_backlight_timeout_control(Led* instance, bool ping, bool set_always_on);
 
-FuriState* led_get_wattmeter_brightness_state(Led* instance);
+FuriState* led_get_brightness_state(Led* instance, LedGroup group);
+
+FuriState* led_get_backlight_time_state(Led* instance);
 
 #ifdef __cplusplus
 }

--- a/applications/services/led/led.h
+++ b/applications/services/led/led.h
@@ -85,7 +85,7 @@ void led_set_color_batch(Led* instance, const LedBatch* items);
 
 void led_set_brightness(Led* instance, LedGroup group, uint8_t brightness);
 
-bool led_backlight_set_time(Led* instance, uint32_t timeout_seconds);
+bool led_backlight_set_time(Led* instance, uint32_t timeout_ms);
 
 void led_backlight_timeout_control(Led* instance, bool ping, bool set_always_on);
 

--- a/applications/services/led/led_backend.c
+++ b/applications/services/led/led_backend.c
@@ -3,9 +3,12 @@
 #include <furi_bsp.h>
 #include <furi_hal_nvm.h>
 #include <furi_hal_resources.h>
+#include <furi_hal_pwm.h>
 #include <api_lock.h>
 #include <drivers/ws2812/ws2812.h>
 #include <settings/settings.h>
+#include <input/input.h>
+#include <input_touch/input_touch.h>
 
 #define TAG "Led"
 
@@ -21,19 +24,28 @@
 #define LED_LINE3_INDEX             (2U)
 #define LED_LINES_COUNT             (3U)
 
-#define LED_BRIGHTNESS_MULTIPLIER (0.5f)
+#define LED_RGB_BRIGHTNESS_MULTIPLIER (0.5f)
+
+#define LED_BACKLIGHT_PWM_RESOLUTION 8 // 8-bit PWM for backlight
+#define LED_BACKLIGHT_PWM_FREQ_HZ    40000 // 40kHz PWM for backlight
+
+#define LED_BACKLIGHT_TIME_DEFAULT 15
 
 typedef struct {
     uint32_t line[LED_TOTAL_LEDS_COUNT];
     LedColor colors[LED_TOTAL_LEDS_COUNT];
     StatusLedPower mask_power;
     FuriState* brightness[LedGroupMax];
+    FuriState* backlight_time;
+    bool backlight_always_on;
 } LedState;
 
 struct Led {
     FuriEventLoop* event_loop;
     FuriMessageQueue* message_queue;
+    FuriEventLoopTimer* backlight_timer;
     Ws2812* ws2812;
+    FuriHalPwm* backlight_pwm;
     LedState led_state;
 };
 
@@ -41,6 +53,9 @@ typedef enum {
     LedMessageTypeSetColorSingle,
     LedMessageTypeSetColorBatch,
     LedMessageTypeSetBrightness,
+    LedMessageTypeSetBacklightTime,
+    LedMessageTypeBacklightControl,
+    LedMessageTypeBacklightInputToggle,
 } LedMessageType;
 
 typedef enum {
@@ -50,35 +65,75 @@ typedef enum {
 } LedUpdateLine;
 
 typedef struct {
-    LedType type;
-    LedColor color;
-} LedMessageSetColorSingle;
-
-typedef struct {
-    const LedBatch* items;
-} LedMessageSetColorBatch;
-
-typedef struct {
-    LedGroup group;
-    uint8_t brightness;
-} LedMessageSetBrightness;
-
-typedef struct {
     LedMessageType type;
     FuriApiLock lock;
     bool* result;
     union {
-        LedMessageSetColorSingle set_color_single;
-        LedMessageSetColorBatch set_color_batch;
-        LedMessageSetBrightness set_brightness;
+        struct {
+            LedType type;
+            LedColor color;
+        } set_color_single;
+
+        struct {
+            const LedBatch* items;
+        } set_color_batch;
+
+        struct {
+            LedGroup group;
+            uint8_t brightness;
+        } set_brightness;
+
+        struct {
+            uint32_t timeout_seconds;
+        } set_backlight_time;
+
+        struct {
+            enum {
+                LedBacklightTimeFlagPing = (1 << 0U),
+                LedBacklightTimeFlagAlwaysOn = (1 << 1U),
+            } flags;
+        } backlight_time_control;
     };
 } LedMessage;
 
-static const char* led_group_names[LedGroupMax] = {
-    [LedGroupLink] = SETTINGS_LED_GROUP_LINK,
-    [LedGroupPower] = SETTINGS_LED_GROUP_POWER,
-    [LedGroupWattmeter] = SETTINGS_LED_GROUP_WATTMETER,
+static const struct {
+    const char* name;
+    uint8_t default_value;
+} led_settings[LedGroupMax] = {
+    [LedGroupLink] = {SETTINGS_LED_GROUP_LINK, 255},
+    [LedGroupPower] = {SETTINGS_LED_GROUP_POWER, 255},
+    [LedGroupWattmeter] = {SETTINGS_LED_GROUP_WATTMETER, 255},
+    [LedGroupDisplayBacklight] = {SETTINGS_LED_BACKLIGHT, 51}, // 20%
 };
+
+static void led_backlight_brightness_transition(Led* instance, uint8_t new_value) {
+    // TODO: smooth transition using DMA + PWM
+
+    if(new_value == 0) {
+        if(instance->backlight_pwm) {
+            furi_hal_pwm_set_duty_cycle(instance->backlight_pwm, 0);
+            furi_hal_pwm_deinit(instance->backlight_pwm);
+            instance->backlight_pwm = NULL;
+        }
+    } else {
+        uint32_t max_value = (1 << LED_BACKLIGHT_PWM_RESOLUTION) - 1;
+        uint32_t duty_cycle = (new_value * max_value) / 255;
+        if(!instance->backlight_pwm) {
+            // To enable the device, the CTRL signal must be high for 500 µs.
+            // The PWM signal can then be applied with a pulse width (tp)
+            // greater or smaller than tON. To force the device into shutdown mode,
+            // the CTRL signal must be low for at least 32 ms.
+            // Requiring the CTRL pin to be low for 32 mS before the device enters
+            // shutdown allows for PWM dimming frequencies as low as 100 Hz.
+            // The device is enabled again when a CTRL signal is high for a period of 500 µs minimum.
+            // TODO: rework for new HW revision
+            instance->backlight_pwm = furi_hal_pwm_init(&gpio_display_ctrl, LED_BACKLIGHT_PWM_RESOLUTION, LED_BACKLIGHT_PWM_FREQ_HZ, false);
+            furi_hal_pwm_set_duty_cycle(instance->backlight_pwm, 140);
+            furi_delay_us(2400);
+        }
+        furi_hal_pwm_set_duty_cycle(instance->backlight_pwm, duty_cycle);
+    }
+}
 
 static bool led_line_is_wanna_power(uint32_t* line_buffer, size_t led_count) {
     furi_assert(line_buffer);
@@ -202,27 +257,46 @@ static const LedType leds_in_wattmeter_group[] = {
     LedTypeBatteryCenter,
 };
 
-static const LedType* leds_group[] = {
+static const LedType* leds_group[LedGroupMax] = {
     [LedGroupLink] = leds_in_link_group,
     [LedGroupPower] = leds_in_power_group,
     [LedGroupWattmeter] = leds_in_wattmeter_group,
+    [LedGroupDisplayBacklight] = NULL,
 };
 
-const size_t leds_in_group_count[] = {
+const size_t leds_in_group_count[LedGroupMax] = {
     [LedGroupLink] = COUNT_OF(leds_in_link_group),
     [LedGroupPower] = COUNT_OF(leds_in_power_group),
     [LedGroupWattmeter] = COUNT_OF(leds_in_wattmeter_group),
+    [LedGroupDisplayBacklight] = 0,
 };
 
 static void led_set_color(Led* instance, LedType type, LedColor color, uint8_t brightness) {
     instance->led_state.colors[type] = color;
 
     LedColor adjusted_color = {
-        ((float)color.r * brightness) / 255.0f * LED_BRIGHTNESS_MULTIPLIER,
-        ((float)color.g * brightness) / 255.0f * LED_BRIGHTNESS_MULTIPLIER,
-        ((float)color.b * brightness) / 255.0f * LED_BRIGHTNESS_MULTIPLIER,
+        ((float)color.r * brightness) / 255.0f * LED_RGB_BRIGHTNESS_MULTIPLIER,
+        ((float)color.g * brightness) / 255.0f * LED_RGB_BRIGHTNESS_MULTIPLIER,
+        ((float)color.b * brightness) / 255.0f * LED_RGB_BRIGHTNESS_MULTIPLIER,
     };
     instance->led_state.line[type] = ws2812_urgb_u32(adjusted_color.r, adjusted_color.g, adjusted_color.b);
+}
+
+static void led_backlight_enable(Led* instance, bool enable) {
+    uint8_t brightness = 0;
+    if(enable) {
+        furi_state_get(instance->led_state.brightness[LedGroupDisplayBacklight], &brightness);
+    }
+    led_backlight_brightness_transition(instance, brightness);
+}
+
+static void led_backlight_ping(Led* instance) {
+    led_backlight_enable(instance, true);
+    if(!instance->led_state.backlight_always_on) {
+        uint32_t backlight_time;
+        furi_state_get(instance->led_state.backlight_time, &backlight_time);
+        furi_event_loop_timer_start(instance->backlight_timer, backlight_time * 1000);
+    }
 }
 
 static void led_process_set_color_batch(Led* instance, LedItem* items, size_t count) {
@@ -266,24 +340,30 @@ static void led_process_set_color_batch(Led* instance, LedItem* items, size_t co
     led_update_lines(instance, update_line);
 }
 
-void led_process_set_brightness(Led* instance, LedGroup group, uint8_t brightness) {
+void led_process_set_brightness(Led* instance, LedGroup group, uint8_t brightness, bool save_to_nvm) {
     furi_assert(instance);
     furi_check(group < LedGroupMax);
+    furi_state_set(instance->led_state.brightness[group], &brightness);
 
-    const LedType* group_leds = leds_group[group];
-    size_t group_leds_count = leds_in_group_count[group];
-    LedUpdateLine update_line = 0;
+    if(group == LedGroupDisplayBacklight) {
+        led_backlight_ping(instance);
+    } else {
+        const LedType* group_leds = leds_group[group];
+        size_t group_leds_count = leds_in_group_count[group];
+        LedUpdateLine update_line = 0;
 
-    for(size_t i = 0; i < group_leds_count; i++) {
-        LedType type = group_leds[i];
-        led_set_color(instance, type, instance->led_state.colors[type], brightness);
-        update_line |= led_get_update_line_by_type(type);
+        for(size_t i = 0; i < group_leds_count; i++) {
+            LedType type = group_leds[i];
+            led_set_color(instance, type, instance->led_state.colors[type], brightness);
+            update_line |= led_get_update_line_by_type(type);
+        }
+
+        led_update_lines(instance, update_line);
     }
 
-    led_update_lines(instance, update_line);
-
-    furi_hal_nvm_set_uint32(led_group_names[group], brightness);
-    furi_state_set(instance->led_state.brightness[group], &brightness);
+    if(save_to_nvm) {
+        furi_hal_nvm_set_uint32(led_settings[group].name, brightness);
+    }
 }
 
 static void led_message_queue_callback(FuriEventLoopObject* object, void* context) {
@@ -312,7 +392,37 @@ static void led_message_queue_callback(FuriEventLoopObject* object, void* contex
         result = true;
         break;
     case LedMessageTypeSetBrightness:
-        led_process_set_brightness(instance, msg.set_brightness.group, msg.set_brightness.brightness);
+        led_process_set_brightness(instance, msg.set_brightness.group, msg.set_brightness.brightness, true);
+        result = true;
+        break;
+    case LedMessageTypeSetBacklightTime:
+        uint32_t timeout = msg.set_backlight_time.timeout_seconds;
+        furi_state_set(instance->led_state.backlight_time, &timeout);
+        furi_hal_nvm_set_uint32(SETTINGS_LED_BACKLIGHT_TIME, timeout);
+
+        furi_event_loop_timer_stop(instance->backlight_timer);
+        if(!instance->led_state.backlight_always_on) {
+            furi_event_loop_timer_start(instance->backlight_timer, timeout * 1000);
+        }
+        result = true;
+        break;
+    case LedMessageTypeBacklightControl:
+        if(msg.backlight_time_control.flags & LedBacklightTimeFlagPing) {
+            led_backlight_ping(instance);
+        }
+        if(msg.backlight_time_control.flags & LedBacklightTimeFlagAlwaysOn) {
+            instance->led_state.backlight_always_on = true;
+            led_backlight_enable(instance, true);
+        } else {
+            instance->led_state.backlight_always_on = false;
+            if((msg.backlight_time_control.flags & LedBacklightTimeFlagPing) == 0) {
+                led_backlight_enable(instance, false);
+            }
+        }
+        result = true;
+        break;
+    case LedMessageTypeBacklightInputToggle:
+        led_backlight_ping(instance);
         result = true;
         break;
 
@@ -338,6 +448,36 @@ static void led_send_message(Led* instance, const LedMessage* message) {
     }
 }
 
+static void led_backlight_timer_callback(void* context) {
+    furi_assert(context);
+    Led* instance = context;
+    if(!instance->led_state.backlight_always_on) {
+        led_backlight_enable(instance, false);
+    }
+}
+
+static void led_backlight_input_key_callback(const void* value, void* context) {
+    furi_assert(context);
+    Led* instance = context;
+
+    InputEvent* input_key_event = (InputEvent*)value;
+    if(input_key_event->type == InputTypePress) {
+        const LedMessage msg = {.type = LedMessageTypeBacklightInputToggle};
+        led_send_message(instance, &msg);
+    }
+}
+
+static void led_backlight_input_touch_callback(const void* value, void* context) {
+    furi_assert(context);
+    Led* instance = context;
+
+    InputTouchEvent* input_touch_event = (InputTouchEvent*)value;
+    if(input_touch_event->type == InputTouchTypeStart) {
+        const LedMessage msg = {.type = LedMessageTypeBacklightInputToggle};
+        led_send_message(instance, &msg);
+    }
+}
+
 static Led* led_alloc(void) {
     Led* instance = (Led*)malloc(sizeof(Led));
 
@@ -346,25 +486,38 @@ static Led* led_alloc(void) {
     instance->ws2812 = ws2812_init(ws2812_pins, LED_LINES_COUNT);
     instance->event_loop = furi_event_loop_alloc();
     instance->message_queue = furi_message_queue_alloc(LED_MAX_MESSAGES, sizeof(LedMessage));
+    instance->backlight_timer = furi_event_loop_timer_alloc(instance->event_loop, led_backlight_timer_callback, FuriEventLoopTimerTypeOnce, instance);
+
+    instance->led_state.backlight_time = furi_state_alloc(sizeof(uint32_t));
+    uint32_t backlight_time_value = 0;
+    if(furi_hal_nvm_get_uint32(SETTINGS_LED_BACKLIGHT_TIME, &backlight_time_value) != FuriHalNvmStorageOK) {
+        backlight_time_value = LED_BACKLIGHT_TIME_DEFAULT;
+        FURI_LOG_E(TAG, "Failed to read %s from NVM, defaulting to %lu", SETTINGS_LED_BACKLIGHT_TIME, backlight_time_value);
+        furi_hal_nvm_set_uint32(SETTINGS_LED_BACKLIGHT_TIME, backlight_time_value);
+    }
+    furi_state_set(instance->led_state.backlight_time, &backlight_time_value);
 
     for(size_t i = 0; i < LedGroupMax; i++) {
         instance->led_state.brightness[i] = furi_state_alloc(sizeof(uint8_t));
-        const char* state_name = led_group_names[i];
+        const char* state_name = led_settings[i].name;
 
-        uint32_t brightness_value;
+        uint32_t brightness_value = 0;
         if(furi_hal_nvm_get_uint32(state_name, &brightness_value) != FuriHalNvmStorageOK) {
-            FURI_LOG_E(TAG, "Failed to read %s from NVM, defaulting to 255", state_name);
-            brightness_value = 255;
+            brightness_value = led_settings[i].default_value;
+            FURI_LOG_E(TAG, "Failed to read %s from NVM, defaulting to %lu", state_name, brightness_value);
             furi_hal_nvm_set_uint32(state_name, brightness_value);
         }
 
         uint8_t brightness_state = (uint8_t)brightness_value;
-        furi_state_set(instance->led_state.brightness[i], &brightness_state);
+        led_process_set_brightness(instance, (LedGroup)i, brightness_state, false);
     }
 
     furi_event_loop_subscribe_message_queue(instance->event_loop, instance->message_queue, FuriEventLoopEventIn, led_message_queue_callback, instance);
 
     furi_record_create(RECORD_LEDS, instance);
+
+    furi_pubsub_subscribe(furi_record_open(RECORD_INPUT_EVENTS), led_backlight_input_key_callback, instance);
+    furi_pubsub_subscribe(furi_record_open(RECORD_INPUT_TOUCH_EVENTS), led_backlight_input_touch_callback, instance);
 
     return instance;
 }
@@ -383,13 +536,7 @@ void led_set_color_single(Led* instance, LedType type, LedColor color) {
 
     const LedMessage msg = {
         .type = LedMessageTypeSetColorSingle,
-
-        .set_color_single =
-            {
-                .type = type,
-                .color = color,
-            },
-
+        .set_color_single = {.type = type, .color = color},
     };
     led_send_message(instance, &msg);
 }
@@ -399,12 +546,7 @@ void led_set_color_batch(Led* instance, const LedBatch* items) {
 
     const LedMessage msg = {
         .type = LedMessageTypeSetColorBatch,
-
-        .set_color_batch =
-            {
-                .items = items,
-            },
-
+        .set_color_batch = {.items = items},
     };
     led_send_message(instance, &msg);
 }
@@ -414,28 +556,44 @@ void led_set_brightness(Led* instance, LedGroup group, uint8_t brightness) {
 
     const LedMessage msg = {
         .type = LedMessageTypeSetBrightness,
-
-        .set_brightness =
-            {
-                .group = group,
-                .brightness = brightness,
-            },
-
+        .set_brightness = {.group = group, .brightness = brightness},
     };
     led_send_message(instance, &msg);
 }
 
-FuriState* led_get_link_brightness_state(Led* instance) {
+bool led_backlight_set_time(Led* instance, uint32_t timeout_seconds) {
     furi_check(instance);
-    return instance->led_state.brightness[LedGroupLink];
+    if(timeout_seconds == 0) {
+        return false;
+    }
+
+    const LedMessage msg = {
+        .type = LedMessageTypeSetBacklightTime,
+        .set_backlight_time = {.timeout_seconds = timeout_seconds},
+    };
+    led_send_message(instance, &msg);
+    return true;
 }
 
-FuriState* led_get_power_brightness_state(Led* instance) {
+void led_backlight_timeout_control(Led* instance, bool ping, bool set_always_on) {
     furi_check(instance);
-    return instance->led_state.brightness[LedGroupPower];
+    const LedMessage msg = {
+        .type = LedMessageTypeBacklightControl,
+        .backlight_time_control =
+            {
+                .flags = (ping ? LedBacklightTimeFlagPing : 0) | (set_always_on ? LedBacklightTimeFlagAlwaysOn : 0),
+            },
+    };
+    led_send_message(instance, &msg);
 }
 
-FuriState* led_get_wattmeter_brightness_state(Led* instance) {
+FuriState* led_get_brightness_state(Led* instance, LedGroup group) {
     furi_check(instance);
-    return instance->led_state.brightness[LedGroupWattmeter];
+    furi_check(group < LedGroupMax);
+    return instance->led_state.brightness[group];
+}
+
+FuriState* led_get_backlight_time_state(Led* instance) {
+    furi_check(instance);
+    return instance->led_state.backlight_time;
 }

--- a/applications/services/led/led_backend.c
+++ b/applications/services/led/led_backend.c
@@ -397,7 +397,7 @@ static void led_message_queue_callback(FuriEventLoopObject* object, void* contex
         result = true;
         break;
     case LedMessageTypeSetBacklightTime:
-        uint32_t timeout = msg.set_backlight_time.timeout_seconds;
+        uint32_t timeout = msg.set_backlight_time.timeout_ms;
         furi_state_set(instance->led_state.backlight_time, &timeout);
         furi_hal_nvm_set_uint32(SETTINGS_LED_BACKLIGHT_TIME, timeout);
 

--- a/applications/services/led/led_backend.c
+++ b/applications/services/led/led_backend.c
@@ -30,6 +30,7 @@
 #define LED_BACKLIGHT_PWM_FREQ_HZ    40000 // 40kHz PWM for backlight
 
 #define LED_BACKLIGHT_TIME_DEFAULT 15
+#define LED_BACKLIGHT_TIME_MAX     ((UINT32_MAX - 1) / 1000)
 
 typedef struct {
     uint32_t line[LED_TOTAL_LEDS_COUNT];
@@ -264,7 +265,7 @@ static const LedType* leds_group[LedGroupMax] = {
     [LedGroupDisplayBacklight] = NULL,
 };
 
-const size_t leds_in_group_count[LedGroupMax] = {
+static const size_t leds_in_group_count[LedGroupMax] = {
     [LedGroupLink] = COUNT_OF(leds_in_link_group),
     [LedGroupPower] = COUNT_OF(leds_in_power_group),
     [LedGroupWattmeter] = COUNT_OF(leds_in_wattmeter_group),
@@ -340,7 +341,7 @@ static void led_process_set_color_batch(Led* instance, LedItem* items, size_t co
     led_update_lines(instance, update_line);
 }
 
-void led_process_set_brightness(Led* instance, LedGroup group, uint8_t brightness, bool save_to_nvm) {
+static void led_process_set_brightness(Led* instance, LedGroup group, uint8_t brightness, bool save_to_nvm) {
     furi_assert(instance);
     furi_check(group < LedGroupMax);
     furi_state_set(instance->led_state.brightness[group], &brightness);
@@ -490,7 +491,8 @@ static Led* led_alloc(void) {
 
     instance->led_state.backlight_time = furi_state_alloc(sizeof(uint32_t));
     uint32_t backlight_time_value = 0;
-    if(furi_hal_nvm_get_uint32(SETTINGS_LED_BACKLIGHT_TIME, &backlight_time_value) != FuriHalNvmStorageOK) {
+    FuriHalNvmStorage res = furi_hal_nvm_get_uint32(SETTINGS_LED_BACKLIGHT_TIME, &backlight_time_value);
+    if((res != FuriHalNvmStorageOK) || (backlight_time_value == 0) || (backlight_time_value > LED_BACKLIGHT_TIME_MAX)) {
         backlight_time_value = LED_BACKLIGHT_TIME_DEFAULT;
         FURI_LOG_E(TAG, "Failed to read %s from NVM, defaulting to %lu", SETTINGS_LED_BACKLIGHT_TIME, backlight_time_value);
         furi_hal_nvm_set_uint32(SETTINGS_LED_BACKLIGHT_TIME, backlight_time_value);
@@ -563,7 +565,7 @@ void led_set_brightness(Led* instance, LedGroup group, uint8_t brightness) {
 
 bool led_backlight_set_time(Led* instance, uint32_t timeout_seconds) {
     furi_check(instance);
-    if(timeout_seconds == 0) {
+    if((timeout_seconds == 0) || (timeout_seconds > LED_BACKLIGHT_TIME_MAX)) {
         return false;
     }
 

--- a/applications/services/led/led_backend.c
+++ b/applications/services/led/led_backend.c
@@ -29,8 +29,8 @@
 #define LED_BACKLIGHT_PWM_RESOLUTION 8 // 8-bit PWM for backlight
 #define LED_BACKLIGHT_PWM_FREQ_HZ    40000 // 40kHz PWM for backlight
 
-#define LED_BACKLIGHT_TIME_DEFAULT 15
-#define LED_BACKLIGHT_TIME_MAX     ((UINT16_MAX) * 100)
+#define LED_BACKLIGHT_TIME_DEFAULT (15 * 1000)
+#define LED_BACKLIGHT_TIME_MAX     ((UINT16_MAX) * 100) // I2C: 16-bit register with 100ms resolution
 
 typedef struct {
     uint32_t line[LED_TOTAL_LEDS_COUNT];
@@ -85,7 +85,7 @@ typedef struct {
         } set_brightness;
 
         struct {
-            uint32_t timeout_seconds;
+            uint32_t timeout_ms;
         } set_backlight_time;
 
         struct {
@@ -563,15 +563,15 @@ void led_set_brightness(Led* instance, LedGroup group, uint8_t brightness) {
     led_send_message(instance, &msg);
 }
 
-bool led_backlight_set_time(Led* instance, uint32_t timeout_seconds) {
+bool led_backlight_set_time(Led* instance, uint32_t timeout_ms) {
     furi_check(instance);
-    if((timeout_seconds == 0) || (timeout_seconds > LED_BACKLIGHT_TIME_MAX)) {
+    if((timeout_ms == 0) || (timeout_ms > LED_BACKLIGHT_TIME_MAX)) {
         return false;
     }
 
     const LedMessage msg = {
         .type = LedMessageTypeSetBacklightTime,
-        .set_backlight_time = {.timeout_seconds = timeout_seconds},
+        .set_backlight_time = {.timeout_ms = timeout_ms},
     };
     led_send_message(instance, &msg);
     return true;

--- a/applications/services/led/led_backend.c
+++ b/applications/services/led/led_backend.c
@@ -30,7 +30,7 @@
 #define LED_BACKLIGHT_PWM_FREQ_HZ    40000 // 40kHz PWM for backlight
 
 #define LED_BACKLIGHT_TIME_DEFAULT 15
-#define LED_BACKLIGHT_TIME_MAX     ((UINT32_MAX - 1) / 1000)
+#define LED_BACKLIGHT_TIME_MAX     ((UINT16_MAX) * 100)
 
 typedef struct {
     uint32_t line[LED_TOTAL_LEDS_COUNT];
@@ -296,7 +296,7 @@ static void led_backlight_ping(Led* instance) {
     if(!instance->led_state.backlight_always_on) {
         uint32_t backlight_time;
         furi_state_get(instance->led_state.backlight_time, &backlight_time);
-        furi_event_loop_timer_start(instance->backlight_timer, backlight_time * 1000);
+        furi_event_loop_timer_start(instance->backlight_timer, backlight_time);
     }
 }
 
@@ -403,14 +403,11 @@ static void led_message_queue_callback(FuriEventLoopObject* object, void* contex
 
         furi_event_loop_timer_stop(instance->backlight_timer);
         if(!instance->led_state.backlight_always_on) {
-            furi_event_loop_timer_start(instance->backlight_timer, timeout * 1000);
+            furi_event_loop_timer_start(instance->backlight_timer, timeout);
         }
         result = true;
         break;
     case LedMessageTypeBacklightControl:
-        if(msg.backlight_time_control.flags & LedBacklightTimeFlagPing) {
-            led_backlight_ping(instance);
-        }
         if(msg.backlight_time_control.flags & LedBacklightTimeFlagAlwaysOn) {
             instance->led_state.backlight_always_on = true;
             led_backlight_enable(instance, true);
@@ -419,6 +416,9 @@ static void led_message_queue_callback(FuriEventLoopObject* object, void* contex
             if((msg.backlight_time_control.flags & LedBacklightTimeFlagPing) == 0) {
                 led_backlight_enable(instance, false);
             }
+        }
+        if(msg.backlight_time_control.flags & LedBacklightTimeFlagPing) {
+            led_backlight_ping(instance);
         }
         result = true;
         break;

--- a/applications/services/power_menu/power_menu.c
+++ b/applications/services/power_menu/power_menu.c
@@ -53,6 +53,7 @@ typedef enum {
     PowerMenuActionPowerLedBrightness,
     PowerMenuActionWattmeterLedBrightness,
     PowerMenuActionBacklight,
+    PowerMenuActionBacklightTime,
     PowerMenuActionPowerOff,
     PowerMenuActionReboot,
     PowerMenuActionCancel,
@@ -64,6 +65,7 @@ static const char* power_menu_items[] = {
     [PowerMenuActionPowerLedBrightness] = "Pwr Led",
     [PowerMenuActionWattmeterLedBrightness] = "Wtm Led",
     [PowerMenuActionBacklight] = "Backlight",
+    [PowerMenuActionBacklightTime] = "BL Time",
     [PowerMenuActionPowerOff] = "Power Off",
     [PowerMenuActionReboot] = "Reboot",
     [PowerMenuActionCancel] = "Cancel",
@@ -105,6 +107,7 @@ typedef struct {
     bool visible;
     size_t selected_index;
     FuriString* backlight_text;
+    FuriString* backlight_time_text;
     FuriString* link_led_brightness_text;
     FuriString* power_led_brightness_text;
     FuriString* wattmeter_led_brightness_text;
@@ -120,6 +123,7 @@ typedef struct {
     FuriEventLoop* event_loop;
     size_t selected_led_batch_index;
     size_t selected_backlight_brightness_index;
+    size_t selected_backlight_time_index;
     size_t selected_link_led_brightness_index;
     size_t selected_power_led_brightness_index;
     size_t selected_wattmeter_led_brightness_index;
@@ -141,40 +145,20 @@ static const char* led_batch_names[] = {
     " On",
     " White",
 };
-
 static_assert(COUNT_OF(items) == COUNT_OF(led_batch_names), "items and led_batch_names count mismatch");
 
 static const size_t led_batch_count = COUNT_OF(items);
 
-static const uint8_t brightness_levels[] = {
-    0,
-    2,
-    5,
-    20,
-    50,
-    75,
-    100,
-};
-
-static const size_t brightness_levels_count = COUNT_OF(brightness_levels);
-
-static const uint8_t led_brightness_levels[] = {
-    0,
-    5,
-    13,
-    26,
-    52,
-    128,
-    192,
-    255,
-};
-
+static const uint8_t led_brightness_levels[] = {0, 5, 13, 26, 52, 128, 192, 255};
 static const size_t led_brightness_levels_count = COUNT_OF(led_brightness_levels);
 
-static size_t led_brightness_get_nearest_index(uint8_t value) {
+static const uint8_t backlight_time_values[] = {1, 5, 10, 15, 30, 60, 90, 120};
+static const size_t backlight_time_values_count = COUNT_OF(backlight_time_values);
+
+static size_t get_nearest_index(uint8_t value, const uint8_t* array, size_t array_size) {
     size_t nearest_index = 0;
-    for(size_t i = 1; i < led_brightness_levels_count; i++) {
-        if(abs((int)led_brightness_levels[i] - value) < abs((int)led_brightness_levels[nearest_index] - value)) {
+    for(size_t i = 1; i < array_size; i++) {
+        if(abs((int)array[i] - value) < abs((int)array[nearest_index] - value)) {
             nearest_index = i;
         }
     }
@@ -303,6 +287,11 @@ static bool power_menu_layout(void* _model) {
                             clay_helper_string_from(model->backlight_text),
                             CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = selected ? COLOR_WHITE : COLOR_BLACK}));
                         break;
+                    case PowerMenuActionBacklightTime:
+                        CLAY_TEXT(
+                            clay_helper_string_from(model->backlight_time_text),
+                            CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = selected ? COLOR_WHITE : COLOR_BLACK}));
+                        break;
                     default:
                         break;
                     }
@@ -333,6 +322,7 @@ static bool power_menu_post_layout(void* _model) {
 
 static bool power_menu_model_init(PowerMenuModel* model, void* context) {
     model->backlight_text = furi_string_alloc();
+    model->backlight_time_text = furi_string_alloc();
     model->link_led_brightness_text = furi_string_alloc();
     model->power_led_brightness_text = furi_string_alloc();
     model->wattmeter_led_brightness_text = furi_string_alloc();
@@ -374,7 +364,13 @@ static bool power_menu_remove_item(PowerMenuModel* model, const char* text) {
 
 static bool power_menu_model_set_backlight_text(PowerMenuModel* model, void* context) {
     uint8_t* brightness = context;
-    furi_string_printf(model->backlight_text, " %d%%", *brightness);
+    furi_string_printf(model->backlight_text, " %d%%", (uint8_t)(*brightness / (255.0f / 100.0f)));
+    return true;
+}
+
+static bool power_menu_model_set_backlight_time_text(PowerMenuModel* model, void* context) {
+    uint32_t* time = context;
+    furi_string_printf(model->backlight_time_text, " %ld s", *time);
     return true;
 }
 
@@ -448,12 +444,6 @@ static void power_menu_model_apply(PowerMenu* instance, bool (*callback)(PowerMe
     with_view_model(instance->view, PowerMenuModel * model, { update = callback(model, context); }, update);
 }
 
-static void power_menu_apply_backlight(PowerMenu* instance) {
-    uint8_t brightness = brightness_levels[instance->selected_backlight_brightness_index];
-    gui_set_backlight(instance->gui, brightness);
-    power_menu_model_apply(instance, power_menu_model_set_backlight_text, &brightness);
-}
-
 #define POWER_MENU_PREV(var, min) (var = (var - 1 + min) % min)
 
 static void power_menu_input_left(PowerMenu* instance, int selected_index) {
@@ -474,8 +464,14 @@ static void power_menu_input_left(PowerMenu* instance, int selected_index) {
         led_set_brightness(instance->led, LedGroupWattmeter, wattmeter_brightness);
         break;
     case PowerMenuActionBacklight:
-        POWER_MENU_PREV(instance->selected_backlight_brightness_index, brightness_levels_count);
-        power_menu_apply_backlight(instance);
+        POWER_MENU_PREV(instance->selected_backlight_brightness_index, led_brightness_levels_count);
+        uint8_t brightness = led_brightness_levels[instance->selected_backlight_brightness_index];
+        led_set_brightness(instance->led, LedGroupDisplayBacklight, brightness);
+        break;
+    case PowerMenuActionBacklightTime:
+        POWER_MENU_PREV(instance->selected_backlight_time_index, backlight_time_values_count);
+        uint8_t backlight_time = backlight_time_values[instance->selected_backlight_time_index];
+        led_backlight_set_time(instance->led, backlight_time);
         break;
     case PowerMenuActionLeds:
         POWER_MENU_PREV(instance->selected_led_batch_index, led_batch_count);
@@ -507,8 +503,14 @@ static void power_menu_input_right(PowerMenu* instance, int selected_index) {
         led_set_brightness(instance->led, LedGroupWattmeter, wattmeter_brightness);
         break;
     case PowerMenuActionBacklight:
-        POWER_MENU_NEXT(instance->selected_backlight_brightness_index, brightness_levels_count);
-        power_menu_apply_backlight(instance);
+        POWER_MENU_NEXT(instance->selected_backlight_brightness_index, led_brightness_levels_count);
+        uint8_t brightness = led_brightness_levels[instance->selected_backlight_brightness_index];
+        led_set_brightness(instance->led, LedGroupDisplayBacklight, brightness);
+        break;
+    case PowerMenuActionBacklightTime:
+        POWER_MENU_NEXT(instance->selected_backlight_time_index, backlight_time_values_count);
+        uint8_t backlight_time = backlight_time_values[instance->selected_backlight_time_index];
+        led_backlight_set_time(instance->led, backlight_time);
         break;
     case PowerMenuActionLeds:
         POWER_MENU_NEXT(instance->selected_led_batch_index, led_batch_count);
@@ -578,7 +580,7 @@ static void power_menu_cpu_app_start_callback(bool pressed, void* context) {
     if(pressed) {
         instance->app_running = true;
         desktop_start_app(&app[PowerMenuCpuAppStart]);
-       // power_menu_remove_app_menu_items(instance);
+        // power_menu_remove_app_menu_items(instance);
     }
 }
 
@@ -647,7 +649,7 @@ static bool power_menu_input(InputEvent* event, void* context) {
 static void power_menu_link_led_brightness_callback(const void* item, void* context) {
     uint8_t* brightness = (uint8_t*)item;
     PowerMenu* instance = context;
-    instance->selected_link_led_brightness_index = led_brightness_get_nearest_index(*brightness);
+    instance->selected_link_led_brightness_index = get_nearest_index(*brightness, led_brightness_levels, led_brightness_levels_count);
     *brightness = led_brightness_levels[instance->selected_link_led_brightness_index];
     power_menu_model_apply(instance, power_menu_model_set_link_led_brightness_text, brightness);
 }
@@ -655,7 +657,7 @@ static void power_menu_link_led_brightness_callback(const void* item, void* cont
 static void power_menu_power_led_brightness_callback(const void* item, void* context) {
     uint8_t* brightness = (uint8_t*)item;
     PowerMenu* instance = context;
-    instance->selected_power_led_brightness_index = led_brightness_get_nearest_index(*brightness);
+    instance->selected_power_led_brightness_index = get_nearest_index(*brightness, led_brightness_levels, led_brightness_levels_count);
     *brightness = led_brightness_levels[instance->selected_power_led_brightness_index];
     power_menu_model_apply(instance, power_menu_model_set_power_led_brightness_text, brightness);
 }
@@ -663,9 +665,26 @@ static void power_menu_power_led_brightness_callback(const void* item, void* con
 static void power_menu_wattmeter_led_brightness_callback(const void* item, void* context) {
     uint8_t* brightness = (uint8_t*)item;
     PowerMenu* instance = context;
-    instance->selected_wattmeter_led_brightness_index = led_brightness_get_nearest_index(*brightness);
+    instance->selected_wattmeter_led_brightness_index = get_nearest_index(*brightness, led_brightness_levels, led_brightness_levels_count);
     *brightness = led_brightness_levels[instance->selected_wattmeter_led_brightness_index];
     power_menu_model_apply(instance, power_menu_model_set_wattmeter_led_brightness_text, brightness);
+}
+
+static void power_menu_display_backlight_brightness_callback(const void* item, void* context) {
+    uint8_t* brightness = (uint8_t*)item;
+    PowerMenu* instance = context;
+    instance->selected_backlight_brightness_index = get_nearest_index(*brightness, led_brightness_levels, led_brightness_levels_count);
+    *brightness = led_brightness_levels[instance->selected_backlight_brightness_index];
+    power_menu_model_apply(instance, power_menu_model_set_backlight_text, brightness);
+}
+
+static void power_menu_display_backlight_time_callback(const void* item, void* context) {
+    uint32_t* time = (uint32_t*)item;
+    uint8_t time_temp = *time > 255 ? 255 : (uint8_t)*time; // FIXME:
+    PowerMenu* instance = context;
+    instance->selected_backlight_time_index = get_nearest_index(time_temp, backlight_time_values, backlight_time_values_count);
+    *time = backlight_time_values[instance->selected_backlight_time_index];
+    power_menu_model_apply(instance, power_menu_model_set_backlight_time_text, time);
 }
 
 static void power_menu_message_queue_callback(FuriEventLoopObject* object, void* context) {
@@ -716,12 +735,13 @@ static PowerMenu* power_menu_alloc(void) {
     view_set_post_layout_callback(instance->view, power_menu_post_layout);
     view_set_input_callback(instance->view, power_menu_input, instance);
     gui_add_view(instance->gui, instance->view, GuiViewPriorityMenu);
-    instance->selected_backlight_brightness_index = 3; // 20%
-    power_menu_apply_backlight(instance);
 
-    furi_state_subscribe(led_get_link_brightness_state(instance->led), power_menu_link_led_brightness_callback, instance);
-    furi_state_subscribe(led_get_power_brightness_state(instance->led), power_menu_power_led_brightness_callback, instance);
-    furi_state_subscribe(led_get_wattmeter_brightness_state(instance->led), power_menu_wattmeter_led_brightness_callback, instance);
+    furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupLink), power_menu_link_led_brightness_callback, instance);
+    furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupPower), power_menu_power_led_brightness_callback, instance);
+    furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupWattmeter), power_menu_wattmeter_led_brightness_callback, instance);
+    furi_state_subscribe(led_get_brightness_state(instance->led, LedGroupDisplayBacklight), power_menu_display_backlight_brightness_callback, instance);
+    furi_state_subscribe(led_get_backlight_time_state(instance->led), power_menu_display_backlight_time_callback, instance);
+
     furi_event_loop_subscribe_message_queue(instance->event_loop, instance->message_queue, FuriEventLoopEventIn, power_menu_message_queue_callback, instance);
 
     furi_record_create(RECORD_POWER_MENU, instance);

--- a/applications/services/power_menu/power_menu.c
+++ b/applications/services/power_menu/power_menu.c
@@ -471,7 +471,7 @@ static void power_menu_input_left(PowerMenu* instance, int selected_index) {
     case PowerMenuActionBacklightTime:
         POWER_MENU_PREV(instance->selected_backlight_time_index, backlight_time_values_count);
         uint8_t backlight_time = backlight_time_values[instance->selected_backlight_time_index];
-        led_backlight_set_time(instance->led, backlight_time);
+        led_backlight_set_time(instance->led, backlight_time * 1000);
         break;
     case PowerMenuActionLeds:
         POWER_MENU_PREV(instance->selected_led_batch_index, led_batch_count);
@@ -510,7 +510,7 @@ static void power_menu_input_right(PowerMenu* instance, int selected_index) {
     case PowerMenuActionBacklightTime:
         POWER_MENU_NEXT(instance->selected_backlight_time_index, backlight_time_values_count);
         uint8_t backlight_time = backlight_time_values[instance->selected_backlight_time_index];
-        led_backlight_set_time(instance->led, backlight_time);
+        led_backlight_set_time(instance->led, backlight_time * 1000);
         break;
     case PowerMenuActionLeds:
         POWER_MENU_NEXT(instance->selected_led_batch_index, led_batch_count);
@@ -679,12 +679,12 @@ static void power_menu_display_backlight_brightness_callback(const void* item, v
 }
 
 static void power_menu_display_backlight_time_callback(const void* item, void* context) {
-    uint32_t* time = (uint32_t*)item;
-    uint8_t time_temp = *time > 255 ? 255 : (uint8_t)*time; // FIXME:
+    uint32_t time = *(uint32_t*)item / 1000;
+    uint8_t time_temp = time > 255 ? 255 : (uint8_t)time; // FIXME:
     PowerMenu* instance = context;
     instance->selected_backlight_time_index = get_nearest_index(time_temp, backlight_time_values, backlight_time_values_count);
-    *time = backlight_time_values[instance->selected_backlight_time_index];
-    power_menu_model_apply(instance, power_menu_model_set_backlight_time_text, time);
+    time = backlight_time_values[instance->selected_backlight_time_index];
+    power_menu_model_apply(instance, power_menu_model_set_backlight_time_text, &time);
 }
 
 static void power_menu_message_queue_callback(FuriEventLoopObject* object, void* context) {

--- a/applications/services/power_menu/power_menu.c
+++ b/applications/services/power_menu/power_menu.c
@@ -370,7 +370,7 @@ static bool power_menu_model_set_backlight_text(PowerMenuModel* model, void* con
 
 static bool power_menu_model_set_backlight_time_text(PowerMenuModel* model, void* context) {
     uint32_t* time = context;
-    furi_string_printf(model->backlight_time_text, " %ld s", *time);
+    furi_string_printf(model->backlight_time_text, " %lu s", *time);
     return true;
 }
 

--- a/applications/services/settings/settings.h
+++ b/applications/services/settings/settings.h
@@ -7,6 +7,8 @@ extern "C" {
 #define SETTINGS_LED_GROUP_LINK      "LedGroupLinkBrightness"
 #define SETTINGS_LED_GROUP_POWER     "LedGroupPowerBrightness"
 #define SETTINGS_LED_GROUP_WATTMETER "LedGroupWattmeterBrightness"
+#define SETTINGS_LED_BACKLIGHT       "LedBacklightBrightness"
+#define SETTINGS_LED_BACKLIGHT_TIME  "LedBacklightTime"
 
 #define SETTINGS_HAPTIC_CALIB_DATA "HapticCalibrationData"
 

--- a/lib/drivers/display/display_jd9853_qspi.c
+++ b/lib/drivers/display/display_jd9853_qspi.c
@@ -3,7 +3,6 @@
 
 #include <furi_hal_gpio.h>
 #include <furi_hal_resources.h>
-#include <furi_hal_pwm.h>
 #include <drivers/tps62868x/tps62868x.h>
 #include <furi_hal_i2c_config.h>
 
@@ -19,8 +18,6 @@
 
 #define FIRST_HSTX_PIN                             12
 #define DISPLAY_JD9853_HSTX_END_TX_DELAY_US        5 //5us
-#define DISPLAY_JD9853_BACKLIGHT_BIT               8 //8-bit PWM for backlight
-#define DISPLAY_JD9853_BACKLIGHT_FREQ_HZ           40000 //25kHz PWM for backlight
 #define DISPLAY_JD9853_CONNECTION_CHECK_TIMEOUT_MS 1000
 
 typedef struct {
@@ -31,9 +28,7 @@ typedef struct {
 struct DisplayJd9853QSPI {
     FuriSemaphore* busy;
     uint32_t dma_tx_channel;
-    FuriHalPwm* backlight_pwm;
     Tps62868x* power_supply;
-    uint8_t backlight;
     DisplayJd9853QSPIBufferHeader buffer_header;
     bool display_is_connected;
 };
@@ -231,41 +226,6 @@ void display_jd9853_qspi_on_sleep_exit(void) {
     display_jd9853_hstx_clock_init();
 }
 
-void display_jd9853_qspi_set_brightness(DisplayJd9853QSPI* display, int8_t brightness) {
-    furi_check(display);
-    if(brightness > 100) brightness = 100;
-    if(brightness < 0) brightness = 0;
-    display->backlight = (uint8_t)brightness;
-    if(!display->backlight) {
-        if(display->backlight_pwm) {
-            furi_hal_pwm_set_duty_cycle(display->backlight_pwm, 0);
-            furi_hal_pwm_deinit(display->backlight_pwm);
-            display->backlight_pwm = NULL;
-        }
-    } else {
-        uint32_t max_value = (1 << DISPLAY_JD9853_BACKLIGHT_BIT) - 1;
-        uint32_t duty_cycle = (brightness * max_value) / 100;
-        if(!display->backlight_pwm) {
-            //To enable the device, the CTRL signal must be high for 500 µs.
-            // The PWM signal can then be applied with a pulse width (tp)
-            // greater or smaller than tON. To force the device into shutdown mode,
-            // the CTRL signal must be low for at least 32 ms.
-            // Requiring the CTRL pin to be low for 32 mS before the device enters
-            // shutdown allows for PWM dimming frequencies as low as 100 Hz.
-            // The device is enabled again when a CTRL signal is high for a period of 500 µs minimum.
-            display->backlight_pwm = furi_hal_pwm_init(&gpio_display_ctrl, DISPLAY_JD9853_BACKLIGHT_BIT, DISPLAY_JD9853_BACKLIGHT_FREQ_HZ, false);
-            furi_hal_pwm_set_duty_cycle(display->backlight_pwm, 140);
-            furi_delay_us(2400);
-        }
-        furi_hal_pwm_set_duty_cycle(display->backlight_pwm, duty_cycle);
-    }
-}
-
-int8_t display_jd9853_qspi_get_brightness(DisplayJd9853QSPI* display) {
-    furi_check(display);
-    return (int8_t)display->backlight;
-}
-
 bool display_jd9853_qspi_check_connection(DisplayJd9853QSPI* display, uint32_t timeout_ms) {
     furi_check(display);
     int64_t start_time = furi_get_tick();
@@ -284,7 +244,6 @@ DisplayJd9853QSPI* display_jd9853_qspi_init(void) {
     DisplayJd9853QSPI* display = malloc(sizeof(DisplayJd9853QSPI));
     display_instance = display;
     display->busy = furi_semaphore_alloc(1, 1);
-    display->backlight = 0;
 
     display->buffer_header.cmd[0] = JD9853_QSPI_CMD_4_LINE_MODE;
     display->buffer_header.cmd[1] = 0;
@@ -346,9 +305,8 @@ DisplayJd9853QSPI* display_jd9853_qspi_init(void) {
         FURI_LOG_E(TAG, "Display not connected");
     }
 
-    display_jd9853_qspi_fill(display, 0); // Fill black
-
-    display_jd9853_qspi_set_brightness(display, 2); // Set backlight to 2%
+    display_jd9853_qspi_fill(display, 0xFF); // Fill white
+    // TODO: fill white before display enable
 
     return display;
 }

--- a/lib/drivers/display/display_jd9853_qspi.h
+++ b/lib/drivers/display/display_jd9853_qspi.h
@@ -14,8 +14,6 @@ void display_jd9853_qspi_deinit(DisplayJd9853QSPI* display);
 void display_jd9853_load_config(DisplayJd9853QSPI* display, const uint8_t* config);
 void display_jd9853_qspi_on_sleep_enter(void);
 void display_jd9853_qspi_on_sleep_exit(void);
-void display_jd9853_qspi_set_brightness(DisplayJd9853QSPI* display, int8_t brightness);
-int8_t display_jd9853_qspi_get_brightness(DisplayJd9853QSPI* display);
 void display_jd9853_qspi_write_buffer(DisplayJd9853QSPI* display, const uint8_t* buffer, size_t size);
 void display_jd9853_qspi_fill(DisplayJd9853QSPI* display, uint8_t color);
 void display_jd9853_qspi_eco_mode(DisplayJd9853QSPI* display, bool enable);


### PR DESCRIPTION
# What's new

- All backlight-related moved to LED service
- Configurable backlight timeout, turning back on with a key/touchpad press
- Storing backlight settings to NVM
- I2C API to control brightness, time and timeout override

# Verification 

- Check backlight config options in power menu

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
