### PR TITLE
Assets: .venv as prerequisite

### DIFF
--- a/assets/CMakeLists.txt
+++ b/assets/CMakeLists.txt
@@ -13,6 +13,19 @@ else()
     set(ASSETS_COMMAND "${PYTHON_DIR}/run_venv.sh")
 endif()
 
+# Prepare the venv in a single prerequisite step: run_venv creates .venv and
+# installs packages on first use, which is not safe to do from several image
+# conversions racing in a parallel build.
+set(VENV_STAMP "${CMAKE_CURRENT_BINARY_DIR}/venv.stamp")
+add_custom_command(
+    OUTPUT  ${VENV_STAMP}
+    COMMAND ${ASSETS_COMMAND} --version
+    COMMAND ${CMAKE_COMMAND} -E touch ${VENV_STAMP}
+    DEPENDS ${ASSETS_COMMAND}
+    WORKING_DIRECTORY ${PYTHON_DIR}
+    COMMENT "Preparing Python virtual environment"
+)
+
 # Generate a C source file for each image
 foreach(IMAGE_SOURCE ${IMAGE_SOURCES})
     get_filename_component(IMAGE_NAME ${IMAGE_SOURCE} NAME_WE)
@@ -25,6 +38,7 @@ foreach(IMAGE_SOURCE ${IMAGE_SOURCES})
             ${IMAGE_SOURCE}
             ${ASSETS_COMMAND}
             ${ASSETS_SCRIPT}
+            ${VENV_STAMP}
         WORKING_DIRECTORY ${PYTHON_DIR}
         COMMENT "Generating ${IMAGE_NAME}.c"
     )

--- a/assets/python/run_venv.sh
+++ b/assets/python/run_venv.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # check for virtual environment
 if [ ! -f ".venv/bin/activate" ]; then
@@ -27,4 +28,4 @@ if ! python3 -c "import PIL" &> /dev/null; then
     pip install pillow
 fi
 
-python3 $@
+python3 "$@"


### PR DESCRIPTION
# What's new

- Dependencies: `venv` is requirement for building assets
- Fixed an error occurring during highly parallel builds

# Verification 

- Check buildbot logs

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
