### PR TITLE
Power: fix BQ28Z620 CLI timing output order

### DIFF
--- a/applications/services/power/power_cli.c
+++ b/applications/services/power/power_cli.c
@@ -224,10 +224,10 @@ static void power_cli_print_bq28z620(Power* power) {
         charging_current_ma,
         design_capacity_mah,
         time_to_empty_min,
+        average_time_to_empty_min,
         average_time_to_full_min,
         standby_current_ma,
         standby_time_to_empty_min,
-        average_time_to_empty_min,
         max_load_current_ma,
         max_load_time_to_empty_min);
     // clang-format on


### PR DESCRIPTION
## What changed

Fix the BQ28Z620 power CLI `printf` argument order so the following labels display the correct values:

- AvgTimeToEmpty
- TimeToFull
- StandbyCurr
- StandbyTimeToEmpty

No functional behavior is changed; this only corrects the CLI output mapping.

## Verification

- Ran `git diff --check`
- Built the firmware successfully using the existing configured build directory