### PR TITLE
tps62868x: make the voltage range check actually reject out-of-range values

### DIFF
--- a/lib/drivers/tps62868x/tps62868x.c
+++ b/lib/drivers/tps62868x/tps62868x.c
@@ -105,7 +105,7 @@ int tps62868x_write_reg(Tps62868x* instance, uint8_t reg, uint8_t* data) {
 }
 
 int tps62868x_set_voltage(Tps62868x* instance, float volt) {
-    furi_check((volt >= TPS62868X_VOLTAGE_MIN) || (volt <= TPS62868X_VOLTAGE_MAX));
+    furi_check((volt >= TPS62868X_VOLTAGE_MIN) && (volt <= TPS62868X_VOLTAGE_MAX));
 
     //Vout = TPS62868X_VOLTAGE_FACTOR * (0.4v + (VOx_SET*0.005v))
     uint8_t volt_data_reg = (uint8_t)(((volt / TPS62868X_VOLTAGE_FACTOR) - 0.4f) / 0.005f);


### PR DESCRIPTION
The voltage range check in `tps62868x_set_voltage()` uses `||` where it needs `&&`:

```c
furi_check((volt >= TPS62868X_VOLTAGE_MIN) || (volt <= TPS62868X_VOLTAGE_MAX));
```

`MIN` is 0.8 and `MAX` is 3.35, so every value satisfies at least one side and the check passes for anything, including negatives. It reads like a range guard but never fires.

What gets through matters, because the register math has no clamp of its own:

```c
uint8_t volt_data_reg = (uint8_t)(((volt / TPS62868X_VOLTAGE_FACTOR) - 0.4f) / 0.005f);
```

Below 0.8 V the expression goes negative and the cast wraps; above 3.35 V it overflows past 255. Either way an out-of-range request quietly programs an unrelated rail voltage instead of being rejected:

```
  requested   reg(uint8)   actual Vout   guard(||)  guard(&&)
  3.3            250         3.30 V     True      True
  0.8              0         0.80 V     True      True
  0.1            186         2.66 V     True      False
  0.2            196         2.76 V     True      False
  5.0            164         2.44 V     True      False
```

Asking for 0.1 V sets roughly 2.66 V, about 27x the request, on the display's VCI rail.

Scope, honestly: the two call sites today are in `display_jd9853_qspi.c`, and one of them passes a hardcoded `3.3f`, which is in range and unaffected. The other is `display_jd9853_qspi_set_vci()`, which takes the voltage as an argument and is exported in `display_jd9853_qspi.h`, but nothing calls it yet. So nothing is misprogramming a display today. The guard will simply not work the first time someone drives VCI from a variable.

One character. `furi_check` behaviour for in-range values is unchanged.
