### PR TITLE
Info: fix property_value_out argument mismatches in the dotted branch

### DIFF
--- a/targets/f100/furi_hal/furi_hal_info.c
+++ b/targets/f100/furi_hal/furi_hal_info.c
@@ -36,8 +36,8 @@ void furi_hal_info_get(PropertyValueCallback out, char sep, void* context) {
     const Version* firmware_version = version_get();
     if(firmware_version) {
         if(sep == '.') {
-            property_value_out(&property_context, NULL, 4, FURI_HAL_MCU_INFO_NAME "firmware", "commit", "hash", version_get_githash(firmware_version));
-            property_value_out(&property_context, NULL, 5, FURI_HAL_MCU_INFO_NAME, "firmware", "branch", "name", version_get_gitbranch(firmware_version));
+            property_value_out(&property_context, NULL, 4, FURI_HAL_MCU_INFO_NAME, "firmware", "commit", "hash", version_get_githash(firmware_version));
+            property_value_out(&property_context, NULL, 4, FURI_HAL_MCU_INFO_NAME, "firmware", "branch", "name", version_get_gitbranch(firmware_version));
         } else {
             property_value_out(&property_context, NULL, 3, FURI_HAL_MCU_INFO_NAME, "firmware", "commit", version_get_githash(firmware_version));
             property_value_out(&property_context, NULL, 3, FURI_HAL_MCU_INFO_NAME, "firmware", "branch", version_get_gitbranch(firmware_version));


### PR DESCRIPTION
# What's new

Two calls in the `sep == '.'` branch of `furi_hal_info_get()` don't line up with what `property_value_out()` expects. The function reads `nparts` key parts off the va_list, then (with `fmt == NULL`) one more argument as the value, so a call needs `nparts + 1` variadic arguments:

- The commit line is missing the comma after `FURI_HAL_MCU_INFO_NAME`, so the preprocessor merges `"rp2350" "firmware"` into the single literal `"rp2350firmware"`. That leaves 4 arguments for `nparts=4` plus a value: the git hash gets eaten as the last key part and the value read runs off the end of the argument list.
- The branch line passes `nparts=5` with exactly 5 arguments, so the branch name gets eaten as a key part and the value read again runs off the end.

Both off-the-end reads are undefined behavior; in practice the out callback receives a wild pointer as `value`. This PR adds the missing comma and sets `nparts` to 4 on both lines, giving the `commit.hash` / `branch.name` leaf keys. The 4-part shape is the right one for dotted output: `commit` can't be both a string and the parent of `commit.dirty`, which is why these two lines push the value down a level while the `'_'` branch keeps 3 parts.

The `'_'` branch that `device_info` uses today is unaffected, so nothing changes on device right now. This bites the first caller that asks for dotted output, and it sits in a public HAL entry point, so better to kill it while the code is a day old.

# Verification

- Wrote a small host program that compiles the real `lib/toolbox/property.c` against a stubbed `FuriString` and runs both call shapes, as they are on `dev` and as fixed, under ASan/UBSan. On `dev`, the commit line yields the key `rp2350firmware.commit.hash.abc12345` with garbage as the value, and the branch line yields `rp2350.firmware.branch.name.feat/some-branch` and then segfaults dereferencing the value pointer. With this patch: `rp2350.firmware.commit.hash` = `abc12345` and `rp2350.firmware.branch.name` = `feat/some-branch`.
- Full firmware build with the CI toolchain (arm-none-eabi-gcc 14.2.1, pico-sdk 2.2.0, cmake Release) succeeds with no new warnings and produces the uf2.
- Not tested on hardware. The dotted branch isn't reachable from the current CLI (`device_info` hardcodes `'_'`), so on-device behavior is identical before and after this patch; the host program is what demonstrates the bug and the fix.

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI
