### PR TITLE
CLI: check malloc result in i2c write/read commands

### DIFF
--- a/applications/services/cli/cli_command_i2c.c
+++ b/applications/services/cli/cli_command_i2c.c
@@ -136,6 +136,10 @@ static bool cli_command_i2c_write(PipeSide* pipe, FuriString* args) {
         }
 
         data = malloc(data_length + 1); // +1 for device register
+        if (!data) {
+            printf(ANSI_FG_RED "Failed" ANSI_RESET " to allocate memory\r\n");
+            break;
+        }
         data[0] = device_register;
         if(!args_read_hex_bytes(data_write, data + 1, data_length)) {
             printf(ANSI_FG_RED "Failed" ANSI_RESET " to read hex data\r\n");
@@ -204,7 +208,10 @@ static bool cli_command_i2c_read(PipeSide* pipe, FuriString* args) {
 
         {
             uint8_t* buffer = malloc(length);
-
+            if (!buffer) {
+                printf(ANSI_FG_RED "Failed" ANSI_RESET " to allocate memory\r\n");
+                break;
+            }
             furi_hal_i2c_acquire(bus_info->handle);
             int success = furi_hal_i2c_master_trx_blocking(bus_info->handle, device_address, &device_register, 1, buffer, length, FURI_HAL_I2C_TIMEOUT_US);
             furi_hal_i2c_release(bus_info->handle);


### PR DESCRIPTION
noticed while testing the i2c commands that write and read never check
if malloc actually succeeded before writing into the buffer in write
it writes the register byte right after the malloc call in read it
just hands the buffer straight to the i2c driver if malloc fails and
returns null heap gets fragmented pretty easy on this thing your
basically writing reading through address 0 and it hardfaults the
board

fix is small just added a nul check on both allocations if it fails
it prints an error message and bails out same way the other error
cases in this file already do

tested it by building locally and running a few i2c write read
commands on the bus works fine didnt touch anything else in the file

side note first time i tried building the whole thing it failed on
the assets step looked like a race in the python venv setup script
when using parallel two jobs tried creating the same venv at once and
one of them lost ran the build again and it went through clean not
related to my change just something i ran into while testing
