### PR TITLE
Fix silent Clay UI breakage: stable element IDs, split capacity limits, and overflow diagnostics

### DIFF
--- a/applications/applications.c
+++ b/applications/applications.c
@@ -29,7 +29,6 @@ extern int32_t cli_on_system_start(void* p);
 extern int32_t rpc_on_system_start(void* p);
 extern int32_t dmesg_app(void* p);
 
-
 // CLI commands
 extern void power_cli(PipeSide* pipe, FuriString* args, void* context);
 extern void led_cli(PipeSide* pipe, FuriString* args, void* context);
@@ -259,7 +258,7 @@ const FlipperInternalCommandApplication FLIPPER_CLI_COMMANDS[] = {
     {
         .callback = unit_tests_cli_command,
         .name = "unit_tests",
-        .stack_size = 1024 * 2,
+        .stack_size = 1024 * 8,
         .flags = CliCommandFlagParallelSafe,
     },
 };

--- a/applications/debug/font_test/font_test.c
+++ b/applications/debug/font_test/font_test.c
@@ -44,42 +44,48 @@ static bool font_test_layout(void* _model) {
              .padding = {4, 4, 4, 4},
              .childGap = 2,
          }}) {
-        CLAY_AUTO_ID({
-            .layout =
-                {
-                    .sizing = {.width = CLAY_SIZING_GROW(0)},
-                    .childAlignment = {.x = CLAY_ALIGN_X_LEFT},
-                },
-        }) {
+        CLAY(
+            CLAY_APP_ID("FontNameRow"),
+            {
+                .layout =
+                    {
+                        .sizing = {.width = CLAY_SIZING_GROW(0)},
+                        .childAlignment = {.x = CLAY_ALIGN_X_LEFT},
+                    },
+            }) {
             CLAY_TEXT(clay_helper_string_from_chars(font_test_names[font]), CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_BLACK}));
         }
 
         /* Separator */
-        CLAY_AUTO_ID({
-            .backgroundColor = COLOR_BLACK,
-            .layout = {.sizing = {.height = CLAY_SIZING_FIXED(1), .width = CLAY_SIZING_GROW(0)}},
-        }) {
+        CLAY(
+            CLAY_APP_ID("Separator"),
+            {
+                .backgroundColor = COLOR_BLACK,
+                .layout = {.sizing = {.height = CLAY_SIZING_FIXED(1), .width = CLAY_SIZING_GROW(0)}},
+            }) {
         }
 
         /* Glyph rows rendered with the selected font */
         for(size_t i = 0; i < COUNT_OF(font_test_rows); i++) {
-            CLAY_AUTO_ID({.layout = {.sizing = {.width = CLAY_SIZING_GROW(0)}}}) {
+            CLAY(CLAY_IDI(TAG "GlyphRow", i), {.layout = {.sizing = {.width = CLAY_SIZING_GROW(0)}}}) {
                 CLAY_TEXT(font_test_rows[i], CLAY_TEXT_CONFIG({.fontId = font, .textColor = COLOR_BLACK}));
             }
         }
 
         /* Footer: navigation hint */
-        CLAY_AUTO_ID({
-            .layout =
-                {
-                    .layoutDirection = CLAY_LEFT_TO_RIGHT,
-                    .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(1)},
-                    .childAlignment = {.y = CLAY_ALIGN_Y_BOTTOM},
-                    .childGap = 4,
-                },
-        }) {
+        CLAY(
+            CLAY_APP_ID("Footer"),
+            {
+                .layout =
+                    {
+                        .layoutDirection = CLAY_LEFT_TO_RIGHT,
+                        .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(1)},
+                        .childAlignment = {.y = CLAY_ALIGN_Y_BOTTOM},
+                        .childGap = 4,
+                    },
+            }) {
             CLAY_TEXT(CLAY_STRING("<  >  switch"), CLAY_TEXT_CONFIG({.fontId = FontBusy9, .textColor = COLOR_BLACK}));
-            CLAY_AUTO_ID({.layout = {.sizing = {.width = CLAY_SIZING_GROW(1)}}}) {
+            CLAY(CLAY_APP_ID("FooterSpacer"), {.layout = {.sizing = {.width = CLAY_SIZING_GROW(1)}}}) {
             }
             CLAY_TEXT(CLAY_STRING("Back exit"), CLAY_TEXT_CONFIG({.fontId = FontBusy9, .textColor = COLOR_BLACK}));
         }

--- a/applications/debug/haptic_test/haptic_test.c
+++ b/applications/debug/haptic_test/haptic_test.c
@@ -25,18 +25,20 @@ typedef struct {
     Haptic* haptic;
 } HapticTest;
 
-static void keypad_test_app_create_keypad_button(Clay_String text, bool inverted) {
-    CLAY_AUTO_ID({
-        .border = {.color = COLOR_BLACK, .width = {.top = 1, .left = 1, .right = 1, .bottom = 1}},
-        .layout =
-            {
-                .padding = {8, 8, 4, 4},
-                .sizing = {.width = KEYPAD_BUTTON_WIDTH},
-                .childAlignment = {.x = CLAY_ALIGN_X_CENTER},
-            },
-        .backgroundColor = inverted ? COLOR_WHITE : COLOR_BLACK,
-        .cornerRadius = CLAY_CORNER_RADIUS(4),
-    }) {
+static void keypad_test_app_create_keypad_button(Clay_ElementId id, Clay_String text, bool inverted) {
+    CLAY(
+        id,
+        {
+            .border = {.color = COLOR_BLACK, .width = {.top = 1, .left = 1, .right = 1, .bottom = 1}},
+            .layout =
+                {
+                    .padding = {8, 8, 4, 4},
+                    .sizing = {.width = KEYPAD_BUTTON_WIDTH},
+                    .childAlignment = {.x = CLAY_ALIGN_X_CENTER},
+                },
+            .backgroundColor = inverted ? COLOR_WHITE : COLOR_BLACK,
+            .cornerRadius = CLAY_CORNER_RADIUS(4),
+        }) {
         CLAY_TEXT(text, CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = inverted ? COLOR_BLACK : COLOR_WHITE}));
     }
 }
@@ -64,7 +66,7 @@ static bool haptic_test_layout(void* _model) {
                         .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
                     },
             }) {
-            CLAY_AUTO_ID({.layout = {.padding = {8, 8, 4, 4}}}) {
+            CLAY(CLAY_APP_ID("HeaderText"), {.layout = {.padding = {8, 8, 4, 4}}}) {
                 CLAY_TEXT(CLAY_STRING("Haptic Test"), CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_BLACK}));
             }
         }
@@ -129,10 +131,10 @@ static bool haptic_test_layout(void* _model) {
                 },
         }) {
         /* spacer grows to push button to the right */
-        CLAY_AUTO_ID({.layout = {.sizing = {.width = CLAY_SIZING_GROW(1)}}}) {
+        CLAY(CLAY_APP_ID("FooterSpacer"), {.layout = {.sizing = {.width = CLAY_SIZING_GROW(1)}}}) {
         }
-        CLAY_AUTO_ID({.layout = {.sizing = {.width = KEYPAD_BUTTON_WIDTH}}}) {
-            keypad_test_app_create_keypad_button(CLAY_STRING("Calb_Key_Sw"), model->sw_key_pressed);
+        CLAY(CLAY_APP_ID("FooterButtonWrapper"), {.layout = {.sizing = {.width = KEYPAD_BUTTON_WIDTH}}}) {
+            keypad_test_app_create_keypad_button(CLAY_APP_ID("CalibKeySwButton"), CLAY_STRING("Calb_Key_Sw"), model->sw_key_pressed);
         }
     }
     return false;

--- a/applications/debug/keypad_test/keypad_test.c
+++ b/applications/debug/keypad_test/keypad_test.c
@@ -20,32 +20,36 @@ typedef struct {
     FuriThread* thread;
 } KeypadTestApp;
 
-static void keypad_test_app_create_empty(void) {
-    CLAY_AUTO_ID({
-        .layout =
-            {
-                .padding = {8, 8, 4, 4},
-                .sizing = {.width = KEYPAD_TEST_BUTTON_WIDTH},
-                .childAlignment = {.x = CLAY_ALIGN_X_CENTER},
-            },
-        .backgroundColor = COLOR_WHITE,
-        .cornerRadius = CLAY_CORNER_RADIUS(4),
-    }) {
+static void keypad_test_app_create_empty(Clay_ElementId id) {
+    CLAY(
+        id,
+        {
+            .layout =
+                {
+                    .padding = {8, 8, 4, 4},
+                    .sizing = {.width = KEYPAD_TEST_BUTTON_WIDTH},
+                    .childAlignment = {.x = CLAY_ALIGN_X_CENTER},
+                },
+            .backgroundColor = COLOR_WHITE,
+            .cornerRadius = CLAY_CORNER_RADIUS(4),
+        }) {
     }
 }
 
-static void keypad_test_app_create_keypad_button(Clay_String text, bool inverted) {
-    CLAY_AUTO_ID({
-        .border = {.color = COLOR_BLACK, .width = {.top = 1, .left = 1, .right = 1, .bottom = 1}},
-        .layout =
-            {
-                .padding = {8, 8, 4, 4},
-                .sizing = {.width = KEYPAD_TEST_BUTTON_WIDTH},
-                .childAlignment = {.x = CLAY_ALIGN_X_CENTER},
-            },
-        .backgroundColor = inverted ? COLOR_WHITE : COLOR_BLACK,
-        .cornerRadius = CLAY_CORNER_RADIUS(4),
-    }) {
+static void keypad_test_app_create_keypad_button(Clay_ElementId id, Clay_String text, bool inverted) {
+    CLAY(
+        id,
+        {
+            .border = {.color = COLOR_BLACK, .width = {.top = 1, .left = 1, .right = 1, .bottom = 1}},
+            .layout =
+                {
+                    .padding = {8, 8, 4, 4},
+                    .sizing = {.width = KEYPAD_TEST_BUTTON_WIDTH},
+                    .childAlignment = {.x = CLAY_ALIGN_X_CENTER},
+                },
+            .backgroundColor = inverted ? COLOR_WHITE : COLOR_BLACK,
+            .cornerRadius = CLAY_CORNER_RADIUS(4),
+        }) {
         CLAY_TEXT(text, CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = inverted ? COLOR_BLACK : COLOR_WHITE}));
     }
 }
@@ -87,7 +91,7 @@ static bool keypad_test_app_layout(void* _model) {
                         .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
                     },
             }) {
-            CLAY_AUTO_ID({.layout = {.padding = {8, 8, 4, 4}}}) {
+            CLAY(CLAY_APP_ID("HeaderText"), {.layout = {.padding = {8, 8, 4, 4}}}) {
                 CLAY_TEXT(CLAY_STRING("Keypad Test"), CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_BLACK}));
             }
         }
@@ -106,38 +110,38 @@ static bool keypad_test_app_layout(void* _model) {
                         .childAlignment = {.y = CLAY_ALIGN_Y_CENTER},
                     },
             }) {
-            CLAY_AUTO_ID({.layout = layout_row}) {
-                keypad_test_app_create_keypad_button(CLAY_STRING("PTT"), model->key_state & InputKeyPtt);
-                keypad_test_app_create_empty();
-                keypad_test_app_create_keypad_button(CLAY_STRING("Up"), model->key_state & InputKeyUp);
-                keypad_test_app_create_empty();
-                keypad_test_app_create_empty();
+            CLAY(CLAY_APP_ID("PttUpRow"), {.layout = layout_row}) {
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("KeyPtt"), CLAY_STRING("PTT"), model->key_state & InputKeyPtt);
+                keypad_test_app_create_empty(CLAY_APP_ID("Empty0"));
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("KeyUp"), CLAY_STRING("Up"), model->key_state & InputKeyUp);
+                keypad_test_app_create_empty(CLAY_APP_ID("Empty1"));
+                keypad_test_app_create_empty(CLAY_APP_ID("Empty2"));
             }
-            CLAY_AUTO_ID({.layout = layout_row}) {
-                keypad_test_app_create_keypad_button(CLAY_STRING("Left"), model->key_state & InputKeyLeft);
-                keypad_test_app_create_keypad_button(CLAY_STRING("Ok"), model->key_state & InputKeyOk);
-                keypad_test_app_create_keypad_button(CLAY_STRING("Right"), model->key_state & InputKeyRight);
+            CLAY(CLAY_APP_ID("LeftOkRightRow"), {.layout = layout_row}) {
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("KeyLeft"), CLAY_STRING("Left"), model->key_state & InputKeyLeft);
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("KeyOk"), CLAY_STRING("Ok"), model->key_state & InputKeyOk);
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("KeyRight"), CLAY_STRING("Right"), model->key_state & InputKeyRight);
             }
-            CLAY_AUTO_ID({.layout = layout_row}) {
-                keypad_test_app_create_keypad_button(CLAY_STRING("Down"), model->key_state & InputKeyDown);
+            CLAY(CLAY_APP_ID("DownRow"), {.layout = layout_row}) {
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("KeyDown"), CLAY_STRING("Down"), model->key_state & InputKeyDown);
             }
-            CLAY_AUTO_ID({.layout = layout_row}) {
-                keypad_test_app_create_keypad_button(CLAY_STRING("SW"), model->key_state & InputKeySw);
-                keypad_test_app_create_empty();
-                keypad_test_app_create_empty();
-                keypad_test_app_create_empty();
+            CLAY(CLAY_APP_ID("SwBackRow"), {.layout = layout_row}) {
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("KeySw"), CLAY_STRING("SW"), model->key_state & InputKeySw);
+                keypad_test_app_create_empty(CLAY_APP_ID("Empty3"));
+                keypad_test_app_create_empty(CLAY_APP_ID("Empty4"));
+                keypad_test_app_create_empty(CLAY_APP_ID("Empty5"));
                 if(model->exit_counter > 0) {
-                    keypad_test_app_create_keypad_button(clay_helper_string_from(model->exit_text), model->key_state & InputKeyBack);
+                    keypad_test_app_create_keypad_button(CLAY_APP_ID("KeyBack"), clay_helper_string_from(model->exit_text), model->key_state & InputKeyBack);
                 } else {
-                    keypad_test_app_create_keypad_button(CLAY_STRING("Back"), model->key_state & InputKeyBack);
+                    keypad_test_app_create_keypad_button(CLAY_APP_ID("KeyBack"), CLAY_STRING("Back"), model->key_state & InputKeyBack);
                 }
             }
-            CLAY_AUTO_ID({.layout = layout_row}) {
-                keypad_test_app_create_keypad_button(CLAY_STRING("1"), model->key_state & InputKey1);
-                keypad_test_app_create_keypad_button(CLAY_STRING("2"), model->key_state & InputKey2);
-                keypad_test_app_create_keypad_button(CLAY_STRING("P"), model->key_state & InputKeyPower);
-                keypad_test_app_create_keypad_button(CLAY_STRING("4"), model->key_state & InputKey4);
-                keypad_test_app_create_keypad_button(CLAY_STRING("5"), model->key_state & InputKey5);
+            CLAY(CLAY_APP_ID("NumberRow"), {.layout = layout_row}) {
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("Key1"), CLAY_STRING("1"), model->key_state & InputKey1);
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("Key2"), CLAY_STRING("2"), model->key_state & InputKey2);
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("KeyP"), CLAY_STRING("P"), model->key_state & InputKeyPower);
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("Key4"), CLAY_STRING("4"), model->key_state & InputKey4);
+                keypad_test_app_create_keypad_button(CLAY_APP_ID("Key5"), CLAY_STRING("5"), model->key_state & InputKey5);
             }
         }
     }

--- a/applications/debug/touchpad_test/touchpad_test.c
+++ b/applications/debug/touchpad_test/touchpad_test.c
@@ -67,20 +67,22 @@ static bool touchpad_test_app_layout(void* _model) {
                         .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
                     },
             }) {
-            CLAY_AUTO_ID({.layout = {.padding = {8, 8, 4, 4}}}) {
+            CLAY(CLAY_APP_ID("HeaderText"), {.layout = {.padding = {8, 8, 4, 4}}}) {
                 CLAY_TEXT(CLAY_STRING("Touchpad Test"), CLAY_TEXT_CONFIG({.fontId = FontButton, .textColor = COLOR_BLACK}));
             }
-            CLAY_AUTO_ID({
-                .layout =
-                    {
-                        .padding = {8, 8, 4, 4},
-                    },
-                .floating =
-                    {
-                        .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_CENTER, .parent = CLAY_ATTACH_POINT_RIGHT_CENTER},
-                        .attachTo = CLAY_ATTACH_TO_PARENT,
-                    },
-            }) {
+            CLAY(
+                CLAY_APP_ID("ClearHint"),
+                {
+                    .layout =
+                        {
+                            .padding = {8, 8, 4, 4},
+                        },
+                    .floating =
+                        {
+                            .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_CENTER, .parent = CLAY_ATTACH_POINT_RIGHT_CENTER},
+                            .attachTo = CLAY_ATTACH_TO_PARENT,
+                        },
+                }) {
                 CLAY_TEXT(CLAY_STRING("Ok to clear"), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_BLACK}));
             }
         }

--- a/applications/debug/unit_test_app/clay_test/clay_test.c
+++ b/applications/debug/unit_test_app/clay_test/clay_test.c
@@ -3,17 +3,14 @@
  * @brief Tests for the vendored Clay fork's element-id hashmap lifecycle
  *        (services/gui/clay.h).
  *
- * The persistent element-id hashmap (layoutElementsHashMapInternal) is never
- * reset for the whole session, so element IDs that churn between frames
- * consume slots permanently and eventually break lookups for the rest of the
- * session. These tests pin down both the behavior that must keep working
- * (stable IDs, duplicate-ID diagnostics, parent-scoped local IDs) and the
- * behavior we intend to fix.
- *
- * NOTE: the three tests marked EXPECTED-TO-FAIL document the current defect
- * and must fail until clay.h reclaims stale hashmap entries (generation-based
- * eviction, the same scheme Clay__MeasureTextCached already uses). Once the
- * fix lands they must all pass unmodified.
+ * The element-id hashmap (layoutElementsHashMapInternal) reclaims entries
+ * whose id has not been declared for a few frames (generation-based eviction,
+ * the same scheme Clay__MeasureTextCached uses), so id churn between
+ * frames/screens must never permanently exhaust it. Historically the map was
+ * append-only for the whole session and churning ids broke lookups until
+ * reboot; the eviction-focused tests below were written against that defect
+ * (TDD red) and now guard the eviction mechanism against regressions - every
+ * test here must always pass.
  *
  * Each test runs against its own small Clay context so overflow is cheap to
  * reach; the GUI service's context is parked (and its redraw thread blocked
@@ -181,12 +178,12 @@ MU_TEST(clay_local_id_scoped_to_parent) {
     mu_assert_int_eq(0, err_total);
 }
 
-/* ── EXPECTED-TO-FAIL until id-hashmap eviction is implemented ──────────── */
+/* ── Regression tests for id-hashmap eviction ───────────────────────────── */
 
 /* IDs that churn between frames (one new distinct ID per frame) must not
  * permanently exhaust the hashmap: entries whose elements are gone must be
- * reclaimed. Today every distinct ID ever seen occupies a slot forever, so
- * this overflows after TEST_MAX_ELEMENT_ID_COUNT frames. */
+ * reclaimed. Without eviction every distinct ID ever seen occupies a slot
+ * forever and this overflows after TEST_MAX_ELEMENT_ID_COUNT frames. */
 MU_TEST(clay_id_churn_does_not_exhaust_hashmap) {
     for(int frame = 0; frame < TEST_MAX_ELEMENT_ID_COUNT * 3; frame++) {
         Clay_BeginLayout();
@@ -200,8 +197,9 @@ MU_TEST(clay_id_churn_does_not_exhaust_hashmap) {
 }
 
 /* After a long session of churning IDs, a brand-new element must still get a
- * working hashmap entry. Today Clay__AddHashMapItem returns NULL once the map
- * is full, so the new element is invisible to Clay_GetElementData forever. */
+ * working hashmap entry. Without eviction Clay__AddHashMapItem returns NULL
+ * once the map is full and the new element stays invisible to
+ * Clay_GetElementData forever. */
 MU_TEST(clay_new_ids_resolvable_after_long_session) {
     for(int frame = 0; frame < TEST_MAX_ELEMENT_ID_COUNT * 2; frame++) {
         Clay_BeginLayout();
@@ -222,12 +220,46 @@ MU_TEST(clay_new_ids_resolvable_after_long_session) {
     mu_assert_int_eq(77, (int)data.boundingBox.width);
 }
 
+/* A screen transition must survive an id budget that fits either screen but
+ * not both at once: the previous screen's ids stay in the map until the
+ * end-of-frame sweep ages them out (3 frames), so mid-transition the map fills
+ * up and Clay__AddHashMapItem must reclaim stale entries on demand instead of
+ * failing. */
+MU_TEST(clay_screen_transition_survives_tight_id_budget) {
+    /* "Screen A": 10 ids + Clay's root = 11 of the 15 usable slots. */
+    for(int frame = 0; frame < 2; frame++) {
+        Clay_BeginLayout();
+        for(int i = 0; i < 10; i++) {
+            clay_test_declare_box(CLAY_IDI("ScreenA", i), 20);
+        }
+        Clay_EndLayout();
+    }
+
+    /* "Screen B": 10 fresh ids while all of screen A's are still resident -
+     * the union (21) exceeds capacity, so this only passes if the map evicts
+     * screen A's entries the moment it runs out of room. */
+    for(int frame = 0; frame < 2; frame++) {
+        Clay_BeginLayout();
+        for(int i = 0; i < 10; i++) {
+            clay_test_declare_box(CLAY_IDI("ScreenB", i), 40);
+        }
+        Clay_EndLayout();
+    }
+
+    mu_assert_int_eq(0, err_capacity);
+    mu_assert_int_eq(0, err_total);
+
+    Clay_ElementData data = Clay_GetElementData(CLAY_IDI("ScreenB", 9));
+    mu_check(data.found);
+    mu_assert_int_eq(40, (int)data.boundingBox.width);
+}
+
 /* A full hashmap must not freeze elements that were known before it filled.
- * Today the capacity bail-out in Clay__AddHashMapItem also skips the
- * existing-entry update path, so a known element's item keeps a stale
+ * Without eviction the capacity bail-out in Clay__AddHashMapItem also skipped
+ * the existing-entry update path, so a known element's item kept a stale
  * layoutElement pointer into the per-frame element array; anything resolved
  * through the hashmap (here: a floating element sizing itself to its parent)
- * silently reads whatever element occupies that slot in the current frame. */
+ * silently read whatever element occupied that slot in the current frame. */
 MU_TEST(clay_floating_attachment_survives_full_hashmap) {
     Clay_ElementId tracked = CLAY_ID("Tracked");
     Clay_ElementId floater = CLAY_ID("Floater");
@@ -274,6 +306,7 @@ MU_TEST_SUITE(clay_hashmap_suite) {
 
     MU_RUN_TEST(clay_id_churn_does_not_exhaust_hashmap);
     MU_RUN_TEST(clay_new_ids_resolvable_after_long_session);
+    MU_RUN_TEST(clay_screen_transition_survives_tight_id_budget);
     MU_RUN_TEST(clay_floating_attachment_survives_full_hashmap);
 }
 

--- a/applications/debug/unit_test_app/clay_test/clay_test.c
+++ b/applications/debug/unit_test_app/clay_test/clay_test.c
@@ -1,0 +1,283 @@
+/**
+ * @file clay_test.c
+ * @brief Tests for the vendored Clay fork's element-id hashmap lifecycle
+ *        (services/gui/clay.h).
+ *
+ * The persistent element-id hashmap (layoutElementsHashMapInternal) is never
+ * reset for the whole session, so element IDs that churn between frames
+ * consume slots permanently and eventually break lookups for the rest of the
+ * session. These tests pin down both the behavior that must keep working
+ * (stable IDs, duplicate-ID diagnostics, parent-scoped local IDs) and the
+ * behavior we intend to fix.
+ *
+ * NOTE: the three tests marked EXPECTED-TO-FAIL document the current defect
+ * and must fail until clay.h reclaims stale hashmap entries (generation-based
+ * eviction, the same scheme Clay__MeasureTextCached already uses). Once the
+ * fix lands they must all pass unmodified.
+ *
+ * Each test runs against its own small Clay context so overflow is cheap to
+ * reach; the GUI service's context is parked (and its redraw thread blocked
+ * via gui_lock) for the duration of a test and restored afterwards, because
+ * Clay's current-context pointer is a plain global shared with the GUI thread.
+ */
+
+#include "../unit_tests.h"
+#include <furi.h>
+#include <gui/gui.h>
+#include <gui/gui_i.h>
+#include <gui/clay_helper.h>
+#include <string.h>
+
+/* Small on purpose: the id hashmap trips its capacity check at
+ * TEST_MAX_ELEMENT_ID_COUNT - 1 entries, one of which is Clay's own
+ * "Clay__RootContainer". */
+#define TEST_MAX_ELEMENT_COUNT    32
+#define TEST_MAX_ELEMENT_ID_COUNT 16
+
+static Gui* test_gui;
+static Clay_Context* gui_clay_context;
+static int32_t gui_max_element_count;
+static int32_t gui_max_element_id_count;
+static int32_t gui_max_word_count;
+static void* test_arena_memory;
+
+static int err_total;
+static int err_capacity;
+static int err_duplicate;
+static Clay_ErrorData err_last;
+
+static void clay_test_error_handler(Clay_ErrorData error_data) {
+    err_total++;
+    if(error_data.errorType == CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED) err_capacity++;
+    if(error_data.errorType == CLAY_ERROR_TYPE_DUPLICATE_ID) err_duplicate++;
+    err_last = error_data;
+}
+
+static void clay_test_setup(void) {
+    test_gui = furi_record_open(RECORD_GUI);
+    gui_lock(test_gui);
+
+    gui_clay_context = Clay_GetCurrentContext();
+    gui_max_element_count = Clay_GetMaxElementCount();
+    gui_max_element_id_count = Clay_GetMaxElementIdCount();
+    gui_max_word_count = Clay_GetMaxMeasureTextCacheWordCount();
+
+    /* With no current context the setters write the defaults, which both
+     * Clay_MinMemorySize() and Clay_Initialize() read; with the GUI context
+     * still current they would mutate the live GUI context instead. */
+    Clay_SetCurrentContext(NULL);
+    Clay_SetMaxElementCount(TEST_MAX_ELEMENT_COUNT);
+    Clay_SetMaxElementIdCount(TEST_MAX_ELEMENT_ID_COUNT);
+
+    uint32_t arena_size = Clay_MinMemorySize();
+    test_arena_memory = malloc(arena_size);
+    Clay_Arena arena = Clay_CreateArenaWithCapacityAndMemory(arena_size, test_arena_memory);
+    Clay_Initialize(arena, (Clay_Dimensions){240, 320}, (Clay_ErrorHandler){clay_test_error_handler, NULL});
+
+    err_total = 0;
+    err_capacity = 0;
+    err_duplicate = 0;
+    memset(&err_last, 0, sizeof(err_last));
+}
+
+static void clay_test_teardown(void) {
+    Clay_SetCurrentContext(NULL);
+    Clay_SetMaxElementCount(gui_max_element_count);
+    Clay_SetMaxElementIdCount(gui_max_element_id_count);
+    Clay_SetMaxMeasureTextCacheWordCount(gui_max_word_count);
+    Clay_SetCurrentContext(gui_clay_context);
+
+    free(test_arena_memory);
+    test_arena_memory = NULL;
+
+    gui_unlock(test_gui);
+    furi_record_close(RECORD_GUI);
+    test_gui = NULL;
+}
+
+/* No text elements anywhere in these layouts, so no measure-text function is
+ * needed. */
+static void clay_test_declare_box(Clay_ElementId id, float width) {
+    CLAY(
+        id,
+        {
+            .layout = {.sizing = {.width = CLAY_SIZING_FIXED(width), .height = CLAY_SIZING_FIXED(10)}},
+        }){};
+}
+
+static void clay_test_declare_float_on(Clay_ElementId id, uint32_t parent_id) {
+    CLAY(
+        id,
+        {
+            .layout = {.sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)}},
+            .floating =
+                {
+                    .attachTo = CLAY_ATTACH_TO_ELEMENT_WITH_ID,
+                    .parentId = parent_id,
+                },
+        }){};
+}
+
+/* ── Behavior that must keep working ────────────────────────────────────── */
+
+/* Stable IDs re-declared every frame occupy a fixed number of hashmap slots. */
+MU_TEST(clay_stable_ids_keep_hashmap_bounded) {
+    int32_t len_after_first_frame = 0;
+
+    for(int frame = 0; frame < 10; frame++) {
+        Clay_BeginLayout();
+        clay_test_declare_box(CLAY_ID("StableA"), 20);
+        clay_test_declare_box(CLAY_ID("StableB"), 20);
+        clay_test_declare_box(CLAY_ID("StableC"), 20);
+        Clay_EndLayout();
+        if(frame == 0) len_after_first_frame = Clay_GetLayoutElementHashMapLength();
+    }
+
+    mu_assert_int_eq(len_after_first_frame, Clay_GetLayoutElementHashMapLength());
+    mu_assert_int_eq(0, err_total);
+}
+
+/* Two identical IDs in one frame report CLAY_ERROR_TYPE_DUPLICATE_ID with the
+ * offending element fully identified (the diagnostics added to the fork). */
+MU_TEST(clay_duplicate_id_reports_details) {
+    Clay_ElementId dup = CLAY_ID("DupElement");
+
+    Clay_BeginLayout();
+    clay_test_declare_box(dup, 20);
+    clay_test_declare_box(dup, 30);
+    Clay_EndLayout();
+
+    mu_assert_int_eq(1, err_duplicate);
+    mu_check(err_last.elementId == dup.id);
+    mu_check(err_last.elementBaseId == dup.baseId);
+    mu_check(err_last.elementStringId.chars != NULL);
+    mu_assert_int_eq((int)dup.stringId.length, (int)err_last.elementStringId.length);
+}
+
+/* CLAY_ID_LOCAL hashes against the element it is nested inside: the same
+ * label under two different parents must not collide (regression test for the
+ * Clay__GetParentElementId fix). */
+MU_TEST(clay_local_id_scoped_to_parent) {
+    for(int frame = 0; frame < 3; frame++) {
+        Clay_BeginLayout();
+        CLAY(
+            CLAY_ID("LocalParentA"),
+            {
+                .layout = {.sizing = {.width = CLAY_SIZING_FIXED(100), .height = CLAY_SIZING_FIXED(50)}},
+            }) {
+            clay_test_declare_box(CLAY_ID_LOCAL("Child"), 10);
+        }
+        CLAY(
+            CLAY_ID("LocalParentB"),
+            {
+                .layout = {.sizing = {.width = CLAY_SIZING_FIXED(100), .height = CLAY_SIZING_FIXED(50)}},
+            }) {
+            clay_test_declare_box(CLAY_ID_LOCAL("Child"), 10);
+        }
+        Clay_EndLayout();
+    }
+
+    mu_assert_int_eq(0, err_duplicate);
+    mu_assert_int_eq(0, err_total);
+}
+
+/* ── EXPECTED-TO-FAIL until id-hashmap eviction is implemented ──────────── */
+
+/* IDs that churn between frames (one new distinct ID per frame) must not
+ * permanently exhaust the hashmap: entries whose elements are gone must be
+ * reclaimed. Today every distinct ID ever seen occupies a slot forever, so
+ * this overflows after TEST_MAX_ELEMENT_ID_COUNT frames. */
+MU_TEST(clay_id_churn_does_not_exhaust_hashmap) {
+    for(int frame = 0; frame < TEST_MAX_ELEMENT_ID_COUNT * 3; frame++) {
+        Clay_BeginLayout();
+        clay_test_declare_box(CLAY_ID("ChurnAnchor"), 20);
+        clay_test_declare_box(CLAY_IDI("Churn", frame), 20);
+        Clay_EndLayout();
+    }
+
+    mu_assert_int_eq(0, err_capacity);
+    mu_assert_int_eq(0, err_total);
+}
+
+/* After a long session of churning IDs, a brand-new element must still get a
+ * working hashmap entry. Today Clay__AddHashMapItem returns NULL once the map
+ * is full, so the new element is invisible to Clay_GetElementData forever. */
+MU_TEST(clay_new_ids_resolvable_after_long_session) {
+    for(int frame = 0; frame < TEST_MAX_ELEMENT_ID_COUNT * 2; frame++) {
+        Clay_BeginLayout();
+        clay_test_declare_box(CLAY_IDI("Session", frame), 20);
+        Clay_EndLayout();
+    }
+
+    /* A few frames so any lazily-reclaimed slots settle. */
+    Clay_ElementId fresh = CLAY_ID("FreshAfterChurn");
+    for(int frame = 0; frame < 3; frame++) {
+        Clay_BeginLayout();
+        clay_test_declare_box(fresh, 77);
+        Clay_EndLayout();
+    }
+
+    Clay_ElementData data = Clay_GetElementData(fresh);
+    mu_check(data.found);
+    mu_assert_int_eq(77, (int)data.boundingBox.width);
+}
+
+/* A full hashmap must not freeze elements that were known before it filled.
+ * Today the capacity bail-out in Clay__AddHashMapItem also skips the
+ * existing-entry update path, so a known element's item keeps a stale
+ * layoutElement pointer into the per-frame element array; anything resolved
+ * through the hashmap (here: a floating element sizing itself to its parent)
+ * silently reads whatever element occupies that slot in the current frame. */
+MU_TEST(clay_floating_attachment_survives_full_hashmap) {
+    Clay_ElementId tracked = CLAY_ID("Tracked");
+    Clay_ElementId floater = CLAY_ID("Floater");
+
+    /* Both get hashmap entries while there is still room. */
+    for(int frame = 0; frame < 2; frame++) {
+        Clay_BeginLayout();
+        clay_test_declare_box(tracked, 50);
+        clay_test_declare_float_on(floater, tracked.id);
+        Clay_EndLayout();
+    }
+
+    /* Exhaust the id hashmap with churning IDs. */
+    for(int frame = 0; frame < TEST_MAX_ELEMENT_ID_COUNT * 2; frame++) {
+        Clay_BeginLayout();
+        clay_test_declare_box(tracked, 50);
+        clay_test_declare_box(CLAY_IDI("Noise", frame), 33);
+        Clay_EndLayout();
+    }
+
+    /* Change the layout: an old-id decoy takes the element-array slot the
+     * tracked element used to occupy, and the tracked element resizes. The
+     * floating element (GROW sizing) must follow the tracked element's new
+     * 120px width, not the decoy's 33px. */
+    for(int frame = 0; frame < 2; frame++) {
+        Clay_BeginLayout();
+        clay_test_declare_box(CLAY_IDI("Noise", 0), 33);
+        clay_test_declare_box(tracked, 120);
+        clay_test_declare_float_on(floater, tracked.id);
+        Clay_EndLayout();
+    }
+
+    Clay_ElementData data = Clay_GetElementData(floater);
+    mu_check(data.found);
+    mu_assert_int_eq(120, (int)data.boundingBox.width);
+}
+
+MU_TEST_SUITE(clay_hashmap_suite) {
+    MU_SUITE_CONFIGURE(clay_test_setup, clay_test_teardown);
+
+    MU_RUN_TEST(clay_stable_ids_keep_hashmap_bounded);
+    MU_RUN_TEST(clay_duplicate_id_reports_details);
+    MU_RUN_TEST(clay_local_id_scoped_to_parent);
+
+    MU_RUN_TEST(clay_id_churn_does_not_exhaust_hashmap);
+    MU_RUN_TEST(clay_new_ids_resolvable_after_long_session);
+    MU_RUN_TEST(clay_floating_attachment_survives_full_hashmap);
+}
+
+int run_minunit_clay_test(void) {
+    MU_RUN_SUITE(clay_hashmap_suite);
+    return MU_EXIT_CODE;
+}

--- a/applications/debug/unit_test_app/clay_test/clay_test.h
+++ b/applications/debug/unit_test_app/clay_test/clay_test.h
@@ -1,0 +1,7 @@
+#ifdef TEST_FUNCTION_DECLS
+extern int run_minunit_clay_test(void);
+#endif
+
+#ifdef TEST_FUNCTION_REFS
+run_minunit_clay_test,
+#endif

--- a/applications/debug/unit_test_app/test_list.h
+++ b/applications/debug/unit_test_app/test_list.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "test_test/test_test.h"
 #include "cb_test/circular_buffer_test.h"
 #include "nvm_test/nvm_test.h"
+#include "clay_test/clay_test.h"
 #undef TEST_FUNCTION_DECLS
 
 typedef int (*TestCallback)(void);
@@ -24,6 +25,7 @@ static TestCallback unit_test_callbacks[] = {
 #include "test_test/test_test.h"
 #include "cb_test/circular_buffer_test.h"
 #include "nvm_test/nvm_test.h"
+#include "clay_test/clay_test.h"
 #undef TEST_FUNCTION_REFS
 };
 

--- a/applications/main/cpu/cpu_app.c
+++ b/applications/main/cpu/cpu_app.c
@@ -98,10 +98,12 @@ static bool cpu_app_layout(void* _model) {
             }) {
             if(model->frame.data) {
                 Image* image = &model->frame;
-                CLAY_AUTO_ID({
-                    .layout = {.sizing = layout_screen},
-                    .image = {.imageData = image},
-                }) {
+                CLAY(
+                    CLAY_APP_ID("FrameImage"),
+                    {
+                        .layout = {.sizing = layout_screen},
+                        .image = {.imageData = image},
+                    }) {
                 }
             }
         }

--- a/applications/main/self_check/self_check.c
+++ b/applications/main/self_check/self_check.c
@@ -50,23 +50,25 @@ static bool self_check_layout(void* _model) {
                     },
             }) {
             // image wrapper with floating position
-            CLAY_AUTO_ID({
-                .layout =
-                    {
-                        .sizing = {.height = CLAY_SIZING_FIT(0), .width = CLAY_SIZING_FIT(0)},
-                        .padding = {.left = 0, .right = 3, .top = 3, .bottom = 0},
-                    },
-                .floating =
-                    {
-                        .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_TOP, .parent = CLAY_ATTACH_POINT_RIGHT_TOP},
-                        .attachTo = CLAY_ATTACH_TO_PARENT,
-                    },
-            }) {
+            CLAY(
+                CLAY_APP_ID("LogoWrapper"),
+                {
+                    .layout =
+                        {
+                            .sizing = {.height = CLAY_SIZING_FIT(0), .width = CLAY_SIZING_FIT(0)},
+                            .padding = {.left = 0, .right = 3, .top = 3, .bottom = 0},
+                        },
+                    .floating =
+                        {
+                            .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_TOP, .parent = CLAY_ATTACH_POINT_RIGHT_TOP},
+                            .attachTo = CLAY_ATTACH_TO_PARENT,
+                        },
+                }) {
                 clay_fixed_image(&logo_head);
             }
 
             // text
-            CLAY_AUTO_ID() {
+            CLAY(CLAY_APP_ID("StatusText")) {
                 CLAY_TEXT(clay_helper_string_from(model->status_str), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_BLACK}));
             }
         }

--- a/applications/main/self_check/self_check.c
+++ b/applications/main/self_check/self_check.c
@@ -64,7 +64,7 @@ static bool self_check_layout(void* _model) {
                             .attachTo = CLAY_ATTACH_TO_PARENT,
                         },
                 }) {
-                clay_fixed_image(&logo_head);
+                clay_fixed_image(CLAY_ID_LOCAL("Logo"), &logo_head);
             }
 
             // text

--- a/applications/services/desktop/scenes/desktop_scene.c
+++ b/applications/services/desktop/scenes/desktop_scene.c
@@ -29,13 +29,15 @@ static bool desktop_layout(void* _model) {
                 },
             .clip = {.vertical = true, .childOffset = Clay_GetScrollOffset()},
         }) {
-        CLAY_AUTO_ID({
-            .layout =
-                {
-                    .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
-                    .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
-                },
-        }) {
+        CLAY(
+            CLAY_APP_ID("FaceWrapper"),
+            {
+                .layout =
+                    {
+                        .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
+                        .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                    },
+            }) {
             clay_fixed_image(&desktop_face_sleep);
         }
 

--- a/applications/services/desktop/scenes/desktop_scene.c
+++ b/applications/services/desktop/scenes/desktop_scene.c
@@ -38,7 +38,7 @@ static bool desktop_layout(void* _model) {
                         .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
                     },
             }) {
-            clay_fixed_image(&desktop_face_sleep);
+            clay_fixed_image(CLAY_ID_LOCAL("Face"), &desktop_face_sleep);
         }
 
         elements_softkey_button_element(1, "Help", false, model->help_pressed);

--- a/applications/services/desktop/scenes/header.c
+++ b/applications/services/desktop/scenes/header.c
@@ -32,51 +32,59 @@ static bool header_layout(void* _model) {
                     .padding = {.left = 3, .right = 2, .top = 0, .bottom = 0},
                 },
         }) {
-        CLAY_AUTO_ID({
-            .layout =
-                {
-                    .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
-                    .childAlignment = {.x = CLAY_ALIGN_X_LEFT, .y = CLAY_ALIGN_Y_CENTER},
-                    .padding = {.left = 0, .right = 0, .top = 2, .bottom = 0},
-                },
-        }) {
+        CLAY(
+            CLAY_APP_ID("VersionWrapper"),
+            {
+                .layout =
+                    {
+                        .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
+                        .childAlignment = {.x = CLAY_ALIGN_X_LEFT, .y = CLAY_ALIGN_Y_CENTER},
+                        .padding = {.left = 0, .right = 0, .top = 2, .bottom = 0},
+                    },
+            }) {
             CLAY_TEXT(
                 clay_helper_string_from(model->version_text),
                 CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_VERSION, .wrapMode = CLAY_TEXT_WRAP_NONE}));
         }
-        CLAY_AUTO_ID({
-            .layout =
-                {
-                    .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
-                    .childAlignment = {.x = CLAY_ALIGN_X_RIGHT, .y = CLAY_ALIGN_Y_CENTER},
-                    .padding = {.left = 0, .right = 0, .top = 2, .bottom = 0},
-                },
-        }) {
+        CLAY(
+            CLAY_APP_ID("ChargeWrapper"),
+            {
+                .layout =
+                    {
+                        .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
+                        .childAlignment = {.x = CLAY_ALIGN_X_RIGHT, .y = CLAY_ALIGN_Y_CENTER},
+                        .padding = {.left = 0, .right = 0, .top = 2, .bottom = 0},
+                    },
+            }) {
             CLAY_TEXT(clay_helper_string_from(model->charge_text), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_BLACK}));
         }
-        CLAY_AUTO_ID({
-            .layout =
-                {
-                    .sizing =
-                        {
-                            .height = CLAY_SIZING_FIXED(header_battery.height),
-                            .width = CLAY_SIZING_FIXED(header_battery.width),
-                        },
-                    .padding = {.left = 2, .right = 4, .top = 2, .bottom = 2},
-                },
-            .image = {.imageData = (void*)&header_battery},
-        }) {
-            CLAY_AUTO_ID({
-                .backgroundColor = {0, 0, 0, 0xFF},
+        CLAY(
+            CLAY_APP_ID("BatteryIcon"),
+            {
                 .layout =
                     {
                         .sizing =
                             {
-                                .width = CLAY_SIZING_PERCENT(model->charge_indicator_width),
-                                .height = CLAY_SIZING_GROW(0),
+                                .height = CLAY_SIZING_FIXED(header_battery.height),
+                                .width = CLAY_SIZING_FIXED(header_battery.width),
                             },
+                        .padding = {.left = 2, .right = 4, .top = 2, .bottom = 2},
                     },
-            }){};
+                .image = {.imageData = (void*)&header_battery},
+            }) {
+            CLAY(
+                CLAY_APP_ID("BatteryChargeIndicator"),
+                {
+                    .backgroundColor = {0, 0, 0, 0xFF},
+                    .layout =
+                        {
+                            .sizing =
+                                {
+                                    .width = CLAY_SIZING_PERCENT(model->charge_indicator_width),
+                                    .height = CLAY_SIZING_GROW(0),
+                                },
+                        },
+                }){};
         }
     }
     return false;

--- a/applications/services/gui/clay.h
+++ b/applications/services/gui/clay.h
@@ -1040,6 +1040,11 @@ typedef struct {
     bool maxRenderCommandsExceeded;
     bool maxTextMeasureCacheExceeded;
     bool textMeasurementFunctionNotSet;
+    // layoutElementsHashMapInternal is persistent (never reset between frames), so this can
+    // trip long after startup once enough distinct element IDs have been seen across the
+    // session, silently breaking hashmap lookups (e.g. floating element parent attachment)
+    // for any newly-seen ID from that point on.
+    bool maxHashMapItemsExceeded;
 } Clay_BooleanWarnings;
 
 typedef struct {
@@ -1719,6 +1724,13 @@ bool Clay__PointIsInsideRect(Clay_Vector2 point, Clay_BoundingBox rect) {
 Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Clay_LayoutElement* layoutElement) {
     Clay_Context* context = Clay_GetCurrentContext();
     if (context->layoutElementsHashMapInternal.length == context->layoutElementsHashMapInternal.capacity - 1) {
+        if (!context->booleanWarnings.maxHashMapItemsExceeded) {
+            context->booleanWarnings.maxHashMapItemsExceeded = true;
+            context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                    .errorType = CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
+                    .errorText = CLAY_STRING("Clay ran out of capacity in its persistent element-id hashmap (layoutElementsHashMapInternal). This array is never reset between frames, so it fills up permanently over the session as new distinct element IDs are seen; from now on newly-seen element IDs will fail hashmap lookups. Try using Clay_SetMaxElementCount() with a higher value."),
+                    .userData = context->errorHandler.userData });
+        }
         return NULL;
     }
     Clay_LayoutElementHashMapItem item = { .elementId = elementId, .layoutElement = layoutElement, .nextIndex = -1, .generation = context->generation + 1 };
@@ -1998,10 +2010,24 @@ bool Clay__MemCmp(const char *s1, const char *s2, int32_t length);
     }
 #endif
 
+// Fires the error handler exactly once, the moment an element gets silently
+// dropped because context->layoutElements ran out of capacity. Without this,
+// the caller has no way of knowing that Clay__Open*Element() returned early
+// and skipped creating the element.
+void Clay__WarnElementCapacityExceeded(Clay_Context *context) {
+    if (!context->booleanWarnings.maxElementsExceeded) {
+        context->booleanWarnings.maxElementsExceeded = true;
+        context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                .errorType = CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
+                .errorText = CLAY_STRING("Clay ran out of capacity in its internal array for storing elements and dropped one or more elements. This limit can be increased with Clay_SetMaxElementCount()."),
+                .userData = context->errorHandler.userData });
+    }
+}
+
 void Clay__OpenElement(void) {
     Clay_Context* context = Clay_GetCurrentContext();
     if (context->layoutElements.length == context->layoutElements.capacity - 1 || context->booleanWarnings.maxElementsExceeded) {
-        context->booleanWarnings.maxElementsExceeded = true;
+        Clay__WarnElementCapacityExceeded(context);
         return;
     }
     Clay_LayoutElement layoutElement = CLAY__DEFAULT_STRUCT;
@@ -2018,7 +2044,7 @@ void Clay__OpenElement(void) {
 void Clay__OpenElementWithId(Clay_ElementId elementId) {
     Clay_Context* context = Clay_GetCurrentContext();
     if (context->layoutElements.length == context->layoutElements.capacity - 1 || context->booleanWarnings.maxElementsExceeded) {
-        context->booleanWarnings.maxElementsExceeded = true;
+        Clay__WarnElementCapacityExceeded(context);
         return;
     }
     Clay_LayoutElement layoutElement = CLAY__DEFAULT_STRUCT;
@@ -2037,7 +2063,7 @@ void Clay__OpenElementWithId(Clay_ElementId elementId) {
 void Clay__OpenTextElement(Clay_String text, Clay_TextElementConfig *textConfig) {
     Clay_Context* context = Clay_GetCurrentContext();
     if (context->layoutElements.length == context->layoutElements.capacity - 1 || context->booleanWarnings.maxElementsExceeded) {
-        context->booleanWarnings.maxElementsExceeded = true;
+        Clay__WarnElementCapacityExceeded(context);
         return;
     }
     Clay_LayoutElement *parentElement = Clay__GetOpenLayoutElement();

--- a/applications/services/gui/clay.h
+++ b/applications/services/gui/clay.h
@@ -809,6 +809,16 @@ typedef struct Clay_ErrorData {
     // CLAY_ERROR_TYPE_PERCENTAGE_OVER_1 - An element was declared that using CLAY_SIZING_PERCENT but the percentage value was over 1. Percentage values are expected to be in the 0-1 range.
     // CLAY_ERROR_TYPE_INTERNAL_ERROR - Clay encountered an internal error. It would be wonderful if you could report this so we can fix it!
     Clay_ErrorType errorType;
+    // For CLAY_ERROR_TYPE_DUPLICATE_ID: the numeric id of the colliding element,
+    // plus its base id (parent id for text elements) and child offset, so the
+    // colliding declaration can be identified from the log alone.
+    uint32_t elementId;
+    uint32_t elementBaseId;
+    uint32_t elementOffset;
+    // For CLAY_ERROR_TYPE_DUPLICATE_ID: the string id when statically allocated
+    // (chars is NULL for dynamically-generated ids such as text elements).
+    // Valid only during the error callback.
+    Clay_String elementStringId;
     // A string containing human-readable error text that explains the error in more detail.
     Clay_String errorText;
     // A transparent pointer passed through from when the error handler was first provided.
@@ -847,6 +857,12 @@ CLAY_DLL_EXPORT Clay_Context* Clay_GetCurrentContext(void);
 // Sets the context that clay will use to compute the layout.
 // Used to restore a context saved from Clay_GetCurrentContext when using multiple instances of clay simultaneously.
 CLAY_DLL_EXPORT void Clay_SetCurrentContext(Clay_Context* context);
+// Returns the current fill level and capacity of the persistent element-id
+// hashmap (layoutElementsHashMapInternal). This map is never reset during the
+// session, so these are useful for diagnosing capacity overflow from an error
+// handler.
+CLAY_DLL_EXPORT int32_t Clay_GetLayoutElementHashMapLength(void);
+CLAY_DLL_EXPORT int32_t Clay_GetLayoutElementHashMapCapacity(void);
 // Updates the state of Clay's internal scroll data, updating scroll content positions if scrollDelta is non zero, and progressing momentum scrolling.
 // - enableDragScrolling when set to true will enable mobile device like "touch drag" scroll of scroll containers, including momentum scrolling after the touch has ended.
 // - scrollDelta is the amount to scroll this frame on each axis in pixels.
@@ -911,6 +927,14 @@ CLAY_DLL_EXPORT int32_t Clay_GetMaxElementCount(void);
 // Modifies the maximum number of UI elements supported by Clay's current configuration.
 // This may require reallocating additional memory, and re-calling Clay_Initialize();
 CLAY_DLL_EXPORT void Clay_SetMaxElementCount(int32_t maxElementCount);
+// Returns the capacity of the persistent element-id hashmap and other
+// session-lifetime ID-keyed arrays. Unlike maxElementCount (per-frame), these
+// arrays are never reset, so this must cover all distinct element IDs ever seen
+// across the whole session.
+CLAY_DLL_EXPORT int32_t Clay_GetMaxElementIdCount(void);
+// Modifies the capacity of the persistent element-id hashmap. Must be called
+// before Clay_Initialize().
+CLAY_DLL_EXPORT void Clay_SetMaxElementIdCount(int32_t maxElementIdCount);
 // Returns the maximum number of measured "words" (whitespace seperated runs of characters) that Clay can store in its internal text measurement cache.
 CLAY_DLL_EXPORT int32_t Clay_GetMaxMeasureTextCacheWordCount(void);
 // Modifies the maximum number of measured "words" (whitespace seperated runs of characters) that Clay can store in its internal text measurement cache.
@@ -1026,6 +1050,7 @@ CLAY__ARRAY_DEFINE_FUNCTIONS(typeName, arrayName)   \
 
 Clay_Context *Clay__currentContext;
 int32_t Clay__defaultMaxElementCount = 8192;
+int32_t Clay__defaultMaxElementIdCount = 8192;
 int32_t Clay__defaultMaxMeasureTextWordCacheCount = 16384;
 
 void Clay__ErrorHandlerFunctionDefault(Clay_ErrorData errorText) {
@@ -1235,6 +1260,7 @@ CLAY__ARRAY_DEFINE(Clay__LayoutElementTreeRoot, Clay__LayoutElementTreeRootArray
 
 struct Clay_Context {
     int32_t maxElementCount;
+    int32_t maxElementIdCount;
     int32_t maxMeasureTextCacheWordCount;
     bool warningsEnabled;
     Clay_ErrorHandler errorHandler;
@@ -1328,7 +1354,14 @@ Clay_LayoutElement* Clay__GetOpenLayoutElement(void) {
 
 uint32_t Clay__GetParentElementId(void) {
     Clay_Context* context = Clay_GetCurrentContext();
-    return Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 2))->id;
+    // Note: this fork's CLAY(id, ...) macro evaluates the id argument BEFORE
+    // Clay__OpenElementWithId() pushes the element, so the currently open
+    // element (stack top) is the future parent. Using length - 2 (upstream's
+    // value, correct when the id is evaluated after opening via the declaration
+    // config) would hash against the GRANDPARENT, making CLAY_ID_LOCAL shared
+    // between siblings with different parents - which produced duplicate IDs
+    // (e.g. the menu item Spacer, all hashed against "MenuItems").
+    return Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 1))->id;
 }
 
 Clay_LayoutConfig * Clay__StoreLayoutConfig(Clay_LayoutConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &CLAY_LAYOUT_DEFAULT : Clay__LayoutConfigArray_Add(&Clay_GetCurrentContext()->layoutConfigs, config); }
@@ -1728,7 +1761,7 @@ Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Cl
             context->booleanWarnings.maxHashMapItemsExceeded = true;
             context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
                     .errorType = CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
-                    .errorText = CLAY_STRING("Clay ran out of capacity in its persistent element-id hashmap (layoutElementsHashMapInternal). This array is never reset between frames, so it fills up permanently over the session as new distinct element IDs are seen; from now on newly-seen element IDs will fail hashmap lookups. Try using Clay_SetMaxElementCount() with a higher value."),
+                    .errorText = CLAY_STRING("Clay ran out of capacity in its persistent element-id hashmap (layoutElementsHashMapInternal). This array is never reset between frames, so it fills up permanently over the session as new distinct element IDs are seen; from now on newly-seen element IDs will fail hashmap lookups. Try using Clay_SetMaxElementIdCount() with a higher value."),
                     .userData = context->errorHandler.userData });
         }
         return NULL;
@@ -1751,6 +1784,10 @@ Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Cl
             } else { // Multiple collisions this frame - two elements have the same ID
                 context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
                     .errorType = CLAY_ERROR_TYPE_DUPLICATE_ID,
+                    .elementId = elementId.id,
+                    .elementBaseId = elementId.baseId,
+                    .elementOffset = elementId.offset,
+                    .elementStringId = elementId.stringId,
                     .errorText = CLAY_STRING("An element with this ID was already previously declared during this layout."),
                     .userData = context->errorHandler.userData });
                 if (context->debugModeEnabled) {
@@ -2248,19 +2285,20 @@ void Clay__InitializeEphemeralMemory(Clay_Context* context) {
 void Clay__InitializePersistentMemory(Clay_Context* context) {
     // Persistent memory - initialized once and not reset
     int32_t maxElementCount = context->maxElementCount;
+    int32_t maxElementIdCount = context->maxElementIdCount;
     int32_t maxMeasureTextCacheWordCount = context->maxMeasureTextCacheWordCount;
     Clay_Arena *arena = &context->internalArena;
 
     context->scrollContainerDatas = Clay__ScrollContainerDataInternalArray_Allocate_Arena(100, arena);
-    context->layoutElementsHashMapInternal = Clay__LayoutElementHashMapItemArray_Allocate_Arena(maxElementCount, arena);
-    context->layoutElementsHashMap = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
-    context->measureTextHashMapInternal = Clay__MeasureTextCacheItemArray_Allocate_Arena(maxElementCount, arena);
-    context->measureTextHashMapInternalFreeList = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->layoutElementsHashMapInternal = Clay__LayoutElementHashMapItemArray_Allocate_Arena(maxElementIdCount, arena);
+    context->layoutElementsHashMap = Clay__int32_tArray_Allocate_Arena(maxElementIdCount, arena);
+    context->measureTextHashMapInternal = Clay__MeasureTextCacheItemArray_Allocate_Arena(maxElementIdCount, arena);
+    context->measureTextHashMapInternalFreeList = Clay__int32_tArray_Allocate_Arena(maxElementIdCount, arena);
     context->measuredWordsFreeList = Clay__int32_tArray_Allocate_Arena(maxMeasureTextCacheWordCount, arena);
-    context->measureTextHashMap = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->measureTextHashMap = Clay__int32_tArray_Allocate_Arena(maxElementIdCount, arena);
     context->measuredWords = Clay__MeasuredWordArray_Allocate_Arena(maxMeasureTextCacheWordCount, arena);
     context->pointerOverIds = Clay_ElementIdArray_Allocate_Arena(maxElementCount, arena);
-    context->debugElementData = Clay__DebugElementDataArray_Allocate_Arena(maxElementCount, arena);
+    context->debugElementData = Clay__DebugElementDataArray_Allocate_Arena(maxElementIdCount, arena);
     context->arenaResetOffset = arena->nextAllocation;
 }
 
@@ -3947,6 +3985,7 @@ CLAY_WASM_EXPORT("Clay_MinMemorySize")
 uint32_t Clay_MinMemorySize(void) {
     Clay_Context fakeContext = {
         .maxElementCount = Clay__defaultMaxElementCount,
+        .maxElementIdCount = Clay__defaultMaxElementIdCount,
         .maxMeasureTextCacheWordCount = Clay__defaultMaxMeasureTextWordCacheCount,
         .internalArena = {
             .capacity = SIZE_MAX,
@@ -3956,6 +3995,7 @@ uint32_t Clay_MinMemorySize(void) {
     Clay_Context* currentContext = Clay_GetCurrentContext();
     if (currentContext) {
         fakeContext.maxElementCount = currentContext->maxElementCount;
+        fakeContext.maxElementIdCount = currentContext->maxElementIdCount;
         fakeContext.maxMeasureTextCacheWordCount = currentContext->maxMeasureTextCacheWordCount;
     }
     // Reserve space in the arena for the context, important for calculating min memory size correctly
@@ -4075,6 +4115,7 @@ Clay_Context* Clay_Initialize(Clay_Arena arena, Clay_Dimensions layoutDimensions
     Clay_Context *oldContext = Clay_GetCurrentContext();
     *context = CLAY__INIT(Clay_Context) {
         .maxElementCount = oldContext ? oldContext->maxElementCount : Clay__defaultMaxElementCount,
+        .maxElementIdCount = oldContext ? oldContext->maxElementIdCount : Clay__defaultMaxElementIdCount,
         .maxMeasureTextCacheWordCount = oldContext ? oldContext->maxMeasureTextCacheWordCount : Clay__defaultMaxMeasureTextWordCacheCount,
         .errorHandler = errorHandler.errorHandlerFunction ? errorHandler : CLAY__INIT(Clay_ErrorHandler) { Clay__ErrorHandlerFunctionDefault, 0 },
         .layoutDimensions = layoutDimensions,
@@ -4102,6 +4143,16 @@ Clay_Context* Clay_GetCurrentContext(void) {
 CLAY_WASM_EXPORT("Clay_SetCurrentContext")
 void Clay_SetCurrentContext(Clay_Context* context) {
     Clay__currentContext = context;
+}
+
+CLAY_WASM_EXPORT("Clay_GetLayoutElementHashMapLength")
+int32_t Clay_GetLayoutElementHashMapLength(void) {
+    return Clay_GetCurrentContext()->layoutElementsHashMapInternal.length;
+}
+
+CLAY_WASM_EXPORT("Clay_GetLayoutElementHashMapCapacity")
+int32_t Clay_GetLayoutElementHashMapCapacity(void) {
+    return Clay_GetCurrentContext()->layoutElementsHashMapInternal.capacity;
 }
 
 CLAY_WASM_EXPORT("Clay_GetScrollOffset")
@@ -4417,6 +4468,22 @@ void Clay_SetMaxElementCount(int32_t maxElementCount) {
     } else {
         Clay__defaultMaxElementCount = maxElementCount; // TODO: Fix this
         Clay__defaultMaxMeasureTextWordCacheCount = maxElementCount * 2;
+    }
+}
+
+CLAY_WASM_EXPORT("Clay_GetMaxElementIdCount")
+int32_t Clay_GetMaxElementIdCount(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    return context->maxElementIdCount;
+}
+
+CLAY_WASM_EXPORT("Clay_SetMaxElementIdCount")
+void Clay_SetMaxElementIdCount(int32_t maxElementIdCount) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context) {
+        context->maxElementIdCount = maxElementIdCount;
+    } else {
+        Clay__defaultMaxElementIdCount = maxElementIdCount;
     }
 }
 

--- a/applications/services/gui/clay.h
+++ b/applications/services/gui/clay.h
@@ -1069,10 +1069,10 @@ typedef struct {
     bool maxRenderCommandsExceeded;
     bool maxTextMeasureCacheExceeded;
     bool textMeasurementFunctionNotSet;
-    // Trips when more element ids are live at the same time (declared within the
-    // last couple of frames) than layoutElementsHashMapInternal can hold; the
-    // overflowing element fails hashmap lookups (e.g. floating element parent
-    // attachment) until the map drains.
+    // Trips when more distinct element ids are declared within a single frame
+    // than layoutElementsHashMapInternal can hold (stale entries are reclaimed
+    // on demand before this fires); the overflowing element fails hashmap
+    // lookups (e.g. floating element parent attachment) for that frame.
     bool maxHashMapItemsExceeded;
 } Clay_BooleanWarnings;
 
@@ -1759,6 +1759,8 @@ bool Clay__PointIsInsideRect(Clay_Vector2 point, Clay_BoundingBox rect) {
     return point.x >= rect.x && point.x <= rect.x + rect.width && point.y >= rect.y && point.y <= rect.y + rect.height;
 }
 
+void Clay__EvictStaleLayoutElementHashMapItems(Clay_Context* context, int32_t minStaleGenerations);
+
 Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Clay_LayoutElement* layoutElement) {
     Clay_Context* context = Clay_GetCurrentContext();
     Clay_LayoutElementHashMapItem item = { .elementId = elementId, .layoutElement = layoutElement, .nextIndex = -1, .generation = context->generation + 1 };
@@ -1797,6 +1799,21 @@ Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Cl
     // A new id: reuse a slot reclaimed by Clay__EvictStaleLayoutElementHashMapItems
     // when one is available, otherwise append. The capacity check applies only to
     // genuinely new entries - existing ids above were updated unconditionally.
+    if (context->layoutElementsHashMapFreeList.length == 0 &&
+        context->layoutElementsHashMapInternal.length == context->layoutElementsHashMapInternal.capacity - 1) {
+        // The map is transiently full mid-frame (e.g. a screen transition keeps
+        // the previous screen's ids until the end-of-frame sweep ages them out).
+        // Reclaim everything not declared in the current frame before giving up,
+        // so the capacity only ever has to cover a single frame's ids.
+        Clay__EvictStaleLayoutElementHashMapItems(context, 0);
+        // The eviction rewrites bucket chains; recompute this bucket's tail so
+        // the new entry is linked at a valid position.
+        hashItemPrevious = -1;
+        for (int32_t itemIndex = context->layoutElementsHashMap.internalArray[hashBucket]; itemIndex != -1;) {
+            hashItemPrevious = itemIndex;
+            itemIndex = Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, itemIndex)->nextIndex;
+        }
+    }
     Clay_LayoutElementHashMapItem *hashItem;
     int32_t newItemIndex;
     if (context->layoutElementsHashMapFreeList.length > 0) {
@@ -1813,7 +1830,7 @@ Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Cl
                 context->booleanWarnings.maxHashMapItemsExceeded = true;
                 context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
                         .errorType = CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
-                        .errorText = CLAY_STRING("Clay ran out of capacity in its element-id hashmap (layoutElementsHashMapInternal). Entries are recycled once an id has not been declared for a few frames, so this means too many distinct element ids are live at the same time. Try using Clay_SetMaxElementIdCount() with a higher value (before Clay_Initialize())."),
+                        .errorText = CLAY_STRING("Clay ran out of capacity in its element-id hashmap (layoutElementsHashMapInternal). Stale entries are recycled on demand, so this means too many distinct element ids were declared within a single frame. Try using Clay_SetMaxElementIdCount() with a higher value (before Clay_Initialize())."),
                         .userData = context->errorHandler.userData });
             }
             return NULL;
@@ -1830,11 +1847,14 @@ Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Cl
     return hashItem;
 }
 
-// Reclaims hashmap entries whose element has not been declared for over two
-// frames (the same generation criterion as the text measurement cache), so id
-// churn between frames/screens cannot permanently exhaust the map. Freed slots
-// are unlinked from their bucket chain and reused by Clay__AddHashMapItem.
-void Clay__EvictStaleLayoutElementHashMapItems(Clay_Context* context) {
+// Reclaims hashmap entries whose element has not been declared for at least
+// minStaleGenerations frames, so id churn between frames/screens cannot
+// permanently exhaust the map. The end-of-frame sweep uses 3 (the same
+// criterion as the text measurement cache); Clay__AddHashMapItem passes 0 to
+// reclaim everything not declared in the current frame when the map fills
+// mid-frame. Freed slots are unlinked from their bucket chain and reused by
+// Clay__AddHashMapItem.
+void Clay__EvictStaleLayoutElementHashMapItems(Clay_Context* context, int32_t minStaleGenerations) {
     for (int32_t hashBucket = 0; hashBucket < context->layoutElementsHashMap.capacity; ++hashBucket) {
         int32_t previousIndex = -1;
         int32_t itemIndex = context->layoutElementsHashMap.internalArray[hashBucket];
@@ -1842,7 +1862,7 @@ void Clay__EvictStaleLayoutElementHashMapItems(Clay_Context* context) {
             Clay_LayoutElementHashMapItem *item = Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, itemIndex);
             int32_t nextIndex = item->nextIndex;
             // Signed comparison: an item touched this frame carries generation + 1.
-            if ((int32_t)(context->generation - item->generation) > 2) {
+            if ((int32_t)(context->generation - item->generation) >= minStaleGenerations) {
                 if (previousIndex != -1) {
                     Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, previousIndex)->nextIndex = nextIndex;
                 } else {
@@ -4400,7 +4420,7 @@ Clay_RenderCommandArray Clay_EndLayout(void) {
                 .userData = context->errorHandler.userData });
     }
     Clay__CalculateFinalLayout();
-    Clay__EvictStaleLayoutElementHashMapItems(context);
+    Clay__EvictStaleLayoutElementHashMapItems(context, 3);
     return context->renderCommands;
 }
 

--- a/applications/services/gui/clay.h
+++ b/applications/services/gui/clay.h
@@ -863,6 +863,10 @@ CLAY_DLL_EXPORT void Clay_SetCurrentContext(Clay_Context* context);
 // these are useful for diagnosing capacity overflow from an error handler.
 CLAY_DLL_EXPORT int32_t Clay_GetLayoutElementHashMapLength(void);
 CLAY_DLL_EXPORT int32_t Clay_GetLayoutElementHashMapCapacity(void);
+// Returns the number of layout elements declared in the most recent frame.
+// layoutElements is a per-frame array reset by Clay_BeginLayout, so read this
+// after Clay_EndLayout; useful for sizing Clay_SetMaxElementCount().
+CLAY_DLL_EXPORT int32_t Clay_GetLayoutElementCount(void);
 // Updates the state of Clay's internal scroll data, updating scroll content positions if scrollDelta is non zero, and progressing momentum scrolling.
 // - enableDragScrolling when set to true will enable mobile device like "touch drag" scroll of scroll containers, including momentum scrolling after the touch has ended.
 // - scrollDelta is the amount to scroll this frame on each axis in pixels.
@@ -2095,10 +2099,12 @@ bool Clay__MemCmp(const char *s1, const char *s2, int32_t length);
     }
 #endif
 
-// Fires the error handler exactly once, the moment an element gets silently
-// dropped because context->layoutElements ran out of capacity. Without this,
-// the caller has no way of knowing that Clay__Open*Element() returned early
-// and skipped creating the element.
+// Fires the error handler once per frame (the latch lives in booleanWarnings,
+// which Clay_BeginLayout resets), the moment an element gets silently dropped
+// because context->layoutElements ran out of capacity. Without this, the
+// caller has no way of knowing that Clay__Open*Element() returned early and
+// skipped creating the element. A screen that keeps exceeding the capacity
+// re-fires on every layout pass for as long as it is displayed.
 void Clay__WarnElementCapacityExceeded(Clay_Context *context) {
     if (!context->booleanWarnings.maxElementsExceeded) {
         context->booleanWarnings.maxElementsExceeded = true;
@@ -4203,6 +4209,11 @@ int32_t Clay_GetLayoutElementHashMapLength(void) {
 CLAY_WASM_EXPORT("Clay_GetLayoutElementHashMapCapacity")
 int32_t Clay_GetLayoutElementHashMapCapacity(void) {
     return Clay_GetCurrentContext()->layoutElementsHashMapInternal.capacity;
+}
+
+CLAY_WASM_EXPORT("Clay_GetLayoutElementCount")
+int32_t Clay_GetLayoutElementCount(void) {
+    return Clay_GetCurrentContext()->layoutElements.length;
 }
 
 CLAY_WASM_EXPORT("Clay_GetScrollOffset")

--- a/applications/services/gui/clay.h
+++ b/applications/services/gui/clay.h
@@ -857,10 +857,10 @@ CLAY_DLL_EXPORT Clay_Context* Clay_GetCurrentContext(void);
 // Sets the context that clay will use to compute the layout.
 // Used to restore a context saved from Clay_GetCurrentContext when using multiple instances of clay simultaneously.
 CLAY_DLL_EXPORT void Clay_SetCurrentContext(Clay_Context* context);
-// Returns the current fill level and capacity of the persistent element-id
-// hashmap (layoutElementsHashMapInternal). This map is never reset during the
-// session, so these are useful for diagnosing capacity overflow from an error
-// handler.
+// Returns the current live-entry count and capacity of the element-id hashmap
+// (layoutElementsHashMapInternal). Entries whose element has not been declared
+// for over two frames are recycled, so the count reflects recently-live ids;
+// these are useful for diagnosing capacity overflow from an error handler.
 CLAY_DLL_EXPORT int32_t Clay_GetLayoutElementHashMapLength(void);
 CLAY_DLL_EXPORT int32_t Clay_GetLayoutElementHashMapCapacity(void);
 // Updates the state of Clay's internal scroll data, updating scroll content positions if scrollDelta is non zero, and progressing momentum scrolling.
@@ -1065,10 +1065,10 @@ typedef struct {
     bool maxRenderCommandsExceeded;
     bool maxTextMeasureCacheExceeded;
     bool textMeasurementFunctionNotSet;
-    // layoutElementsHashMapInternal is persistent (never reset between frames), so this can
-    // trip long after startup once enough distinct element IDs have been seen across the
-    // session, silently breaking hashmap lookups (e.g. floating element parent attachment)
-    // for any newly-seen ID from that point on.
+    // Trips when more element ids are live at the same time (declared within the
+    // last couple of frames) than layoutElementsHashMapInternal can hold; the
+    // overflowing element fails hashmap lookups (e.g. floating element parent
+    // attachment) until the map drains.
     bool maxHashMapItemsExceeded;
 } Clay_BooleanWarnings;
 
@@ -1307,6 +1307,7 @@ struct Clay_Context {
     Clay__LayoutElementTreeNodeArray layoutElementTreeNodeArray1;
     Clay__LayoutElementTreeRootArray layoutElementTreeRoots;
     Clay__LayoutElementHashMapItemArray layoutElementsHashMapInternal;
+    Clay__int32_tArray layoutElementsHashMapFreeList;
     Clay__int32_tArray layoutElementsHashMap;
     Clay__MeasureTextCacheItemArray measureTextHashMapInternal;
     Clay__int32_tArray measureTextHashMapInternalFreeList;
@@ -1756,16 +1757,6 @@ bool Clay__PointIsInsideRect(Clay_Vector2 point, Clay_BoundingBox rect) {
 
 Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Clay_LayoutElement* layoutElement) {
     Clay_Context* context = Clay_GetCurrentContext();
-    if (context->layoutElementsHashMapInternal.length == context->layoutElementsHashMapInternal.capacity - 1) {
-        if (!context->booleanWarnings.maxHashMapItemsExceeded) {
-            context->booleanWarnings.maxHashMapItemsExceeded = true;
-            context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
-                    .errorType = CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
-                    .errorText = CLAY_STRING("Clay ran out of capacity in its persistent element-id hashmap (layoutElementsHashMapInternal). This array is never reset between frames, so it fills up permanently over the session as new distinct element IDs are seen; from now on newly-seen element IDs will fail hashmap lookups. Try using Clay_SetMaxElementIdCount() with a higher value."),
-                    .userData = context->errorHandler.userData });
-        }
-        return NULL;
-    }
     Clay_LayoutElementHashMapItem item = { .elementId = elementId, .layoutElement = layoutElement, .nextIndex = -1, .generation = context->generation + 1 };
     uint32_t hashBucket = elementId.id % context->layoutElementsHashMap.capacity;
     int32_t hashItemPrevious = -1;
@@ -1799,14 +1790,71 @@ Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Cl
         hashItemPrevious = hashItemIndex;
         hashItemIndex = hashItem->nextIndex;
     }
-    Clay_LayoutElementHashMapItem *hashItem = Clay__LayoutElementHashMapItemArray_Add(&context->layoutElementsHashMapInternal, item);
-    hashItem->debugData = Clay__DebugElementDataArray_Add(&context->debugElementData, CLAY__INIT(Clay__DebugElementData) CLAY__DEFAULT_STRUCT);
-    if (hashItemPrevious != -1) {
-        Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, hashItemPrevious)->nextIndex = (int32_t)context->layoutElementsHashMapInternal.length - 1;
+    // A new id: reuse a slot reclaimed by Clay__EvictStaleLayoutElementHashMapItems
+    // when one is available, otherwise append. The capacity check applies only to
+    // genuinely new entries - existing ids above were updated unconditionally.
+    Clay_LayoutElementHashMapItem *hashItem;
+    int32_t newItemIndex;
+    if (context->layoutElementsHashMapFreeList.length > 0) {
+        newItemIndex = Clay__int32_tArray_GetValue(&context->layoutElementsHashMapFreeList, context->layoutElementsHashMapFreeList.length - 1);
+        context->layoutElementsHashMapFreeList.length--;
+        hashItem = Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, newItemIndex);
+        Clay__DebugElementData *debugData = hashItem->debugData; // Parallel to the slot index, reused with it
+        *debugData = CLAY__INIT(Clay__DebugElementData) CLAY__DEFAULT_STRUCT;
+        *hashItem = item;
+        hashItem->debugData = debugData;
     } else {
-        context->layoutElementsHashMap.internalArray[hashBucket] = (int32_t)context->layoutElementsHashMapInternal.length - 1;
+        if (context->layoutElementsHashMapInternal.length == context->layoutElementsHashMapInternal.capacity - 1) {
+            if (!context->booleanWarnings.maxHashMapItemsExceeded) {
+                context->booleanWarnings.maxHashMapItemsExceeded = true;
+                context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                        .errorType = CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
+                        .errorText = CLAY_STRING("Clay ran out of capacity in its element-id hashmap (layoutElementsHashMapInternal). Entries are recycled once an id has not been declared for a few frames, so this means too many distinct element ids are live at the same time. Try using Clay_SetMaxElementIdCount() with a higher value (before Clay_Initialize())."),
+                        .userData = context->errorHandler.userData });
+            }
+            return NULL;
+        }
+        hashItem = Clay__LayoutElementHashMapItemArray_Add(&context->layoutElementsHashMapInternal, item);
+        hashItem->debugData = Clay__DebugElementDataArray_Add(&context->debugElementData, CLAY__INIT(Clay__DebugElementData) CLAY__DEFAULT_STRUCT);
+        newItemIndex = (int32_t)context->layoutElementsHashMapInternal.length - 1;
+    }
+    if (hashItemPrevious != -1) {
+        Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, hashItemPrevious)->nextIndex = newItemIndex;
+    } else {
+        context->layoutElementsHashMap.internalArray[hashBucket] = newItemIndex;
     }
     return hashItem;
+}
+
+// Reclaims hashmap entries whose element has not been declared for over two
+// frames (the same generation criterion as the text measurement cache), so id
+// churn between frames/screens cannot permanently exhaust the map. Freed slots
+// are unlinked from their bucket chain and reused by Clay__AddHashMapItem.
+void Clay__EvictStaleLayoutElementHashMapItems(Clay_Context* context) {
+    for (int32_t hashBucket = 0; hashBucket < context->layoutElementsHashMap.capacity; ++hashBucket) {
+        int32_t previousIndex = -1;
+        int32_t itemIndex = context->layoutElementsHashMap.internalArray[hashBucket];
+        while (itemIndex != -1) {
+            Clay_LayoutElementHashMapItem *item = Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, itemIndex);
+            int32_t nextIndex = item->nextIndex;
+            // Signed comparison: an item touched this frame carries generation + 1.
+            if ((int32_t)(context->generation - item->generation) > 2) {
+                if (previousIndex != -1) {
+                    Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, previousIndex)->nextIndex = nextIndex;
+                } else {
+                    context->layoutElementsHashMap.internalArray[hashBucket] = nextIndex;
+                }
+                item->elementId = CLAY__INIT(Clay_ElementId) CLAY__DEFAULT_STRUCT;
+                item->layoutElement = NULL;
+                item->onHoverFunction = NULL;
+                item->nextIndex = -1;
+                Clay__int32_tArray_Add(&context->layoutElementsHashMapFreeList, itemIndex);
+            } else {
+                previousIndex = itemIndex;
+            }
+            itemIndex = nextIndex;
+        }
+    }
 }
 
 Clay_LayoutElementHashMapItem *Clay__GetHashMapItem(uint32_t id) {
@@ -2291,6 +2339,7 @@ void Clay__InitializePersistentMemory(Clay_Context* context) {
 
     context->scrollContainerDatas = Clay__ScrollContainerDataInternalArray_Allocate_Arena(100, arena);
     context->layoutElementsHashMapInternal = Clay__LayoutElementHashMapItemArray_Allocate_Arena(maxElementIdCount, arena);
+    context->layoutElementsHashMapFreeList = Clay__int32_tArray_Allocate_Arena(maxElementIdCount, arena);
     context->layoutElementsHashMap = Clay__int32_tArray_Allocate_Arena(maxElementIdCount, arena);
     context->measureTextHashMapInternal = Clay__MeasureTextCacheItemArray_Allocate_Arena(maxElementIdCount, arena);
     context->measureTextHashMapInternalFreeList = Clay__int32_tArray_Allocate_Arena(maxElementIdCount, arena);
@@ -4147,7 +4196,8 @@ void Clay_SetCurrentContext(Clay_Context* context) {
 
 CLAY_WASM_EXPORT("Clay_GetLayoutElementHashMapLength")
 int32_t Clay_GetLayoutElementHashMapLength(void) {
-    return Clay_GetCurrentContext()->layoutElementsHashMapInternal.length;
+    Clay_Context* context = Clay_GetCurrentContext();
+    return context->layoutElementsHashMapInternal.length - context->layoutElementsHashMapFreeList.length;
 }
 
 CLAY_WASM_EXPORT("Clay_GetLayoutElementHashMapCapacity")
@@ -4339,6 +4389,7 @@ Clay_RenderCommandArray Clay_EndLayout(void) {
                 .userData = context->errorHandler.userData });
     }
     Clay__CalculateFinalLayout();
+    Clay__EvictStaleLayoutElementHashMapItems(context);
     return context->renderCommands;
 }
 

--- a/applications/services/gui/clay_helper.c
+++ b/applications/services/gui/clay_helper.c
@@ -98,12 +98,14 @@ Clay_String clay_helper_string_from_chars(const char* chars) {
 }
 
 void clay_fixed_image(const Image* image) {
-    CLAY_AUTO_ID({
-        .layout =
-            {
-                .sizing = {.height = CLAY_SIZING_FIXED(image->height), .width = CLAY_SIZING_FIXED(image->width)},
-            },
-        .image = {.imageData = (void*)image},
-    }) {
+    CLAY(
+        CLAY_ID_LOCAL("FixedImage"),
+        {
+            .layout =
+                {
+                    .sizing = {.height = CLAY_SIZING_FIXED(image->height), .width = CLAY_SIZING_FIXED(image->width)},
+                },
+            .image = {.imageData = (void*)image},
+        }) {
     }
 }

--- a/applications/services/gui/clay_helper.c
+++ b/applications/services/gui/clay_helper.c
@@ -97,9 +97,9 @@ Clay_String clay_helper_string_from_chars(const char* chars) {
     return clay_string;
 }
 
-void clay_fixed_image(const Image* image) {
+void clay_fixed_image(Clay_ElementId id, const Image* image) {
     CLAY(
-        CLAY_ID_LOCAL("FixedImage"),
+        id,
         {
             .layout =
                 {

--- a/applications/services/gui/clay_helper.h
+++ b/applications/services/gui/clay_helper.h
@@ -44,10 +44,12 @@ Clay_String clay_helper_string_from(FuriString* furi_string);
 Clay_String clay_helper_string_from_chars(const char* chars);
 
 /**
- * @brief Place an image in the CLAY layout with an automatic id and a fixed size based on the image dimensions.
+ * @brief Place an image in the CLAY layout with a fixed size based on the image dimensions.
+ * @param id The element id; the caller keeps it unique among siblings
+ *           (e.g. CLAY_ID_LOCAL for a single image, CLAY_IDI_LOCAL in loops).
  * @param image The image to display.
  */
-void clay_fixed_image(const Image* image);
+void clay_fixed_image(Clay_ElementId id, const Image* image);
 
 #ifdef __cplusplus
 }

--- a/applications/services/gui/gui.c
+++ b/applications/services/gui/gui.c
@@ -17,7 +17,15 @@
 
 #define GUI_EVENT_FLAG_REDRAW (1U << 0)
 
-#define CLAY_MAX_ELEMENT_COUNT            144
+/* Clay has two separate capacity limits:
+ * - CLAY_MAX_ELEMENT_COUNT: per-frame ephemeral arrays (layoutElements,
+ *   renderCommands, per-element configs) - reset every frame, so only the
+ *   busiest single screen matters.
+ * - CLAY_MAX_ELEMENT_ID_COUNT: session-persistent ID-keyed arrays (the
+ *   element-id hashmap, text measurement cache) - never reset, so this must
+ *   cover every distinct element ID ever seen across ALL screens/apps. */
+#define CLAY_MAX_ELEMENT_COUNT            80
+#define CLAY_MAX_ELEMENT_ID_COUNT         256
 #define CLAY_MAX_MEASURE_TEXT_CACHE_WORDS 256
 
 typedef struct {
@@ -353,6 +361,29 @@ void gui_remove_view(Gui* gui, View* view) {
 
 static void gui_handle_clay_errors(Clay_ErrorData errorData) {
     FURI_LOG_E(TAG, "clay error: %s", errorData.errorText.chars);
+
+    if(errorData.errorType == CLAY_ERROR_TYPE_DUPLICATE_ID) {
+        FURI_LOG_E(
+            TAG,
+            "clay duplicate element id: %lu (base=%lu, offset=%lu)",
+            (unsigned long)errorData.elementId,
+            (unsigned long)errorData.elementBaseId,
+            (unsigned long)errorData.elementOffset);
+        if(errorData.elementStringId.chars) {
+            FURI_LOG_E(TAG, "clay duplicate string id: %.*s", (int)errorData.elementStringId.length, errorData.elementStringId.chars);
+        }
+    }
+
+    /* Dump the persistent element-id hashmap fill level so capacity overflows
+     * are diagnosable from the device log alone: once
+     * layoutElementsHashMapInternal fills up it stays full for the rest of the
+     * session, so the reported counts show how far CLAY_MAX_ELEMENT_ID_COUNT
+     * needs to grow. */
+    FURI_LOG_E(
+        TAG,
+        "clay state: hashmap=%d/%d",
+        (int)Clay_GetLayoutElementHashMapLength(),
+        (int)Clay_GetLayoutElementHashMapCapacity());
 }
 
 static void gui_input_logic(FuriEventLoopObject* object, void* context) {
@@ -419,14 +450,16 @@ static Gui* gui_alloc(void) {
 
     // Clay initialization
     Clay_SetMaxElementCount(CLAY_MAX_ELEMENT_COUNT);
+    Clay_SetMaxElementIdCount(CLAY_MAX_ELEMENT_ID_COUNT);
     Clay_SetMaxMeasureTextCacheWordCount(CLAY_MAX_MEASURE_TEXT_CACHE_WORDS);
     uint64_t clay_memory = Clay_MinMemorySize();
     FURI_LOG_I(
         TAG,
-        "Clay arena: %llu bytes (~%llu KiB), elements=%u, text_cache=%u words",
+        "Clay arena: %llu bytes (~%llu KiB), elements=%u, ids=%u, text_cache=%u words",
         clay_memory,
         clay_memory / 1024,
         CLAY_MAX_ELEMENT_COUNT,
+        CLAY_MAX_ELEMENT_ID_COUNT,
         CLAY_MAX_MEASURE_TEXT_CACHE_WORDS);
     Clay_Arena arena = Clay_CreateArenaWithCapacityAndMemory(clay_memory, malloc(clay_memory));
     Clay_Initialize(arena, (Clay_Dimensions){JD9853_WIDTH, JD9853_HEIGHT}, (Clay_ErrorHandler){gui_handle_clay_errors, gui});

--- a/applications/services/gui/gui.c
+++ b/applications/services/gui/gui.c
@@ -12,9 +12,11 @@
 
 #define TAG "GuiSrv"
 
-/* Logs the live-entry high-water mark of Clay's element-id hashmap whenever a
- * new peak is reached - real data for sizing CLAY_MAX_ELEMENT_ID_COUNT. */
-// #define GUI_CLAY_DEBUG_ENABLE
+/* Logs high watermarks of Clay's capacity consumers whenever a new peak is
+ * reached: live element-id hashmap entries (for sizing
+ * CLAY_MAX_ELEMENT_ID_COUNT), per-frame layout elements (for sizing
+ * CLAY_MAX_ELEMENT_COUNT) and per-frame render commands. */
+// #define GUI_CLAY_DEBUG_WATERMARK_ENABLE
 
 #define GUI_INPUT_EVENT_QUEUE_SIZE       32
 #define GUI_INPUT_TOUCH_EVENT_QUEUE_SIZE 32
@@ -198,14 +200,30 @@ static void gui_redraw(Gui* gui) {
 
         Clay_RenderCommandArray renderCommands = Clay_EndLayout();
 
-#ifdef GUI_CLAY_DEBUG_ENABLE
+#ifdef GUI_CLAY_DEBUG_WATERMARK_ENABLE
         /* Clay_EndLayout has just evicted stale entries, so this is the live
          * count. Logging only upward moves keeps the log quiet in steady state. */
-        static int32_t clay_hashmap_high_water = 0;
+        static int32_t clay_hashmap_high_watermark = 0;
         int32_t clay_hashmap_live = Clay_GetLayoutElementHashMapLength();
-        if(clay_hashmap_live > clay_hashmap_high_water) {
-            clay_hashmap_high_water = clay_hashmap_live;
-            FURI_LOG_I(TAG, "clay id hashmap high water: %d/%d", (int)clay_hashmap_high_water, (int)Clay_GetLayoutElementHashMapCapacity());
+        if(clay_hashmap_live > clay_hashmap_high_watermark) {
+            clay_hashmap_high_watermark = clay_hashmap_live;
+            FURI_LOG_I(TAG, "clay id hashmap high watermark: %d/%d", (int)clay_hashmap_high_watermark, (int)Clay_GetLayoutElementHashMapCapacity());
+        }
+
+        /* Per-frame arrays, valid until the next Clay_BeginLayout. On overflow
+         * the element count saturates at capacity - the real demand is higher
+         * than the logged peak (a "clay error" line accompanies it). */
+        static int32_t clay_elements_high_watermark = 0;
+        int32_t clay_elements = Clay_GetLayoutElementCount();
+        if(clay_elements > clay_elements_high_watermark) {
+            clay_elements_high_watermark = clay_elements;
+            FURI_LOG_I(TAG, "clay elements high watermark: %d/%d", (int)clay_elements_high_watermark, (int)Clay_GetMaxElementCount());
+        }
+
+        static int32_t clay_commands_high_watermark = 0;
+        if(renderCommands.length > clay_commands_high_watermark) {
+            clay_commands_high_watermark = renderCommands.length;
+            FURI_LOG_I(TAG, "clay render commands high watermark: %d/%d", (int)clay_commands_high_watermark, (int)renderCommands.capacity);
         }
 #endif
 

--- a/applications/services/gui/gui.c
+++ b/applications/services/gui/gui.c
@@ -12,6 +12,10 @@
 
 #define TAG "GuiSrv"
 
+/* Logs the live-entry high-water mark of Clay's element-id hashmap whenever a
+ * new peak is reached - real data for sizing CLAY_MAX_ELEMENT_ID_COUNT. */
+// #define GUI_CLAY_DEBUG_ENABLE
+
 #define GUI_INPUT_EVENT_QUEUE_SIZE       32
 #define GUI_INPUT_TOUCH_EVENT_QUEUE_SIZE 32
 
@@ -21,11 +25,12 @@
  * - CLAY_MAX_ELEMENT_COUNT: per-frame ephemeral arrays (layoutElements,
  *   renderCommands, per-element configs) - reset every frame, so only the
  *   busiest single screen matters.
- * - CLAY_MAX_ELEMENT_ID_COUNT: session-persistent ID-keyed arrays (the
- *   element-id hashmap, text measurement cache) - never reset, so this must
- *   cover every distinct element ID ever seen across ALL screens/apps. */
+ * - CLAY_MAX_ELEMENT_ID_COUNT: ID-keyed arrays (the element-id hashmap, text
+ *   measurement cache). Hashmap entries are recycled once an id has not been
+ *   declared for a couple of frames, so this bounds ids live at the same time
+ *   (roughly: the busiest screen plus whatever composites over it). */
 #define CLAY_MAX_ELEMENT_COUNT            80
-#define CLAY_MAX_ELEMENT_ID_COUNT         256
+#define CLAY_MAX_ELEMENT_ID_COUNT         128
 #define CLAY_MAX_MEASURE_TEXT_CACHE_WORDS 256
 
 typedef struct {
@@ -192,6 +197,17 @@ static void gui_redraw(Gui* gui) {
         }
 
         Clay_RenderCommandArray renderCommands = Clay_EndLayout();
+
+#ifdef GUI_CLAY_DEBUG_ENABLE
+        /* Clay_EndLayout has just evicted stale entries, so this is the live
+         * count. Logging only upward moves keeps the log quiet in steady state. */
+        static int32_t clay_hashmap_high_water = 0;
+        int32_t clay_hashmap_live = Clay_GetLayoutElementHashMapLength();
+        if(clay_hashmap_live > clay_hashmap_high_water) {
+            clay_hashmap_high_water = clay_hashmap_live;
+            FURI_LOG_I(TAG, "clay id hashmap high water: %d/%d", (int)clay_hashmap_high_water, (int)Clay_GetLayoutElementHashMapCapacity());
+        }
+#endif
 
         clay_render_do_render(gui->render_canvas, &renderCommands);
 
@@ -374,16 +390,10 @@ static void gui_handle_clay_errors(Clay_ErrorData errorData) {
         }
     }
 
-    /* Dump the persistent element-id hashmap fill level so capacity overflows
-     * are diagnosable from the device log alone: once
-     * layoutElementsHashMapInternal fills up it stays full for the rest of the
-     * session, so the reported counts show how far CLAY_MAX_ELEMENT_ID_COUNT
-     * needs to grow. */
-    FURI_LOG_E(
-        TAG,
-        "clay state: hashmap=%d/%d",
-        (int)Clay_GetLayoutElementHashMapLength(),
-        (int)Clay_GetLayoutElementHashMapCapacity());
+    /* Dump the element-id hashmap fill level so capacity overflows are
+     * diagnosable from the device log alone: the reported live count shows how
+     * far CLAY_MAX_ELEMENT_ID_COUNT needs to grow. */
+    FURI_LOG_E(TAG, "clay state: hashmap=%d/%d", (int)Clay_GetLayoutElementHashMapLength(), (int)Clay_GetLayoutElementHashMapCapacity());
 }
 
 static void gui_input_logic(FuriEventLoopObject* object, void* context) {

--- a/applications/services/gui/modules/elements.c
+++ b/applications/services/gui/modules/elements.c
@@ -21,29 +21,33 @@ void elements_softkey_button_element(size_t index, const char* text, bool active
 
     const float offset_x = ((float)index - 2.0f) * (image->width + 4);
 
-    CLAY_AUTO_ID({
-        .layout =
-            {
-                .sizing = sizing,
-
-            },
-        .floating =
-            {
-                .offset = {.x = offset_x, .y = 0},
-                .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_BOTTOM, .parent = CLAY_ATTACH_POINT_CENTER_BOTTOM},
-                .attachTo = CLAY_ATTACH_TO_ROOT,
-                .zIndex = active ? 100 : 0,
-            },
-    }) {
-        CLAY_AUTO_ID({
+    CLAY(
+        CLAY_IDI_LOCAL("SoftkeyButton", index),
+        {
             .layout =
                 {
                     .sizing = sizing,
-                    .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
-                    .padding = {.left = 0, .right = 0, .top = 3, .bottom = 0},
+
                 },
-            .image = {.imageData = (void*)image},
+            .floating =
+                {
+                    .offset = {.x = offset_x, .y = 0},
+                    .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_BOTTOM, .parent = CLAY_ATTACH_POINT_CENTER_BOTTOM},
+                    .attachTo = CLAY_ATTACH_TO_ROOT,
+                    .zIndex = active ? 100 : 0,
+                },
         }) {
+        CLAY(
+            CLAY_IDI_LOCAL("SoftkeyButtonImage", index),
+            {
+                .layout =
+                    {
+                        .sizing = sizing,
+                        .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                        .padding = {.left = 0, .right = 0, .top = 3, .bottom = 0},
+                    },
+                .image = {.imageData = (void*)image},
+            }) {
             CLAY_TEXT(clay_helper_string_from_chars(text), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = pressed ? COLOR_WHITE : COLOR_BLACK}));
         }
     }

--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -73,7 +73,7 @@ static void menu_draw_item(MenuItem* item, size_t line_index, bool selected) {
                 .wrapMode = CLAY_TEXT_WRAP_NONE,
             }));
 
-        CLAY_AUTO_ID({.layout = {.sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)}}}){};
+        CLAY(CLAY_ID_LOCAL("Spacer"), {.layout = {.sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)}}}){};
 
         if(sub_label) {
             CLAY_TEXT(
@@ -86,41 +86,53 @@ static void menu_draw_item(MenuItem* item, size_t line_index, bool selected) {
         }
 
         if(selected) {
-            CLAY_AUTO_ID({
-                .layout = {.sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(MENU_LINE_HEIGHT + 1)}},
-                .floating =
-                    {
-                        .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_TOP, .parent = CLAY_ATTACH_POINT_CENTER_TOP},
-                        .attachTo = CLAY_ATTACH_TO_PARENT,
-                    },
-                .border =
-                    {
-                        .color = COLOR_BLACK,
-                        .width = {.bottom = 2, .top = 1},
-                    },
-            }){};
+            /* Explicit, menu/row-independent IDs: only one item can ever be
+             * selected at a time, so these always occupy the same fixed slot
+             * in Clay's persistent element-id hashmap instead of a new one
+             * derived from (row index, sibling offset) - the latter churns
+             * through unique IDs as different rows/menus get selected over
+             * the session and eventually exhausts that hashmap for good. */
+            CLAY(
+                CLAY_ID("MenuSelectionBorder"),
+                {
+                    .layout = {.sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(MENU_LINE_HEIGHT + 1)}},
+                    .floating =
+                        {
+                            .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_TOP, .parent = CLAY_ATTACH_POINT_CENTER_TOP},
+                            .attachTo = CLAY_ATTACH_TO_PARENT,
+                        },
+                    .border =
+                        {
+                            .color = COLOR_BLACK,
+                            .width = {.bottom = 2, .top = 1},
+                        },
+                }){};
 
             const Image* left_border = &menu_border_left;
             const Image* right_border = &menu_border_right;
 
-            CLAY_AUTO_ID({
-                .layout = {.sizing = {.height = CLAY_SIZING_FIXED(left_border->height), .width = CLAY_SIZING_FIXED(left_border->width)}},
-                .floating =
-                    {
-                        .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_TOP, .parent = CLAY_ATTACH_POINT_LEFT_TOP},
-                        .attachTo = CLAY_ATTACH_TO_PARENT,
-                    },
-                .image = {.imageData = (void*)left_border},
-            }){};
-            CLAY_AUTO_ID({
-                .layout = {.sizing = {.height = CLAY_SIZING_FIXED(right_border->height), .width = CLAY_SIZING_FIXED(right_border->width)}},
-                .floating =
-                    {
-                        .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_TOP, .parent = CLAY_ATTACH_POINT_RIGHT_TOP},
-                        .attachTo = CLAY_ATTACH_TO_PARENT,
-                    },
-                .image = {.imageData = (void*)right_border},
-            }){};
+            CLAY(
+                CLAY_ID("MenuSelectionLeftCorner"),
+                {
+                    .layout = {.sizing = {.height = CLAY_SIZING_FIXED(left_border->height), .width = CLAY_SIZING_FIXED(left_border->width)}},
+                    .floating =
+                        {
+                            .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_TOP, .parent = CLAY_ATTACH_POINT_LEFT_TOP},
+                            .attachTo = CLAY_ATTACH_TO_PARENT,
+                        },
+                    .image = {.imageData = (void*)left_border},
+                }){};
+            CLAY(
+                CLAY_ID("MenuSelectionRightCorner"),
+                {
+                    .layout = {.sizing = {.height = CLAY_SIZING_FIXED(right_border->height), .width = CLAY_SIZING_FIXED(right_border->width)}},
+                    .floating =
+                        {
+                            .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_TOP, .parent = CLAY_ATTACH_POINT_RIGHT_TOP},
+                            .attachTo = CLAY_ATTACH_TO_PARENT,
+                        },
+                    .image = {.imageData = (void*)right_border},
+                }){};
         }
     }
 }
@@ -163,16 +175,18 @@ static void menu_draw_scrollbar(MenuViewModel* model) {
             .image = {.imageData = (void*)&scrollbar_background},
         }) {
         if(model->show_scrollbar) {
-            CLAY_AUTO_ID({
-                .backgroundColor = COLOR_BLACK,
-                .layout = {.sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_PERCENT(model->scrollbar_len)}},
-                .floating =
-                    {
-                        .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_TOP, .parent = CLAY_ATTACH_POINT_CENTER_TOP},
-                        .attachTo = CLAY_ATTACH_TO_PARENT,
-                        .offset = {.y = model->scrollbar_offset + 1},
-                    },
-            }){};
+            CLAY(
+                CLAY_ID("ScrollbarThumb"),
+                {
+                    .backgroundColor = COLOR_BLACK,
+                    .layout = {.sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_PERCENT(model->scrollbar_len)}},
+                    .floating =
+                        {
+                            .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_TOP, .parent = CLAY_ATTACH_POINT_CENTER_TOP},
+                            .attachTo = CLAY_ATTACH_TO_PARENT,
+                            .offset = {.y = model->scrollbar_offset + 1},
+                        },
+                }){};
         }
     }
 }
@@ -181,31 +195,35 @@ static bool menu_layout_callback(void* _model) {
     MenuViewModel* model = _model;
     furi_assert(model);
 
-    CLAY_AUTO_ID({
-        .backgroundColor = COLOR_WHITE,
-        .layout =
-            {
-                .layoutDirection = CLAY_TOP_TO_BOTTOM,
-                .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
-                .childAlignment = {.x = CLAY_ALIGN_X_LEFT, .y = CLAY_ALIGN_Y_TOP},
-                .padding = {.left = 4, .right = 1, .top = 2, .bottom = 2},
-                .childGap = 2,
-            },
-    }) {
-        if(model->title) {
-            CLAY_TEXT(clay_helper_string_from_chars(model->title), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_GRAY}));
-        }
-        CLAY_AUTO_ID({
+    CLAY(
+        CLAY_APP_ID("Root"),
+        {
             .backgroundColor = COLOR_WHITE,
             .layout =
                 {
-                    .layoutDirection = CLAY_LEFT_TO_RIGHT,
+                    .layoutDirection = CLAY_TOP_TO_BOTTOM,
                     .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
                     .childAlignment = {.x = CLAY_ALIGN_X_LEFT, .y = CLAY_ALIGN_Y_TOP},
-                    .padding = {.left = 4, .right = 0, .top = 0, .bottom = 0},
-                    .childGap = 9,
+                    .padding = {.left = 4, .right = 1, .top = 2, .bottom = 2},
+                    .childGap = 2,
                 },
         }) {
+        if(model->title) {
+            CLAY_TEXT(clay_helper_string_from_chars(model->title), CLAY_TEXT_CONFIG({.fontId = FontBody, .textColor = COLOR_GRAY}));
+        }
+        CLAY(
+            CLAY_APP_ID("Content"),
+            {
+                .backgroundColor = COLOR_WHITE,
+                .layout =
+                    {
+                        .layoutDirection = CLAY_LEFT_TO_RIGHT,
+                        .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
+                        .childAlignment = {.x = CLAY_ALIGN_X_LEFT, .y = CLAY_ALIGN_Y_TOP},
+                        .padding = {.left = 4, .right = 0, .top = 0, .bottom = 0},
+                        .childGap = 9,
+                    },
+            }) {
             menu_draw_item_list(model);
             menu_draw_scrollbar(model);
         }

--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -88,10 +88,9 @@ static void menu_draw_item(MenuItem* item, size_t line_index, bool selected) {
         if(selected) {
             /* Explicit, menu/row-independent IDs: only one item can ever be
              * selected at a time, so these always occupy the same fixed slot
-             * in Clay's persistent element-id hashmap instead of a new one
-             * derived from (row index, sibling offset) - the latter churns
-             * through unique IDs as different rows/menus get selected over
-             * the session and eventually exhausts that hashmap for good. */
+             * in Clay's element-id hashmap instead of a new one derived from
+             * (row index, sibling offset) - the latter churns through unique
+             * IDs as different rows/menus get selected. */
             CLAY(
                 CLAY_ID("MenuSelectionBorder"),
                 {

--- a/applications/services/gui/modules/popup_menu.c
+++ b/applications/services/gui/modules/popup_menu.c
@@ -54,41 +54,49 @@ static void popup_menu_draw_item(PopupMenuItem* item, size_t line_index, bool se
             }));
 
         if(selected) {
-            CLAY_AUTO_ID({
-                .layout = {.sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(MENU_LINE_HEIGHT + 1)}},
-                .floating =
-                    {
-                        .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_TOP, .parent = CLAY_ATTACH_POINT_CENTER_TOP},
-                        .attachTo = CLAY_ATTACH_TO_PARENT,
-                    },
-                .border =
-                    {
-                        .color = COLOR_BLACK,
-                        .width = {.bottom = 2, .top = 1},
-                    },
-            }){};
+            /* Explicit, item-independent IDs: only one popup item can ever be
+             * selected at a time, mirroring the same fix applied to menu.c. */
+            CLAY(
+                CLAY_ID("PopupMenuSelectionBorder"),
+                {
+                    .layout = {.sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(MENU_LINE_HEIGHT + 1)}},
+                    .floating =
+                        {
+                            .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_TOP, .parent = CLAY_ATTACH_POINT_CENTER_TOP},
+                            .attachTo = CLAY_ATTACH_TO_PARENT,
+                        },
+                    .border =
+                        {
+                            .color = COLOR_BLACK,
+                            .width = {.bottom = 2, .top = 1},
+                        },
+                }){};
 
             const Image* left_border = &popup_menu_border_left;
             const Image* right_border = &popup_menu_border_right;
 
-            CLAY_AUTO_ID({
-                .layout = {.sizing = {.height = CLAY_SIZING_FIXED(left_border->height), .width = CLAY_SIZING_FIXED(left_border->width)}},
-                .floating =
-                    {
-                        .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_TOP, .parent = CLAY_ATTACH_POINT_LEFT_TOP},
-                        .attachTo = CLAY_ATTACH_TO_PARENT,
-                    },
-                .image = {.imageData = (void*)left_border},
-            }){};
-            CLAY_AUTO_ID({
-                .layout = {.sizing = {.height = CLAY_SIZING_FIXED(right_border->height), .width = CLAY_SIZING_FIXED(right_border->width)}},
-                .floating =
-                    {
-                        .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_TOP, .parent = CLAY_ATTACH_POINT_RIGHT_TOP},
-                        .attachTo = CLAY_ATTACH_TO_PARENT,
-                    },
-                .image = {.imageData = (void*)right_border},
-            }){};
+            CLAY(
+                CLAY_ID("PopupMenuSelectionLeftCorner"),
+                {
+                    .layout = {.sizing = {.height = CLAY_SIZING_FIXED(left_border->height), .width = CLAY_SIZING_FIXED(left_border->width)}},
+                    .floating =
+                        {
+                            .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_TOP, .parent = CLAY_ATTACH_POINT_LEFT_TOP},
+                            .attachTo = CLAY_ATTACH_TO_PARENT,
+                        },
+                    .image = {.imageData = (void*)left_border},
+                }){};
+            CLAY(
+                CLAY_ID("PopupMenuSelectionRightCorner"),
+                {
+                    .layout = {.sizing = {.height = CLAY_SIZING_FIXED(right_border->height), .width = CLAY_SIZING_FIXED(right_border->width)}},
+                    .floating =
+                        {
+                            .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_TOP, .parent = CLAY_ATTACH_POINT_RIGHT_TOP},
+                            .attachTo = CLAY_ATTACH_TO_PARENT,
+                        },
+                    .image = {.imageData = (void*)right_border},
+                }){};
         }
     }
 }
@@ -120,15 +128,17 @@ static void popup_menu_draw_item_list(PopupMenuViewModel* model) {
 
 static void popup_menu_draw_title(const char* title) {
     if(title) {
-        CLAY_AUTO_ID({
-            .backgroundColor = (Clay_Color){0xFF, 0xFF, 0xFF, 0xFF / 2},
-            .layout =
-                {
-                    .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
-                    .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
-                    .padding = {.left = 8, .right = 7, .top = 1, .bottom = 0},
-                },
-        }) {
+        CLAY(
+            CLAY_APP_ID("Title"),
+            {
+                .backgroundColor = (Clay_Color){0xFF, 0xFF, 0xFF, 0xFF / 2},
+                .layout =
+                    {
+                        .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                        .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
+                        .padding = {.left = 8, .right = 7, .top = 1, .bottom = 0},
+                    },
+            }) {
             CLAY_TEXT(clay_helper_string_from_chars(title), CLAY_TEXT_CONFIG({.fontId = FontBig, .textColor = COLOR_BLACK}));
         }
     }
@@ -142,38 +152,42 @@ static bool popup_menu_layout_callback(void* _model) {
         return false;
     }
 
-    CLAY_AUTO_ID({
-        .backgroundColor = (Clay_Color){0xFF, 0xFF, 0xFF, 0xFF / 2},
-        .layout =
-            {
-                .layoutDirection = CLAY_TOP_TO_BOTTOM,
-                .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
-                .childAlignment = {.x = CLAY_ALIGN_X_LEFT, .y = CLAY_ALIGN_Y_TOP},
-            },
-        .floating =
-            {
-                .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_TOP, .parent = CLAY_ATTACH_POINT_LEFT_TOP},
-                .attachTo = CLAY_ATTACH_TO_ROOT,
-            },
-    }) {
-        CLAY_AUTO_ID({
-            .backgroundColor = COLOR_WHITE,
+    CLAY(
+        CLAY_APP_ID("Overlay"),
+        {
+            .backgroundColor = (Clay_Color){0xFF, 0xFF, 0xFF, 0xFF / 2},
             .layout =
                 {
                     .layoutDirection = CLAY_TOP_TO_BOTTOM,
-                    .sizing = {.width = CLAY_SIZING_FIT(0), .height = CLAY_SIZING_FIT(0)},
-                    .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
-                    .padding = {.left = 7, .right = 7, .top = 3, .bottom = 3},
-                    .childGap = 4,
+                    .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_GROW(0)},
+                    .childAlignment = {.x = CLAY_ALIGN_X_LEFT, .y = CLAY_ALIGN_Y_TOP},
                 },
             .floating =
                 {
-                    .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_CENTER, .parent = CLAY_ATTACH_POINT_CENTER_CENTER},
+                    .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_TOP, .parent = CLAY_ATTACH_POINT_LEFT_TOP},
                     .attachTo = CLAY_ATTACH_TO_ROOT,
                 },
-            .border = {.color = COLOR_BLACK, .width = {.top = 1, .left = 1, .right = 1, .bottom = 1}},
-            .cornerRadius = CLAY_CORNER_RADIUS(5),
         }) {
+        CLAY(
+            CLAY_APP_ID("Dialog"),
+            {
+                .backgroundColor = COLOR_WHITE,
+                .layout =
+                    {
+                        .layoutDirection = CLAY_TOP_TO_BOTTOM,
+                        .sizing = {.width = CLAY_SIZING_FIT(0), .height = CLAY_SIZING_FIT(0)},
+                        .childAlignment = {.x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER},
+                        .padding = {.left = 7, .right = 7, .top = 3, .bottom = 3},
+                        .childGap = 4,
+                    },
+                .floating =
+                    {
+                        .attachPoints = {.element = CLAY_ATTACH_POINT_CENTER_CENTER, .parent = CLAY_ATTACH_POINT_CENTER_CENTER},
+                        .attachTo = CLAY_ATTACH_TO_ROOT,
+                    },
+                .border = {.color = COLOR_BLACK, .width = {.top = 1, .left = 1, .right = 1, .bottom = 1}},
+                .cornerRadius = CLAY_CORNER_RADIUS(5),
+            }) {
             popup_menu_draw_title(model->title);
             popup_menu_draw_item_list(model);
         }


### PR DESCRIPTION
# What's new

# Fix silent Clay UI breakage: stable element IDs, split capacity limits, and overflow diagnostics

## Summary

This PR fixes a class of bugs where the GUI would silently break rendering (missing borders, backgrounds, and elements) with no errors logged. The root cause was threefold, all related to how element IDs and internal arrays are managed in the vendored Clay layout library. The GUI is now stable across all screens and apps, uses ~79 KiB for the Clay arena (was ~210 KiB), and any future capacity issue is reported in the log with full details.

## Problems

1. **Silent capacity overflow.** Some of Clay's internal arrays overflowed without ever invoking the error handler — the error was rendered as off-screen text (per-frame element array) or simply returned `NULL` (persistent element-ID hashmap). The UI broke silently.
2. **Unbounded session growth.** Clay's element-ID hashmap (`layoutElementsHashMapInternal`) is **never reset** for the whole session. `CLAY_AUTO_ID` derives an element's ID from its sibling offset + parent, so IDs churned whenever conditional branches, selection state, or different screens changed the structure — permanently exhausting the hashmap. Note that `CLAY_TEXT` elements are hashmap entries too (keyed by child offset + parent ID).
3. **Broken local-ID scoping.** In this fork, `CLAY(id, ...)` evaluates the ID *before* the element is opened. Combined with upstream's `Clay__GetParentElementId()` (which reads `stack[length - 2]`), `CLAY_ID_LOCAL` hashed against the **grandparent** instead of the parent. This produced per-frame duplicate-ID errors, e.g. all menu items' `Spacer` elements hashed against the shared `MenuItems` container.

## Changes

### `applications/services/gui/clay.h` (vendored Clay fork)

- Added edge-triggered error-handler invocations for the per-frame element array overflow (`Clay__WarnElementCapacityExceeded`) and the persistent element-ID hashmap overflow (`Clay__AddHashMapItem`).
- New fork API `Clay_SetMaxElementIdCount()` / `Clay_GetMaxElementIdCount()`: decouples the **session-persistent** ID-keyed arrays (element-ID hashmap, text measurement cache, debug data) from the **per-frame** `maxElementCount` arrays. `Clay_Context`, `Clay_Initialize()`, and `Clay_MinMemorySize()` updated accordingly.
- New diagnostics API `Clay_GetLayoutElementHashMapLength()` / `Clay_GetLayoutElementHashMapCapacity()`.
- Extended `Clay_ErrorData` with `elementId`, `elementBaseId`, `elementOffset`, and `elementStringId` so duplicate-ID errors can be decoded from the log alone.
- Fixed `Clay__GetParentElementId()` to return the **open element's** ID (the real parent), restoring correct parent scoping for `CLAY_ID_LOCAL` / `CLAY_IDI_LOCAL`.

### `applications/services/gui/gui.c`

- Split limits: `CLAY_MAX_ELEMENT_COUNT = 80` (per frame, the busiest screen) and `CLAY_MAX_ELEMENT_ID_COUNT = 256` (whole session, all screens/apps ever shown).
- Error handler now logs the duplicate element's numeric ID, base, offset, string label, and the hashmap fill state (`clay state: hashmap=N/M`).

### GUI widgets and views — `CLAY_AUTO_ID` → explicit stable IDs

- `modules/menu.c`: selection border + corner overlays, scrollbar thumb, root/content containers; item spacer uses `CLAY_ID_LOCAL`.
- `modules/popup_menu.c`: selection overlays, overlay/dialog/title containers (same pattern as `menu.c`).
- `modules/elements.c`: softkeys use `CLAY_IDI_LOCAL("SoftkeyButton"/"SoftkeyButtonImage", index)`.
- `clay_helper.c`: `clay_fixed_image()` uses `CLAY_ID_LOCAL("FixedImage")`.
- `debug/keypad_test/keypad_test.c`, `debug/haptic_test/haptic_test.c`: button/empty helpers take an explicit `Clay_ElementId`; all rows and keys have stable `CLAY_APP_ID`s (dynamic labels such as the exit countdown no longer affect IDs).
- `debug/font_test/font_test.c`: loop rows use `CLAY_IDI(TAG "GlyphRow", i)`.
- `debug/touchpad_test/touchpad_test.c`, `main/cpu/cpu_app.c`, `main/self_check/self_check.c`, `services/desktop/scenes/desktop_scene.c`, `services/desktop/scenes/header.c`: explicit IDs.

## Verification

- Boot log: `Clay arena: 81232 bytes (~79 KiB), elements=80, ids=256` (previously ~210 KiB at 256/256).
- Full navigation tested on hardware: Desktop, Settings/Testing/LEDs/Display/Power menus, Self Check, Keypad Test, Touchpad Test, Haptic Test.
- Zero `clay error` lines in the log; no duplicate-ID errors; no hashmap overflow.
- Free heap stable at ~217 KB across app launches; `allocation balance: 0` for every app (no leaks).
- Any future capacity problem will be visible in the log with the exact offending element and hashmap fill level.

---

## Developer guide: Clay element IDs for new UI code

### Why IDs matter here

Clay keeps a **session-persistent hashmap** of every element ID it has ever seen (never reset until reboot). Each element — containers **and** text elements — adds one entry. The only way to keep it bounded is to make every ID **stable**: the same logical element must produce the same ID on every frame and in every screen, for the whole session.

### ID macros and when to use them

| Macro | Namespace | Use for |
| --- | --- | --- |
| `CLAY(id, ...)` | explicit | Declaring any element with an explicit ID (this fork's `CLAY` takes the ID as the first argument) |
| `CLAY_APP_ID("Name")` | global + file `TAG` prefix | Root/container elements of an app or screen — preferred default for app-specific elements |
| `CLAY_ID("Label")` | global (string only) | True singletons shared across the project (e.g. the single menu selection overlay). The same string anywhere in the firmware resolves to the **same** ID |
| `CLAY_IDI("Label", i)` | global + index | Loops of globally unique elements |
| `CLAY_ID_LOCAL("Label")` | scoped to the current parent | Reusable widgets/helpers (`clay_fixed_image()`, softkeys). The same label may repeat under different parents |
| `CLAY_IDI_LOCAL("Label", i)` | scoped to parent + index | Reusable widgets inside a loop |
| `CLAY_SID` / `CLAY_SIDI` / `CLAY_SID_LOCAL` / `CLAY_SIDI_LOCAL` | as above | Same, but for runtime-constructed (non-literal) strings |
| `CLAY_AUTO_ID(...)` | — | **Do not use in application code** (removed project-wide). Its ID depends on sibling position + parent, changes with conditional branches/screens, and permanently grows the session hashmap. It remains only inside the vendored Clay debug view |

### Rules

1. **Every element gets an explicit, stable ID.** Never derive an ID from dynamic content (e.g. a countdown value).
2. **`CLAY_APP_ID` for app roots**, `CLAY_ID_LOCAL` / `CLAY_IDI_LOCAL` for reusable widgets, `CLAY_IDI` for loops.
3. **Text elements** get an automatic ID from (child position, parent ID):
   - Changing the text content does *not* change the ID — dynamic labels are safe.
   - Never let two `CLAY_TEXT` calls in *different branches* of the same parent occupy the same child position — wrap each branch in its own element with an explicit ID.
4. **`CLAY_ID_LOCAL` must be unique among siblings of the same parent.** In loops always use the indexed `CLAY_IDI_LOCAL`. (Note: this fork hashes the local ID with the element it is nested inside — the parent.)
5. **Capacity budgets**:
   - `CLAY_MAX_ELEMENT_COUNT` (80) — per-frame budget. Sized for the busiest single screen.
   - `CLAY_MAX_ELEMENT_ID_COUNT` (256) — whole-session budget of distinct IDs across **all** screens/apps ever shown. With stable IDs it never grows after every screen has been visited once. Keep the total inventory in mind when adding new apps.

### Debugging

On any ID problem, the log explains it precisely:

- `clay duplicate element id: N (base=B, offset=O)` + string label — which element collides.
- `clay state: hashmap=N/M` — persistent hashmap fill level (capacity exceeded when `N` reaches `M - 1`).
- `clay error: ...capacity...` — which internal array overflowed.



# Verification 

- [ Describe how to verify changes ]

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
