### PR TITLE
CLI: fix screen hard fault when USB disconnects mid-session

### DIFF
--- a/applications/services/cli/cli_command_screen.c
+++ b/applications/services/cli/cli_command_screen.c
@@ -177,7 +177,7 @@ static CommandScreen* cli_command_screen_alloc(PipeSide* pipe) {
     pipe_attach_to_event_loop(instance->pipe, instance->event_loop);
     pipe_set_callback_context(instance->pipe, instance);
     pipe_set_data_arrived_callback(instance->pipe, cli_command_screen_click_callback, FuriEventLoopEventFlagEdge);
-    pipe_set_broken_callback(instance->pipe, cli_command_screen_pipe_broken_callback, FuriEventLoopEventFlagOnce);
+    pipe_set_broken_callback(instance->pipe, cli_command_screen_pipe_broken_callback, 0);
 
     furi_event_loop_set_custom_event_callback(instance->event_loop, cli_command_screen_render_callback, instance);
  

--- a/lib/containers/pipe.c
+++ b/lib/containers/pipe.c
@@ -238,10 +238,19 @@ void pipe_detach_from_event_loop(PipeSide* pipe) {
     furi_event_loop_maybe_unsubscribe(pipe->event_loop, pipe_get_instance_semaphore(pipe));
 
     pipe->event_loop = NULL;
+
+    // Detach is the full inverse of attach + wiring up callbacks: clear everything a
+    // new owner would otherwise inherit, so the pipe is handed off in a pristine state.
+    pipe->callback_context = NULL;
+    pipe->on_data_arrived = NULL;
+    pipe->on_space_freed = NULL;
+    pipe->on_pipe_broken = NULL;
 }
 
 void pipe_set_callback_context(PipeSide* pipe, void* context) {
     furi_check(pipe);
+    // Must be cleared (NULL) by the current owner before a new one can take over.
+    furi_check(!pipe->callback_context || !context);
     pipe->callback_context = context;
 }
 
@@ -252,6 +261,8 @@ void pipe_set_data_arrived_callback(
     furi_check(pipe);
     furi_check(pipe->event_loop);
     furi_check((event & FuriEventLoopEventMask) == 0);
+    // Must be cleared (NULL) by the current owner before a new one can take over.
+    furi_check(!pipe->on_data_arrived || !callback);
 
     furi_event_loop_maybe_unsubscribe(pipe->event_loop, pipe->receiving);
     pipe->on_data_arrived = callback;
@@ -271,6 +282,8 @@ void pipe_set_space_freed_callback(
     furi_check(pipe);
     furi_check(pipe->event_loop);
     furi_check((event & FuriEventLoopEventMask) == 0);
+    // Must be cleared (NULL) by the current owner before a new one can take over.
+    furi_check(!pipe->on_space_freed || !callback);
 
     furi_event_loop_maybe_unsubscribe(pipe->event_loop, pipe->sending);
     pipe->on_space_freed = callback;
@@ -290,6 +303,8 @@ void pipe_set_broken_callback(
     furi_check(pipe);
     furi_check(pipe->event_loop);
     furi_check((event & FuriEventLoopEventMask) == 0);
+    // Must be cleared (NULL) by the current owner before a new one can take over.
+    furi_check(!pipe->on_pipe_broken || !callback);
 
     FuriSemaphore* semaphore = pipe_get_instance_semaphore(pipe);
     furi_event_loop_maybe_unsubscribe(pipe->event_loop, semaphore);

--- a/lib/containers/pipe.h
+++ b/lib/containers/pipe.h
@@ -235,7 +235,13 @@ void pipe_attach_to_event_loop(PipeSide* pipe, FuriEventLoop* event_loop);
 /**
  * @brief Detaches a `PipeSide` from the `FuriEventLoop` that it was previously
  * attached to.
- * 
+ *
+ * This also clears the callback context and all callbacks set via
+ * `pipe_set_callback_context`, `pipe_set_data_arrived_callback`,
+ * `pipe_set_space_freed_callback` and `pipe_set_broken_callback`, so that the
+ * `PipeSide` is left in a pristine state, ready to be handed off to a new
+ * owner via `pipe_attach_to_event_loop`.
+ *
  * @param [in] pipe Pipe side to detach to the event loop
  */
 void pipe_detach_from_event_loop(PipeSide* pipe);
@@ -267,23 +273,30 @@ typedef void (*PipeSideBrokenCallback)(PipeSide* pipe, void* context);
 
 /**
  * @brief Sets the custom context for all callbacks.
- * 
+ *
  * @param [in]    pipe    Pipe side to set the context of
  * @param [inout] context Custom context that will be passed to callbacks
+ *
+ * @warning The context can only be changed to a non-NULL value while it is
+ * currently NULL. Pass NULL first (or call `pipe_detach_from_event_loop`) to
+ * release it before handing the pipe side off to a new owner.
  */
 void pipe_set_callback_context(PipeSide* pipe, void* context);
 
 /**
  * @brief Sets the callback for when data arrives.
- * 
+ *
  * @param [in] pipe     Pipe side to assign the callback to
  * @param [in] callback Callback to assign to the pipe side. Set to NULL to
  *                      unsubscribe.
  * @param [in] event    Additional event loop flags (e.g. `Edge`, `Once`, etc.).
  *                      Non-flag values of the enum are not allowed.
- * 
+ *
  * @warning Attach the pipe side to an event loop first using
  * `pipe_attach_to_event_loop`.
+ * @warning The callback can only be changed to a non-NULL value while it is
+ * currently NULL. Pass NULL first (or call `pipe_detach_from_event_loop`) to
+ * unsubscribe before handing the pipe side off to a new owner.
  */
 void pipe_set_data_arrived_callback(
     PipeSide* pipe,
@@ -292,15 +305,18 @@ void pipe_set_data_arrived_callback(
 
 /**
  * @brief Sets the callback for when data is read out of the opposite `PipeSide`.
- * 
+ *
  * @param [in] pipe     Pipe side to assign the callback to
  * @param [in] callback Callback to assign to the pipe side. Set to NULL to
  *                      unsubscribe.
  * @param [in] event    Additional event loop flags (e.g. `Edge`, `Once`, etc.).
  *                      Non-flag values of the enum are not allowed.
- * 
+ *
  * @warning Attach the pipe side to an event loop first using
  * `pipe_attach_to_event_loop`.
+ * @warning The callback can only be changed to a non-NULL value while it is
+ * currently NULL. Pass NULL first (or call `pipe_detach_from_event_loop`) to
+ * unsubscribe before handing the pipe side off to a new owner.
  */
 void pipe_set_space_freed_callback(
     PipeSide* pipe,
@@ -310,15 +326,18 @@ void pipe_set_space_freed_callback(
 /**
  * @brief Sets the callback for when the opposite `PipeSide` is freed, making
  * the pipe broken.
- * 
+ *
  * @param [in] pipe     Pipe side to assign the callback to
  * @param [in] callback Callback to assign to the pipe side. Set to NULL to
  *                      unsubscribe.
  * @param [in] event    Additional event loop flags (e.g. `Edge`, `Once`, etc.).
  *                      Non-flag values of the enum are not allowed.
- * 
+ *
  * @warning Attach the pipe side to an event loop first using
  * `pipe_attach_to_event_loop`.
+ * @warning The callback can only be changed to a non-NULL value while it is
+ * currently NULL. Pass NULL first (or call `pipe_detach_from_event_loop`) to
+ * unsubscribe before handing the pipe side off to a new owner.
  */
 void pipe_set_broken_callback(
     PipeSide* pipe,


### PR DESCRIPTION
# What's new

Fixes #208 in two parts, plus the guards you asked for.

**Why it hard-faults.** The crash lives in corelibs, not in the overwrite itself. `screen` registers its pipe-broken callback with `FuriEventLoopEventFlagOnce`, and `furi_event_loop_process_event()` frees a `FlagOnce` item during the auto-unsubscribe (it runs before `current_item` is set, so the unsubscribe takes the immediate-free path instead of free-later) and then calls the callback through the freed item. Yanking USB mid-`screen` fires exactly that. I've sent the corelibs fix separately: flipperdevices/fbtng-corelibs#40. On this side, `screen`'s broken callback moves to `0` flags — the same idiom `cli_shell` uses for its own broken callback, and the handler only calls `furi_event_loop_stop()`, which is idempotent. That kills the fault here without waiting on a submodule bump.

**The overwrite you traced.** The shell actually does detach the pipe before spawning a command thread (`cli_shell_execute_command` calls `cli_shell_detach_pipe()` first, and `pipe_attach_to_event_loop()` already `furi_check`s double-attach), but `pipe_detach_from_event_loop()` only cleared `event_loop`. The context and the three callbacks stayed behind. So what `screen` was overwriting were the shell's stale leftovers, silently. Two changes make the handoff contract real:

- `pipe_detach_from_event_loop()` is now the full inverse of attach-plus-wiring: it also clears the callback context and all three callbacks, so a pipe is always handed off pristine.
- The four setters (`context`, `data_arrived`, `space_freed`, `broken`) now `furi_check` that they're not overwriting a live non-NULL value with a different one, the guard you wished had been there. Any future clobbering fails loudly at the call site instead of costing hours in the debugger.

Audited all four wiring users in the tree (`cli_shell.c`, `cli_uart.c`, `cli_vcp.c`, `cli_command_screen.c`): every existing transition is NULL-to-set or set-to-NULL, so nothing trips the new checks. `screen` itself needs no rewiring — with detach doing its job, its attach/set sequence is legitimate ownership transfer, and the shell reinstalls its own wiring after `furi_thread_join()` as before.

# Verification

- Full build with the CI toolchain (arm-none-eabi-gcc 14.2.1, pico-sdk 2.2.0, cmake Release): clean, no new warnings, uf2 produced. Also built once more with the corelibs fix applied to the submodule to confirm the pair composes.
- Call-site audit above for the new `furi_check`s.
- No Flipper One hardware here, so the actual repro needs an on-device pass: run `screen` over CDC, yank USB mid-render (a few times, timing matters), confirm no hard fault and that a reconnect gets a working CLI; then `screen`, Ctrl+C, another command, and `screen` again in the same session to exercise detach/reinstall under the guards. Same subset over the UART CLI wouldn't hurt since it shares the guarded API.

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation) — build-verified and statically traced only; no Flipper One hardware, on-device steps listed above
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI
