### PR TITLE
fusb302: read Status1 when checking rx_empty, not Control0

### DIFF
--- a/lib/drivers/fusb302/fusb302.c
+++ b/lib/drivers/fusb302/fusb302.c
@@ -629,7 +629,7 @@ Fusb302Status fusb302_pd_message_receive(Fusb302* instance, Fusb302PdMsg* msg) {
     Fusb302Status res = Fusb302StatusUnknown;
     Fusb302Status1RegBits status1_bits = {0};
     do {
-        res = fusb302_read_reg(instance, Fusb302RegControl0, (uint8_t*)&status1_bits);
+        res = fusb302_read_reg(instance, Fusb302RegStatus1, (uint8_t*)&status1_bits);
         if(res != Fusb302StatusOk) {
             break;
         }


### PR DESCRIPTION
`fusb302_pd_message_receive()` reads `Control0` and then tests it as if it were `Status1`:

```c
Fusb302Status1RegBits status1_bits = {0};
res = fusb302_read_reg(instance, Fusb302RegControl0, (uint8_t*)&status1_bits);
...
if(status1_bits.rx_empty) {
```

Those are different registers with different layouts — `Control0` is `0x06`, `Status1` is `0x41` — so `rx_empty` (bit 5 of Status1) actually lands on `int_mask` (bit 5 of Control0). `fusb302_pd_message_send()` a little further down does the same check correctly against `Fusb302RegStatus1`, which is what makes this one look like a slip rather than intent.

The practical effect, if it ran: `fusb302_start_drp_logic()` clears `control0.int_mask` and nothing sets it again, so the aliased bit reads 0 almost always. The function would decide the RX FIFO has data whatever the chip actually says, and read `Fusb302RegFifos` anyway, so the receive parser drifts out of sync with the real FIFO.

Scope, so this isn't oversold: it doesn't run today. The only call site is commented out in `applications/services/pd/pd.c:100` along with the rest of the PD receive loop, so nothing reaches it on current HEAD. I'm sending it because it's a one-word fix that would otherwise be waiting for whoever picks PD back up, and it'd look like a hardware problem rather than a wrong constant.

`fusb302.c` compiles clean with the change:

```
[1/1] Building C object CMakeFiles/flipperone-mcu-firmware.dir/lib/drivers/fusb302/fusb302.c.o
```

Note the full firmware build on `dev` currently stops in `iqs7211e.c` under gcc 12.3.1, unrelated to this and covered by #218.
