### PR TITLE
Furi BSP: handle a failed expander re-init in main reset

### DIFF
--- a/targets/f1/furi_bsp/furi_bsp_expander.c
+++ b/targets/f1/furi_bsp/furi_bsp_expander.c
@@ -177,13 +177,16 @@ void furi_bsp_main_reset(void) {
         furi_delay_ms(10);
 
         expander_main->handle = pcal6416_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, PCAL6416_ADDRESS_A0);
-        pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
-        expander_main->control_state = FuriBspControlExpanderMainMcu;
-        // Todo: Errata lay the I2C line
-        pcal6416_write_output(expander_main->handle, OutputExpMainVcc5v0DevS0En & OutputExpMainMask);
-        pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
-        expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
-
+        if(expander_main->handle) {
+            pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+            expander_main->control_state = FuriBspControlExpanderMainMcu;
+            // Todo: Errata lay the I2C line
+            pcal6416_write_output(expander_main->handle, OutputExpMainVcc5v0DevS0En & OutputExpMainMask);
+            pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
+            expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
+        } else {
+            furi_bsp_show_error_message_main_expander();
+        }
     } else {
         furi_bsp_show_error_message_main_expander();
     }

--- a/targets/f2/furi_bsp/furi_bsp_expander.c
+++ b/targets/f2/furi_bsp/furi_bsp_expander.c
@@ -177,13 +177,16 @@ void furi_bsp_main_reset(void) {
         furi_delay_ms(10);
 
         expander_main->handle = pcal6416_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, PCAL6416_ADDRESS_A0);
-        pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
-        expander_main->control_state = FuriBspControlExpanderMainMcu;
+        if(expander_main->handle) {
+            pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+            expander_main->control_state = FuriBspControlExpanderMainMcu;
 
-        pcal6416_write_output(expander_main->handle, OutputExpMainNMuxEn & OutputExpMainMask);
-        pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
-        expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
-
+            pcal6416_write_output(expander_main->handle, OutputExpMainNMuxEn & OutputExpMainMask);
+            pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
+            expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
+        } else {
+            furi_bsp_show_error_message_main_expander();
+        }
     } else {
         furi_bsp_show_error_message_main_expander();
     }


### PR DESCRIPTION
# What's new

`furi_bsp_main_reset()` frees the main expander with `pcal6416_deinit()`, which ends in
`free(instance)`, then calls `pcal6416_init()` and throws the return value away.
`expander_main->handle` still points at the freed instance, and the next three lines all go
through it:

```c
pcal6416_deinit(expander_main->handle);              // free(instance)
...
pcal6416_init(&furi_hal_i2c_handle_main, ...);       // result discarded
pcal6416_set_input_callback(expander_main->handle, ...);   // writes through the freed pointer
furi_bsp_expander_main_write_output(OutputExpMainVcc5v0DevS0En);
pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
```

`pcal6416_set_input_callback()` writes `instance->input_callback` and
`instance->callback_context` inside a critical section. That is a write into freed memory. The
new instance leaks, and its callback is never set, so the interrupt `pcal6416_init()` just
registered drops every expander event.

Both other call sites in this file assign the result, at lines 67 and 151. That reads like an
omission here, not deliberate reuse.

So: assign the handle, and fall into the existing degraded-mode path when the re-init fails.
That is what the rest of the file already does.

# Verification

Compiles clean on this branch:

```
[183/327] Building C object .../targets/f100/furi_bsp/furi_bsp_expander.c.o
```

A full link needs #218 on top, because `arm-none-eabi-gcc` 12.3.1 rejects `iqs7211e.c` with
`-Werror=maybe-uninitialized` on current `dev` regardless of this change. With that one
applied locally the tree links:

```
[139/139] Linking CXX executable flipperone-mcu-firmware.elf
exit 0
```

I have no Flipper One, so this is read from the source and compile-verified, not run. The reset
path is reached on a main-board reset, which I cannot trigger here.
