### PR TITLE
IQS7211E: initialize the registers read over I2C before using them

### DIFF
--- a/lib/drivers/iqs7211e/iqs7211e.c
+++ b/lib/drivers/iqs7211e/iqs7211e.c
@@ -521,7 +521,7 @@ static bool iqs7211e_initialization(Iqs7211e* instance) {
         }
         break;
     case Iqs7211eInitStateReadReset:
-        Iqs7211eInfoFlags info_flags;
+        Iqs7211eInfoFlags info_flags = {0};
         iqs7211e_read_reg(instance, Iqs7211eRegInfoFlags, (uint16_t*)&info_flags, Iqs7211eI2cTransferTypeNext);
         IQS7211E_DEBUG(TAG, "Init read reset");
         if(info_flags.show_reset) {
@@ -533,7 +533,7 @@ static bool iqs7211e_initialization(Iqs7211e* instance) {
         }
         break;
     case Iqs7211eInitStateChipReset:
-        Iqs7211eSysControl sys_control;
+        Iqs7211eSysControl sys_control = {0};
         iqs7211e_read_reg(instance, Iqs7211eRegSysControl, (uint16_t*)&sys_control, Iqs7211eI2cTransferTypeNext);
         sys_control.sw_reset = 1;
         iqs7211e_write_reg(instance, Iqs7211eRegSysControl, (uint16_t*)&sys_control, Iqs7211eI2cTransferTypeStop);
@@ -547,7 +547,7 @@ static bool iqs7211e_initialization(Iqs7211e* instance) {
         instance->init_state = Iqs7211eInitStateAckReset;
         break;
     case Iqs7211eInitStateAckReset:
-        Iqs7211eSysControl sys_control_ack;
+        Iqs7211eSysControl sys_control_ack = {0};
         iqs7211e_read_reg(instance, Iqs7211eRegSysControl, (uint16_t*)&sys_control_ack, Iqs7211eI2cTransferTypeNext);
         sys_control_ack.ack_reset = 1;
         iqs7211e_write_reg(instance, Iqs7211eRegSysControl, (uint16_t*)&sys_control_ack, Iqs7211eI2cTransferTypeStop);
@@ -555,7 +555,7 @@ static bool iqs7211e_initialization(Iqs7211e* instance) {
         instance->init_state = Iqs7211eInitStateAti;
         break;
     case Iqs7211eInitStateAti:
-        Iqs7211eSysControl sys_control_ati;
+        Iqs7211eSysControl sys_control_ati = {0};
         iqs7211e_read_reg(instance, Iqs7211eRegSysControl, (uint16_t*)&sys_control_ati, Iqs7211eI2cTransferTypeNext);
         sys_control_ati.tp_re_ati = 1;
         iqs7211e_write_reg(instance, Iqs7211eRegSysControl, (uint16_t*)&sys_control_ati, Iqs7211eI2cTransferTypeStop);
@@ -563,7 +563,7 @@ static bool iqs7211e_initialization(Iqs7211e* instance) {
         instance->init_state = Iqs7211eInitStateWaitForAti;
         break;
     case Iqs7211eInitStateWaitForAti:
-        Iqs7211eInfoFlags info_flags_ati;
+        Iqs7211eInfoFlags info_flags_ati = {0};
         iqs7211e_read_reg(instance, Iqs7211eRegInfoFlags, (uint16_t*)&info_flags_ati, Iqs7211eI2cTransferTypeStop);
         IQS7211E_DEBUG(TAG, "Init wait for ATI");
         if(!info_flags_ati.re_ati_occurred) {
@@ -610,7 +610,7 @@ void iqs7211e_run(Iqs7211e* instance) {
         break;
     case Iqs7211eStateSwReset:
         if(instance->ready) {
-            Iqs7211eSysControl sys_control;
+            Iqs7211eSysControl sys_control = {0};
             iqs7211e_read_reg(instance, Iqs7211eRegSysControl, (uint16_t*)&sys_control, Iqs7211eI2cTransferTypeNext);
             sys_control.sw_reset = 1;
             iqs7211e_write_reg(instance, Iqs7211eRegSysControl, (uint16_t*)&sys_control, Iqs7211eI2cTransferTypeStop);


### PR DESCRIPTION
`iqs7211e_read_reg()` only writes through `data` on the success path:

```c
if(ret == PICO_ERROR_GENERIC || ret == PICO_ERROR_TIMEOUT) {
    FURI_LOG_E(TAG, "Failed to read reg 0x%02X", reg);
    iqs7211e_i2c_release(instance);
} else {
    *data = buffer[0] | (buffer[1] << 8);
}
```

Both failure paths — the read failing, and the earlier register-address write failing — log, release the bus, and return without touching `*data`. It does return an `int`, but none of the 11 call sites look at it.

That leaves six locals in the init/run state machine holding stack garbage whenever the I2C transfer fails:

- `info_flags` (`Iqs7211eInitStateReadReset`) and `info_flags_ati` (`Iqs7211eInitStateWaitForAti`) are branched on, so init can take the wrong path or decide ATI finished when it hasn't.
- `sys_control`, `sys_control_ack`, `sys_control_ati` and the `sys_control` in the run-state reset are read, have one bit set, then written straight back to `Iqs7211eRegSysControl`. On a failed read that writes uninitialised stack memory into the touch controller's control register.

The scalars right above these are already initialised (`uint16_t prod_num = 0;` and friends), so this looks like the struct cases were just missed rather than deliberate.

gcc 12.3.1 flags two of them under the repo's own `-Werror -Wall`:

```
lib/drivers/iqs7211e/iqs7211e.c:524:27: error: '*(uint16_t *)((char *)&info_flags + offsetof(Iqs7211eInfoFlags, charging_mode))' may be used uninitialized [-Werror=maybe-uninitialized]
lib/drivers/iqs7211e/iqs7211e.c:569:12: error: '*(uint16_t *)((char *)&info_flags_ati + offsetof(Iqs7211eInfoFlags, charging_mode))' may be used uninitialized [-Werror=maybe-uninitialized]
```

CI pins 14.2.1, which doesn't report it, so this isn't breaking anything today — the build is green either way. The uninitialised use doesn't depend on the compiler version though.

With the six initialisers the full firmware builds clean for me (`cmake --build . --parallel` → `Linking CXX executable flipperone-mcu-firmware.elf`, exit 0) on gcc 12.3.1 and pico-sdk 2.2.0.

Being straight about the limits of this: zeroing makes the failure deterministic, it doesn't make it correct. A failed read still ends up writing a mostly-zero SysControl with one bit set instead of the real register contents. The real fix is to check what `iqs7211e_read_reg()` returns and skip the write or retry, but that changes how the init state machine handles errors and felt like your call rather than mine. Happy to do that as a follow-up if you want it.

I don't have hardware, so I haven't seen a real I2C failure on a board — this comes from reading the error paths.
