### PR TITLE
Issue 185 dmesg log history

### DIFF
--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -11,6 +11,8 @@
 #include "cli_uart.h"
 
 static void cli_commands_init(CliRegistry* registry) {
+    cli_log_history_init();
+    cli_registry_add_command(registry, "dmesg", CliCommandFlagParallelSafe, cli_command_dmesg, NULL);
     cli_registry_add_command(registry, "uptime", CliCommandFlagParallelSafe, cli_command_uptime, NULL);
     cli_registry_add_command(registry, "log", CliCommandFlagParallelSafe, cli_command_log, NULL);
     cli_registry_add_command(registry, "top", CliCommandFlagParallelSafe, cli_command_top, NULL);

--- a/applications/services/cli/cli_commands_common.c
+++ b/applications/services/cli/cli_commands_common.c
@@ -10,6 +10,12 @@
 #include <furi_hal_clock.h>
 #include <furi_hal_otp.h>
 
+#define CLI_LOG_HISTORY_CAPACITY 4096
+
+static uint8_t cli_log_history_buffer[CLI_LOG_HISTORY_CAPACITY];
+static size_t cli_log_history_write_index = 0;
+static size_t cli_log_history_size = 0;
+
 void cli_command_uptime(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(pipe);
     UNUSED(args);
@@ -22,6 +28,46 @@ static void cli_command_log_tx_callback(const uint8_t* buffer, size_t size, void
     PipeSide* pipe = context;
     pipe_send(pipe, buffer, size);
 }
+
+static void cli_log_history_tx_callback(const uint8_t* buffer, size_t size, void* context){
+    UNUSED(context);
+
+    for(size_t i = 0; i < size; ++i){
+        cli_log_history_buffer[cli_log_history_write_index] = buffer[i];
+
+        cli_log_history_write_index = 
+            (cli_log_history_write_index + 1) % CLI_LOG_HISTORY_CAPACITY;
+        
+            if(cli_log_history_size < CLI_LOG_HISTORY_CAPACITY){
+                ++cli_log_history_size;
+            }
+    }
+}
+
+void cli_log_history_init(void) {
+    FuriLogHandler log_handler = {
+        .callback = cli_log_history_tx_callback,
+        .context = NULL,
+    };
+
+    furi_log_add_handler(log_handler);
+}
+
+void cli_command_dmesg(PipeSide* pipe, FuriString* args, void* context) {
+    UNUSED(args);
+    UNUSED(context);
+
+    size_t read_index = 
+        (cli_log_history_write_index + CLI_LOG_HISTORY_CAPACITY - cli_log_history_size) %
+        CLI_LOG_HISTORY_CAPACITY;
+    
+    for(size_t i = 0; i < CLI_LOG_HISTORY_CAPACITY; ++i){
+        pipe_send(pipe, &cli_log_history_buffer[read_index], 1);
+        read_index = (read_index + 1) % CLI_LOG_HISTORY_CAPACITY;
+    }
+
+}
+
 
 static bool cli_command_log_level_set_from_string(FuriString* level) {
     FuriLogLevel log_level;

--- a/applications/services/cli/cli_commands_common.c
+++ b/applications/services/cli/cli_commands_common.c
@@ -32,6 +32,7 @@ static void cli_command_log_tx_callback(const uint8_t* buffer, size_t size, void
 static void cli_log_history_tx_callback(const uint8_t* buffer, size_t size, void* context){
     UNUSED(context);
 
+    FURI_CRITICAL_ENTER();
     for(size_t i = 0; i < size; ++i){
         cli_log_history_buffer[cli_log_history_write_index] = buffer[i];
 
@@ -42,6 +43,7 @@ static void cli_log_history_tx_callback(const uint8_t* buffer, size_t size, void
                 ++cli_log_history_size;
             }
     }
+    FURI_CRITICAL_EXIT();
 }
 
 void cli_log_history_init(void) {
@@ -56,14 +58,23 @@ void cli_log_history_init(void) {
 void cli_command_dmesg(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(args);
     UNUSED(context);
+    static uint8_t cli_log_history_snapshot[CLI_LOG_HISTORY_CAPACITY];
+    size_t snapshot_size = 0;
 
-    size_t read_index = 
+    FURI_CRITICAL_ENTER();
+    size_t read_index =
         (cli_log_history_write_index + CLI_LOG_HISTORY_CAPACITY - cli_log_history_size) %
         CLI_LOG_HISTORY_CAPACITY;
-    
-    for(size_t i = 0; i < CLI_LOG_HISTORY_CAPACITY; ++i){
-        pipe_send(pipe, &cli_log_history_buffer[read_index], 1);
+
+    snapshot_size = cli_log_history_size;
+    for(size_t i = 0; i < snapshot_size; ++i) {
+        cli_log_history_snapshot[i] = cli_log_history_buffer[read_index];
         read_index = (read_index + 1) % CLI_LOG_HISTORY_CAPACITY;
+    }
+    FURI_CRITICAL_EXIT();
+
+    for(size_t i = 0; i < snapshot_size; ++i) {
+        pipe_send(pipe, &cli_log_history_snapshot[i], 1);
     }
 
 }

--- a/applications/services/cli/cli_commands_common.h
+++ b/applications/services/cli/cli_commands_common.h
@@ -11,3 +11,5 @@ void cli_command_i2c(PipeSide* pipe, FuriString* args, void* context);
 void cli_command_expander_ext(PipeSide* pipe, FuriString* args, void* context);
 void cli_command_clock_out(PipeSide* pipe, FuriString* args, void* context);
 void cli_command_otp(PipeSide* pipe, FuriString* args, void* context);
+void cli_command_dmesg(PipeSide* pipe, FuriString* args, void* context);
+void cli_log_history_init(void);


### PR DESCRIPTION
# What's new

- Store recent log output,  then let the user run dmesg to dump it

# Verification 

- I just ran the firmware build again and saw : "ninja: no work to do."

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
