### PR TITLE
Desktop: start/stop app from CLI

### DIFF
--- a/applications/applications.c
+++ b/applications/applications.c
@@ -28,6 +28,7 @@ extern int32_t font_test_app(void* p);
 extern int32_t cli_on_system_start(void* p);
 extern int32_t rpc_on_system_start(void* p);
 extern int32_t dmesg_app(void* p);
+extern int32_t cpu_app(void* p);
 
 
 // CLI commands
@@ -37,6 +38,7 @@ extern void uart_echo_cli(PipeSide* pipe, FuriString* args, void* context);
 extern void dmesg_cli(PipeSide* pipe, FuriString* args, void* context);
 extern void input_cli_command(PipeSide* pipe, FuriString* args, void* context);
 extern void unit_tests_cli_command(PipeSide* pipe, FuriString* args, void* context);
+extern void desktop_command_cli(PipeSide* pipe, FuriString* args, void* context);
 
 const FlipperInternalApplication FLIPPER_SERVICES[] = {
     {
@@ -190,6 +192,22 @@ const FlipperInternalApplication FLIPPER_APPS[] = {
         .stack_size = 2048,
         .flags = FlipperInternalApplicationFlagDefault,
     },
+    {
+        .app = cpu_app,
+        .name = "CPU App Start",
+        .appid = "cpu_app_start",
+        .stack_size = 1024 * 4,
+        .flags = FlipperInternalApplicationFlagDefault,
+        .args = "start",
+    },
+    {
+        .app = cpu_app,
+        .name = "CPU App Maskrom",
+        .appid = "cpu_app_maskrom",
+        .stack_size = 1024 * 4,
+        .flags = FlipperInternalApplicationFlagDefault,
+        .args = "maskrom",
+    },
 };
 const size_t FLIPPER_APPS_COUNT = COUNT_OF(FLIPPER_APPS);
 
@@ -259,6 +277,12 @@ const FlipperInternalCommandApplication FLIPPER_CLI_COMMANDS[] = {
     {
         .callback = unit_tests_cli_command,
         .name = "unit_tests",
+        .stack_size = 1024 * 2,
+        .flags = CliCommandFlagParallelSafe,
+    },
+    {
+        .callback = desktop_command_cli,
+        .name = "desktop",
         .stack_size = 1024 * 2,
         .flags = CliCommandFlagParallelSafe,
     },

--- a/applications/main/cpu/cpu_app.c
+++ b/applications/main/cpu/cpu_app.c
@@ -141,9 +141,6 @@ static void cpu_app_model_apply(CpuApp* instance, bool (*callback)(CpuAppModel* 
     with_view_model(instance->display_view, CpuAppModel * model, { update = callback(model, context); }, update);
 }
 
-/* Reset the CPU and power hardware to a clean state. Runs on every app exit
- * path (menu "Stop", desktop stop_app, etc.) to make sure the CPU is never
- * left running behind the desktop. */
 static void cpu_app_do_shutdown(CpuApp* instance) {
     furi_hal_reset_pd_and_charger();
     furi_bsp_linux_reset();
@@ -163,7 +160,6 @@ static void __isr __not_in_flash_func(cpu_app_pio_get_frame_isr)(uint8_t* data, 
             },
     };
 
-    //furi_check(furi_message_queue_put(instance->app_queue, &message, 0) == FuriStatusOk);
     if(furi_message_queue_put(instance->app_queue, &message, 0) != FuriStatusOk) {
         FURI_LOG_E(TAG, "cpu_app_spi_get_frame_isr message = %ld", furi_message_queue_get_count(instance->app_queue));
     }
@@ -274,9 +270,6 @@ static CpuApp* cpu_app_alloc(void) {
 }
 
 static void cpu_app_free(CpuApp* instance) {
-    // Drop any pending frame before freeing the buffers it points to,
-    // otherwise a later redraw would blit freed memory.
-    gui_clear_frame(instance->gui);
 
     gui_set_menu(instance->gui, NULL);
     gui_remove_view(instance->gui, instance->display_view);
@@ -292,8 +285,7 @@ static void cpu_app_free(CpuApp* instance) {
     furi_event_loop_free(instance->event_loop);
     furi_message_queue_free(instance->app_queue);
     pio_get_frame_deinit(instance->pio_get_frame);
-    // Safety: clear a frame that may have been pushed between the first
-    // clear and the PIO deinit (no pushes are possible after deinit).
+
     gui_clear_frame(instance->gui);
     free(instance);
 }
@@ -314,8 +306,7 @@ int32_t cpu_app(void* p) {
     }
 
     furi_event_loop_run(instance->event_loop);
-    // Clean up the hardware on every exit path (menu "Stop", desktop stop_app,
-    // etc.) so the CPU never keeps running behind the desktop.
+
     cpu_app_do_shutdown(instance);
     cpu_app_free(instance);
     return 0;

--- a/applications/main/cpu/cpu_app.c
+++ b/applications/main/cpu/cpu_app.c
@@ -141,6 +141,16 @@ static void cpu_app_model_apply(CpuApp* instance, bool (*callback)(CpuAppModel* 
     with_view_model(instance->display_view, CpuAppModel * model, { update = callback(model, context); }, update);
 }
 
+/* Reset the CPU and power hardware to a clean state. Runs on every app exit
+ * path (menu "Stop", desktop stop_app, etc.) to make sure the CPU is never
+ * left running behind the desktop. */
+static void cpu_app_do_shutdown(CpuApp* instance) {
+    furi_hal_reset_pd_and_charger();
+    furi_bsp_linux_reset();
+    // Do not leave the old frame on screen after the app exits.
+    gui_clear_frame(instance->gui);
+}
+
 static void __isr __not_in_flash_func(cpu_app_pio_get_frame_isr)(uint8_t* data, size_t size, void* context) {
     CpuApp* instance = context;
 
@@ -178,11 +188,14 @@ static void cpu_app_message_logic(FuriEventLoopObject* object, void* context) {
             furi_bsp_linux_reset();
             furi_bsp_linux_start();
             instance->skip_frames = 2;
+            // Drop the stale frame so the screen shows the "starting" image
+            // right away instead of the old picture.
+            gui_clear_frame(instance->gui);
             cpu_app_model_apply(instance, cpu_app_model_init, NULL);
             break;
         case CpuAppMessageTypeShutdown:
-            furi_hal_reset_pd_and_charger();
-            furi_bsp_linux_reset();
+            // The actual hardware cleanup happens in cpu_app_do_shutdown()
+            // after the event loop exits, so it covers every exit path.
             furi_thread_signal(furi_thread_get_current(), FuriSignalExit, NULL);
             break;
         case CpuAppMessageTypeMaskrom:
@@ -261,6 +274,10 @@ static CpuApp* cpu_app_alloc(void) {
 }
 
 static void cpu_app_free(CpuApp* instance) {
+    // Drop any pending frame before freeing the buffers it points to,
+    // otherwise a later redraw would blit freed memory.
+    gui_clear_frame(instance->gui);
+
     gui_set_menu(instance->gui, NULL);
     gui_remove_view(instance->gui, instance->display_view);
     gui_remove_view(instance->gui, instance->menu_view);
@@ -275,6 +292,9 @@ static void cpu_app_free(CpuApp* instance) {
     furi_event_loop_free(instance->event_loop);
     furi_message_queue_free(instance->app_queue);
     pio_get_frame_deinit(instance->pio_get_frame);
+    // Safety: clear a frame that may have been pushed between the first
+    // clear and the PIO deinit (no pushes are possible after deinit).
+    gui_clear_frame(instance->gui);
     free(instance);
 }
 
@@ -294,6 +314,9 @@ int32_t cpu_app(void* p) {
     }
 
     furi_event_loop_run(instance->event_loop);
+    // Clean up the hardware on every exit path (menu "Stop", desktop stop_app,
+    // etc.) so the CPU never keeps running behind the desktop.
+    cpu_app_do_shutdown(instance);
     cpu_app_free(instance);
     return 0;
 }

--- a/applications/main/self_check/self_check.c
+++ b/applications/main/self_check/self_check.c
@@ -226,7 +226,6 @@ static void self_check_app_autorun(void) {
     desktop_register_app("self_check", furi_thread_get_current());
 
     if(!self_check_process(NULL)) {
-        // Something is missing: keep running to notify the user.
         self_check_app_main();
     }
 

--- a/applications/main/self_check/self_check.c
+++ b/applications/main/self_check/self_check.c
@@ -9,6 +9,7 @@
 #include <pd/pd.h>
 #include <usb_mux/usb_mux.h>
 #include <assets.h>
+#include <desktop/desktop.h>
 
 #define TAG "SelfCheck"
 
@@ -220,9 +221,16 @@ static void self_check_app_main(void) {
 static void self_check_app_autorun(void) {
     FURI_LOG_I(TAG, "Starting self check autorun");
 
+    // Occupy the desktop app slot right away: no other app can be started
+    // via desktop while we are running (and desktop can stop us on demand).
+    desktop_register_app("self_check", furi_thread_get_current());
+
     if(!self_check_process(NULL)) {
+        // Something is missing: keep running to notify the user.
         self_check_app_main();
     }
+
+    desktop_unregister_app("self_check");
 }
 
 int32_t self_check_app(void* p) {

--- a/applications/main/self_check/self_check.c
+++ b/applications/main/self_check/self_check.c
@@ -223,7 +223,9 @@ static void self_check_app_autorun(void) {
 
     // Occupy the desktop app slot right away: no other app can be started
     // via desktop while we are running (and desktop can stop us on demand).
-    desktop_register_app("self_check", furi_thread_get_current());
+    if(!desktop_register_app("self_check", furi_thread_get_current())) {
+        FURI_LOG_E(TAG, "Failed to register with desktop");
+    }
 
     if(!self_check_process(NULL)) {
         self_check_app_main();

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -18,13 +18,18 @@
 
 typedef enum {
     DesktopMessageTypeAppStart,
+    DesktopMessageTypeAppStop,
     DesktopMessageTypeAppClosed,
+    DesktopMessageTypeAppRegister,
+    DesktopMessageTypeAppUnregister,
 } DesktopMessageType;
 
 typedef struct {
     DesktopMessageType type;
     const FlipperInternalApplication* app;
     const char* args;
+    const char* appid;
+    FuriThread* thread;
 } DesktopAppMessage;
 
 typedef struct {
@@ -34,8 +39,10 @@ typedef struct {
 
 typedef struct {
     bool running;
+    bool external;
     char* args;
     FuriThread* thread;
+    const char* name;
 } DesktopApp;
 
 struct Desktop {
@@ -112,6 +119,7 @@ static void desktop_do_app_closed(Desktop* desktop) {
 
     furi_thread_free(desktop->app.thread);
     desktop->app.thread = NULL;
+    desktop->app.name = NULL;
 
     FURI_LOG_I(TAG, "Application stopped. Free heap: %zu", memmgr_get_free_heap());
 }
@@ -130,13 +138,47 @@ static void desktop_app_message_logic(FuriEventLoopObject* object, void* context
             FURI_LOG_E(TAG, "App start requested, but another app is already running");
         } else {
             desktop->app.running = true;
+            desktop->app.external = false;
+            desktop->app.name = message.app->name;
             desktop_start_internal_app(desktop, message.app, message.args);
+        }
+        break;
+    case DesktopMessageTypeAppStop:
+        if(desktop->app.running) {
+            FURI_LOG_I(TAG, "App stop requested, sending exit signal");
+            if(!furi_thread_signal(desktop->app.thread, FuriSignalExit, NULL)) {
+                FURI_LOG_W(TAG, "App did not consume the exit signal");
+            }
         }
         break;
     case DesktopMessageTypeAppClosed:
         furi_check(desktop->app.running);
         desktop_do_app_closed(desktop);
         desktop->app.running = false;
+        desktop->app.external = false;
+        break;
+    case DesktopMessageTypeAppRegister:
+        if(desktop->app.running) {
+            FURI_LOG_E(TAG, "App register requested, but another app is already running: %s", message.appid);
+        } else {
+            desktop->app.running = true;
+            desktop->app.external = true;
+            desktop->app.thread = message.thread;
+            desktop->app.name = message.appid;
+            FURI_LOG_I(TAG, "App registered as running: %s", message.appid);
+        }
+        break;
+    case DesktopMessageTypeAppUnregister:
+        if(desktop->app.running && desktop->app.external) {
+            FURI_LOG_I(TAG, "Registered app exiting: %s", message.appid);
+            desktop_do_app_closed(desktop);
+            desktop->app.running = false;
+            desktop->app.external = false;
+        } else if(desktop->app.running) {
+            FURI_LOG_W(TAG, "Unregister requested for desktop-managed app %s, ignoring", message.appid);
+        } else {
+            FURI_LOG_W(TAG, "Unregister requested for %s, but no app is running", message.appid);
+        }
         break;
     default:
         furi_assert(false);
@@ -234,6 +276,9 @@ static Desktop* desktop_alloc(void) {
     desktop->power_update_timer =
         furi_event_loop_timer_alloc(desktop->event_loop, desktop_power_update_timer_callback, FuriEventLoopTimerTypePeriodic, desktop);
 
+    desktop->app.running = false;
+    desktop->app.external = false;
+
     furi_event_loop_subscribe_message_queue(desktop->event_loop, desktop->app_message_queue, FuriEventLoopEventIn, desktop_app_message_logic, desktop);
     furi_event_loop_subscribe_message_queue(desktop->event_loop, desktop->scene_event_message_queue, FuriEventLoopEventIn, desktop_scene_event_logic, desktop);
 
@@ -281,6 +326,14 @@ bool desktop_start_app(const FlipperInternalApplication* app) {
     furi_assert(app);
 
     Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+
+    if(desktop->app.running) {
+        FURI_LOG_E(
+            TAG, "App start requested for %s, but %s is already running", app->appid, desktop->app.name);
+        furi_record_close(RECORD_DESKTOP);
+        return false;
+    }
+
     DesktopAppMessage message = {
         .type = DesktopMessageTypeAppStart,
         .app = app,
@@ -293,28 +346,81 @@ bool desktop_start_app(const FlipperInternalApplication* app) {
     return true;
 }
 
-extern int32_t cpu_app(void* p);
+const char* desktop_get_running_app_name(void) {
+    Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+    const char* name = desktop->app.running ? desktop->app.name : NULL;
+    furi_record_close(RECORD_DESKTOP);
 
-static const FlipperInternalApplication cpu_app_start = {
-    .app = cpu_app,
-    .name = "CPU App",
-    .appid = "cpu",
-    .stack_size = 1024 * 4,
-    .flags = FlipperInternalApplicationFlagDefault,
-    .args = "start",
-};
+    return name;
+}
 
-static const FlipperInternalApplication cpu_app_maskrom = {
-    .app = cpu_app,
-    .name = "CPU App",
-    .appid = "cpu",
-    .stack_size = 1024 * 4,
-    .flags = FlipperInternalApplicationFlagDefault,
-    .args = "maskrom",
-};
+bool desktop_stop_app(void) {
+    Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+
+    bool running = desktop->app.running;
+
+    DesktopAppMessage message = {
+        .type = DesktopMessageTypeAppStop,
+    };
+    furi_message_queue_put(desktop->app_message_queue, &message, FuriWaitForever);
+    furi_record_close(RECORD_DESKTOP);
+
+    return running;
+}
+
+bool desktop_register_app(const char* appid, FuriThread* thread) {
+    furi_check(appid);
+    furi_check(thread);
+
+    Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+
+    DesktopAppMessage message = {
+        .type = DesktopMessageTypeAppRegister,
+        .appid = appid,
+        .thread = thread,
+    };
+    furi_message_queue_put(desktop->app_message_queue, &message, FuriWaitForever);
+    furi_record_close(RECORD_DESKTOP);
+
+    return true;
+}
+
+bool desktop_unregister_app(const char* appid) {
+    furi_check(appid);
+
+    Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+
+    DesktopAppMessage message = {
+        .type = DesktopMessageTypeAppUnregister,
+        .appid = appid,
+    };
+    furi_message_queue_put(desktop->app_message_queue, &message, FuriWaitForever);
+    furi_record_close(RECORD_DESKTOP);
+
+    return true;
+}
 
 void desktop_start_cpu(bool to_maskrom) {
-    desktop_start_app(to_maskrom ? &cpu_app_maskrom : &cpu_app_start);
+    desktop_start_app_by_id(to_maskrom ? "cpu_app_maskrom" : "cpu_app_start");
+}
+
+bool desktop_start_app_by_id(const char* appid) {
+    furi_assert(appid);
+
+    const FlipperInternalApplication* entry = NULL;
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
+        if(strcmp(FLIPPER_APPS[i].appid, appid) == 0) {
+            entry = &FLIPPER_APPS[i];
+            break;
+        }
+    }
+
+    if(!entry) {
+        FURI_LOG_E(TAG, "App not found in FLIPPER_APPS: %s", appid);
+        return false;
+    }
+
+    return desktop_start_app(entry);
 }
 
 void desktop_power_off(void) {

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -43,6 +43,7 @@ typedef struct {
     char* args;
     FuriThread* thread;
     const char* name;
+    const char* appid;
 } DesktopApp;
 
 struct Desktop {
@@ -120,8 +121,45 @@ static void desktop_do_app_closed(Desktop* desktop) {
     furi_thread_free(desktop->app.thread);
     desktop->app.thread = NULL;
     desktop->app.name = NULL;
+    desktop->app.appid = NULL;
 
     FURI_LOG_I(TAG, "Application stopped. Free heap: %zu", memmgr_get_free_heap());
+}
+
+/* Join/free of an external app thread is deferred to the timer daemon: the
+ * external app calls desktop_unregister_app() from its own thread before it
+ * has fully stopped, so joining synchronously would block the desktop event
+ * loop until the thread completes its shutdown. */
+typedef struct {
+    FuriThread* thread;
+    char* args;
+} DesktopAppCleanupContext;
+
+static void desktop_app_cleanup_callback(void* context, uint32_t arg) {
+    UNUSED(arg);
+    DesktopAppCleanupContext* cleanup = context;
+
+    furi_thread_join(cleanup->thread);
+    FURI_LOG_I(TAG, "App returned: %li", furi_thread_get_return_code(cleanup->thread));
+
+    if(cleanup->args) {
+        free(cleanup->args);
+    }
+
+    furi_thread_free(cleanup->thread);
+    free(cleanup);
+
+    FURI_LOG_I(TAG, "Application stopped. Free heap: %zu", memmgr_get_free_heap());
+}
+
+static bool desktop_is_known_appid(const char* appid) {
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
+        if(strcmp(FLIPPER_APPS[i].appid, appid) == 0) return true;
+    }
+    for(size_t i = 0; i < FLIPPER_AUTORUN_APPS_COUNT; i++) {
+        if(strcmp(FLIPPER_AUTORUN_APPS[i].appid, appid) == 0) return true;
+    }
+    return false;
 }
 
 static void desktop_app_message_logic(FuriEventLoopObject* object, void* context) {
@@ -140,6 +178,7 @@ static void desktop_app_message_logic(FuriEventLoopObject* object, void* context
             desktop->app.running = true;
             desktop->app.external = false;
             desktop->app.name = message.app->name;
+            desktop->app.appid = message.app->appid;
             desktop_start_internal_app(desktop, message.app, message.args);
         }
         break;
@@ -160,20 +199,50 @@ static void desktop_app_message_logic(FuriEventLoopObject* object, void* context
     case DesktopMessageTypeAppRegister:
         if(desktop->app.running) {
             FURI_LOG_E(TAG, "App register requested, but another app is already running: %s", message.appid);
+        } else if(!desktop_is_known_appid(message.appid)) {
+            FURI_LOG_E(TAG, "App register requested for unknown appid: %s", message.appid);
+        } else if(strcmp(furi_thread_get_appid(message.thread), message.appid) != 0) {
+            FURI_LOG_E(
+                TAG,
+                "App register requested for %s, but thread appid is %s",
+                message.appid,
+                furi_thread_get_appid(message.thread));
         } else {
             desktop->app.running = true;
             desktop->app.external = true;
             desktop->app.thread = message.thread;
             desktop->app.name = message.appid;
+            desktop->app.appid = message.appid;
             FURI_LOG_I(TAG, "App registered as running: %s", message.appid);
         }
         break;
     case DesktopMessageTypeAppUnregister:
         if(desktop->app.running && desktop->app.external) {
-            FURI_LOG_I(TAG, "Registered app exiting: %s", message.appid);
-            desktop_do_app_closed(desktop);
-            desktop->app.running = false;
-            desktop->app.external = false;
+            if(strcmp(desktop->app.appid, message.appid) != 0) {
+                FURI_LOG_W(
+                    TAG,
+                    "Unregister appid mismatch: registered %s, requested %s",
+                    desktop->app.appid,
+                    message.appid);
+            } else {
+                FURI_LOG_I(TAG, "Registered app exiting: %s", message.appid);
+
+                // Hand the thread over to the timer daemon for join/free so
+                // the desktop event loop is not blocked while the app thread
+                // is still finishing its shutdown.
+                DesktopAppCleanupContext* cleanup = malloc(sizeof(DesktopAppCleanupContext));
+                cleanup->thread = desktop->app.thread;
+                cleanup->args = desktop->app.args;
+
+                desktop->app.thread = NULL;
+                desktop->app.args = NULL;
+                desktop->app.running = false;
+                desktop->app.external = false;
+                desktop->app.name = NULL;
+                desktop->app.appid = NULL;
+
+                furi_timer_pending_callback(desktop_app_cleanup_callback, cleanup, 0);
+            }
         } else if(desktop->app.running) {
             FURI_LOG_W(TAG, "Unregister requested for desktop-managed app %s, ignoring", message.appid);
         } else {
@@ -354,6 +423,14 @@ const char* desktop_get_running_app_name(void) {
     return name;
 }
 
+const char* desktop_get_running_app_id(void) {
+    Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+    const char* appid = desktop->app.running ? desktop->app.appid : NULL;
+    furi_record_close(RECORD_DESKTOP);
+
+    return appid;
+}
+
 bool desktop_stop_app(void) {
     Desktop* desktop = furi_record_open(RECORD_DESKTOP);
 
@@ -374,6 +451,24 @@ bool desktop_register_app(const char* appid, FuriThread* thread) {
 
     Desktop* desktop = furi_record_open(RECORD_DESKTOP);
 
+    if(desktop->app.running) {
+        FURI_LOG_E(TAG, "App register requested for %s, but %s is already running", appid, desktop->app.name);
+        furi_record_close(RECORD_DESKTOP);
+        return false;
+    }
+
+    if(!desktop_is_known_appid(appid)) {
+        FURI_LOG_E(TAG, "App register requested for unknown appid: %s", appid);
+        furi_record_close(RECORD_DESKTOP);
+        return false;
+    }
+
+    if(strcmp(furi_thread_get_appid(thread), appid) != 0) {
+        FURI_LOG_E(TAG, "App register requested for %s, but thread appid is %s", appid, furi_thread_get_appid(thread));
+        furi_record_close(RECORD_DESKTOP);
+        return false;
+    }
+
     DesktopAppMessage message = {
         .type = DesktopMessageTypeAppRegister,
         .appid = appid,
@@ -389,6 +484,15 @@ bool desktop_unregister_app(const char* appid) {
     furi_check(appid);
 
     Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+
+    bool registered = desktop->app.running && desktop->app.external &&
+                      desktop->app.appid && strcmp(desktop->app.appid, appid) == 0;
+
+    if(!registered) {
+        FURI_LOG_W(TAG, "Unregister requested for %s, but no matching external app is running", appid);
+        furi_record_close(RECORD_DESKTOP);
+        return false;
+    }
 
     DesktopAppMessage message = {
         .type = DesktopMessageTypeAppUnregister,

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -367,27 +367,27 @@ static void desktop_scene_event_logic(FuriEventLoopObject* object, void* context
         consumed = true;
         break;
     case DesktopSceneEventTypeEnterSelfCheckApp:
-        desktop_start_app_by_id("self_check");
+        desktop_start_app_by_id(desktop, "self_check");
         consumed = true;
         break;
     case DesktopSceneEventTypeEnterMaskromApp:
-        desktop_start_app_by_id("cpu_app_maskrom");
+        desktop_start_app_by_id(desktop, "cpu_app_maskrom");
         consumed = true;
         break;
     case DesktopSceneEventTypeEnterCpuStartApp:
-        desktop_start_app_by_id("cpu_app_start");
+        desktop_start_app_by_id(desktop, "cpu_app_start");
         consumed = true;
         break;
     case DesktopSceneEventTypeEnterKeypadApp:
-        desktop_start_app_by_id("keypad_test");
+        desktop_start_app_by_id(desktop, "keypad_test");
         consumed = true;
         break;
     case DesktopSceneEventTypeEnterTouchpadApp:
-        desktop_start_app_by_id("touchpad_test");
+        desktop_start_app_by_id(desktop, "touchpad_test");
         consumed = true;
         break;
     case DesktopSceneEventTypeEnterHapticApp:
-        desktop_start_app_by_id("haptic_test");
+        desktop_start_app_by_id(desktop, "haptic_test");
         consumed = true;
         break;
     }
@@ -554,10 +554,9 @@ bool desktop_unregister_app(const char* appid) {
     return result;
 }
 
-bool desktop_start_app_by_id(const char* appid) {
+bool desktop_start_app_by_id(Desktop* desktop, const char* appid) {
     furi_assert(appid);
-
-    Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+    furi_assert(desktop);
 
     bool result = false;
 
@@ -587,7 +586,6 @@ bool desktop_start_app_by_id(const char* appid) {
 
     } while(false);
 
-    furi_record_close(RECORD_DESKTOP);
     return result;
 }
 

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -312,6 +312,41 @@ bool furi_crash_handler(bool debug) {
     return false; // Always false for this development stage
 }
 
+static bool desktop_start_app_by_id(Desktop* desktop, const char* appid) {
+    furi_assert(appid);
+    furi_assert(desktop);
+
+    bool result = false;
+
+    const FlipperInternalApplication* entry = NULL;
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
+        if(strcmp(FLIPPER_APPS[i].appid, appid) == 0) {
+            entry = &FLIPPER_APPS[i];
+            break;
+        }
+    }
+    do {
+        if(!entry) {
+            FURI_LOG_E(TAG, "App not found in FLIPPER_APPS: %s", appid);
+            break;
+        }
+
+        if(desktop->app.running) {
+            FURI_LOG_E(TAG, "App start requested for %s, but %s is already running", entry->appid, desktop->app.name);
+        } else {
+            desktop->app.running = true;
+            desktop->app.external = false;
+            desktop->app.name = entry->name;
+            desktop->app.appid = entry->appid;
+            desktop_start_internal_app(desktop, entry, entry->args);
+            result = true;
+        };
+
+    } while(false);
+
+    return result;
+}
+
 static void desktop_scene_event_logic(FuriEventLoopObject* object, void* context) {
     furi_check(context);
     Desktop* desktop = context;
@@ -366,30 +401,37 @@ static void desktop_scene_event_logic(FuriEventLoopObject* object, void* context
         scene_enter(desktop->debug_menu_scene, desktop);
         consumed = true;
         break;
-    case DesktopSceneEventTypeEnterSelfCheckApp:
+    case DesktopSceneEventTypeStartSelfCheckApp:
         desktop_start_app_by_id(desktop, "self_check");
         consumed = true;
         break;
-    case DesktopSceneEventTypeEnterMaskromApp:
+    case DesktopSceneEventTypeStartMaskromApp:
         desktop_start_app_by_id(desktop, "cpu_app_maskrom");
         consumed = true;
         break;
-    case DesktopSceneEventTypeEnterCpuStartApp:
+    case DesktopSceneEventTypeStartCpuApp:
         desktop_start_app_by_id(desktop, "cpu_app_start");
         consumed = true;
         break;
-    case DesktopSceneEventTypeEnterKeypadApp:
+    case DesktopSceneEventTypeStartKeypadApp:
         desktop_start_app_by_id(desktop, "keypad_test");
         consumed = true;
         break;
-    case DesktopSceneEventTypeEnterTouchpadApp:
+    case DesktopSceneEventTypeStartTouchpadApp:
         desktop_start_app_by_id(desktop, "touchpad_test");
         consumed = true;
         break;
-    case DesktopSceneEventTypeEnterHapticApp:
+    case DesktopSceneEventTypeStartHapticApp:
         desktop_start_app_by_id(desktop, "haptic_test");
         consumed = true;
         break;
+    case DesktopSceneEventTypeStartAppById: {
+        const char* appid = (const char*)message.data;
+        furi_check(appid);
+        desktop_start_app_by_id(desktop, appid);
+        consumed = true;
+        break;
+    }
     }
 
     if(!consumed) {
@@ -550,41 +592,6 @@ bool desktop_unregister_app(const char* appid) {
     };
     desktop_send_message(desktop, &message);
     furi_record_close(RECORD_DESKTOP);
-
-    return result;
-}
-
-bool desktop_start_app_by_id(Desktop* desktop, const char* appid) {
-    furi_assert(appid);
-    furi_assert(desktop);
-
-    bool result = false;
-
-    const FlipperInternalApplication* entry = NULL;
-    for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
-        if(strcmp(FLIPPER_APPS[i].appid, appid) == 0) {
-            entry = &FLIPPER_APPS[i];
-            break;
-        }
-    }
-    do {
-        if(!entry) {
-            FURI_LOG_E(TAG, "App not found in FLIPPER_APPS: %s", appid);
-            break;
-        }
-
-        if(desktop->app.running) {
-            FURI_LOG_E(TAG, "App start requested for %s, but %s is already running", entry->appid, desktop->app.name);
-        } else {
-            desktop->app.running = true;
-            desktop->app.external = false;
-            desktop->app.name = entry->name;
-            desktop->app.appid = entry->appid;
-            desktop_start_internal_app(desktop, entry, entry->args);
-            result = true;
-        };
-
-    } while(false);
 
     return result;
 }

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -366,6 +366,30 @@ static void desktop_scene_event_logic(FuriEventLoopObject* object, void* context
         scene_enter(desktop->debug_menu_scene, desktop);
         consumed = true;
         break;
+    case DesktopSceneEventTypeEnterSelfCheckApp:
+        desktop_start_app_by_id("self_check");
+        consumed = true;
+        break;
+    case DesktopSceneEventTypeEnterMaskromApp:
+        desktop_start_app_by_id("cpu_app_maskrom");
+        consumed = true;
+        break;
+    case DesktopSceneEventTypeEnterCpuStartApp:
+        desktop_start_app_by_id("cpu_app_start");
+        consumed = true;
+        break;
+    case DesktopSceneEventTypeEnterKeypadApp:
+        desktop_start_app_by_id("keypad_test");
+        consumed = true;
+        break;
+    case DesktopSceneEventTypeEnterTouchpadApp:
+        desktop_start_app_by_id("touchpad_test");
+        consumed = true;
+        break;
+    case DesktopSceneEventTypeEnterHapticApp:
+        desktop_start_app_by_id("haptic_test");
+        consumed = true;
+        break;
     }
 
     if(!consumed) {
@@ -530,12 +554,12 @@ bool desktop_unregister_app(const char* appid) {
     return result;
 }
 
-void desktop_start_cpu(bool to_maskrom) {
-    desktop_start_app_by_id(to_maskrom ? "cpu_app_maskrom" : "cpu_app_start");
-}
-
 bool desktop_start_app_by_id(const char* appid) {
     furi_assert(appid);
+
+    Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+
+    bool result = false;
 
     const FlipperInternalApplication* entry = NULL;
     for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
@@ -544,13 +568,27 @@ bool desktop_start_app_by_id(const char* appid) {
             break;
         }
     }
+    do {
+        if(!entry) {
+            FURI_LOG_E(TAG, "App not found in FLIPPER_APPS: %s", appid);
+            break;
+        }
 
-    if(!entry) {
-        FURI_LOG_E(TAG, "App not found in FLIPPER_APPS: %s", appid);
-        return false;
-    }
+        if(desktop->app.running) {
+            FURI_LOG_E(TAG, "App start requested for %s, but %s is already running", entry->appid, desktop->app.name);
+        } else {
+            desktop->app.running = true;
+            desktop->app.external = false;
+            desktop->app.name = entry->name;
+            desktop->app.appid = entry->appid;
+            desktop_start_internal_app(desktop, entry, entry->args);
+            result = true;
+        };
 
-    return desktop_start_app(entry);
+    } while(false);
+
+    furi_record_close(RECORD_DESKTOP);
+    return result;
 }
 
 void desktop_power_off(void) {

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -5,6 +5,7 @@
 #include <gui/clay_helper.h>
 #include <gui/gui.h>
 #include <assets.h>
+#include <api_lock.h>
 #include "scenes/scenes.h"
 
 #define DESKTOP_APP_MESSAGE_QUEUE_SIZE         4
@@ -22,6 +23,7 @@ typedef enum {
     DesktopMessageTypeAppClosed,
     DesktopMessageTypeAppRegister,
     DesktopMessageTypeAppUnregister,
+    DesktopMessageTypeAppCleanupWorkerDone,
 } DesktopMessageType;
 
 typedef struct {
@@ -30,6 +32,11 @@ typedef struct {
     const char* args;
     const char* appid;
     FuriThread* thread;
+    /* Only used by Register/Unregister so the caller can block until the
+     * desktop thread has applied the state change and get the real result,
+     * instead of racing with it by reading desktop->app.* directly. */
+    FuriApiLock lock;
+    bool* result;
 } DesktopAppMessage;
 
 typedef struct {
@@ -67,6 +74,8 @@ struct Desktop {
     FuriEventLoopTimer* power_update_timer;
 };
 
+static void desktop_send_message(Desktop* instance, const DesktopAppMessage* message);
+
 static void desktop_app_thread_state_callback(FuriThread* thread, FuriThreadState thread_state, void* context) {
     UNUSED(thread);
     furi_assert(context);
@@ -74,9 +83,10 @@ static void desktop_app_thread_state_callback(FuriThread* thread, FuriThreadStat
     if(thread_state == FuriThreadStateStopped) {
         Desktop* desktop = context;
 
-        DesktopAppMessage message;
-        message.type = DesktopMessageTypeAppClosed;
-        furi_message_queue_put(desktop->app_message_queue, &message, FuriWaitForever);
+        DesktopAppMessage message = {
+            .type = DesktopMessageTypeAppClosed,
+        };
+        desktop_send_message(desktop, &message);
     }
 }
 
@@ -126,17 +136,23 @@ static void desktop_do_app_closed(Desktop* desktop) {
     FURI_LOG_I(TAG, "Application stopped. Free heap: %zu", memmgr_get_free_heap());
 }
 
-/* Join/free of an external app thread is deferred to the timer daemon: the
- * external app calls desktop_unregister_app() from its own thread before it
- * has fully stopped, so joining synchronously would block the desktop event
- * loop until the thread completes its shutdown. */
+/* Join/free of an external app thread must happen off both the desktop event
+ * loop (the app calls desktop_unregister_app() from its own thread before it
+ * has fully stopped, so joining there would stall desktop's own message
+ * processing) and the shared FreeRTOS timer daemon (furi_thread_join() polls
+ * until the thread stops, which would stall every other system timer and
+ * pending callback in the firmware).
+ *
+ * Instead, a short-lived worker thread is spawned on demand to do the join;
+ * once it exits, its own thread-stopped callback (which fires with the state
+ * already set to Stopped, so joining it back is instant) posts a message so
+ * the desktop thread can reap it. No thread/resources linger when idle. */
 typedef struct {
     FuriThread* thread;
     char* args;
 } DesktopAppCleanupContext;
 
-static void desktop_app_cleanup_callback(void* context, uint32_t arg) {
-    UNUSED(arg);
+static int32_t desktop_app_cleanup_worker(void* context) {
     DesktopAppCleanupContext* cleanup = context;
 
     furi_thread_join(cleanup->thread);
@@ -150,6 +166,22 @@ static void desktop_app_cleanup_callback(void* context, uint32_t arg) {
     free(cleanup);
 
     FURI_LOG_I(TAG, "Application stopped. Free heap: %zu", memmgr_get_free_heap());
+
+    return 0;
+}
+
+static void desktop_app_cleanup_worker_state_callback(FuriThread* thread, FuriThreadState thread_state, void* context) {
+    furi_assert(context);
+
+    if(thread_state == FuriThreadStateStopped) {
+        Desktop* desktop = context;
+
+        DesktopAppMessage message = {
+            .type = DesktopMessageTypeAppCleanupWorkerDone,
+            .thread = thread,
+        };
+        desktop_send_message(desktop, &message);
+    }
 }
 
 static bool desktop_is_known_appid(const char* appid) {
@@ -170,16 +202,19 @@ static void desktop_app_message_logic(FuriEventLoopObject* object, void* context
     DesktopAppMessage message;
     furi_check(furi_message_queue_get(desktop->app_message_queue, &message, 0) == FuriStatusOk);
 
+    bool result = false;
+
     switch(message.type) {
     case DesktopMessageTypeAppStart:
         if(desktop->app.running) {
-            FURI_LOG_E(TAG, "App start requested, but another app is already running");
+            FURI_LOG_E(TAG, "App start requested for %s, but %s is already running", message.app->appid, desktop->app.name);
         } else {
             desktop->app.running = true;
             desktop->app.external = false;
             desktop->app.name = message.app->name;
             desktop->app.appid = message.app->appid;
             desktop_start_internal_app(desktop, message.app, message.args);
+            result = true;
         }
         break;
     case DesktopMessageTypeAppStop:
@@ -202,11 +237,7 @@ static void desktop_app_message_logic(FuriEventLoopObject* object, void* context
         } else if(!desktop_is_known_appid(message.appid)) {
             FURI_LOG_E(TAG, "App register requested for unknown appid: %s", message.appid);
         } else if(strcmp(furi_thread_get_appid(message.thread), message.appid) != 0) {
-            FURI_LOG_E(
-                TAG,
-                "App register requested for %s, but thread appid is %s",
-                message.appid,
-                furi_thread_get_appid(message.thread));
+            FURI_LOG_E(TAG, "App register requested for %s, but thread appid is %s", message.appid, furi_thread_get_appid(message.thread));
         } else {
             desktop->app.running = true;
             desktop->app.external = true;
@@ -214,22 +245,16 @@ static void desktop_app_message_logic(FuriEventLoopObject* object, void* context
             desktop->app.name = message.appid;
             desktop->app.appid = message.appid;
             FURI_LOG_I(TAG, "App registered as running: %s", message.appid);
+            result = true;
         }
         break;
     case DesktopMessageTypeAppUnregister:
         if(desktop->app.running && desktop->app.external) {
             if(strcmp(desktop->app.appid, message.appid) != 0) {
-                FURI_LOG_W(
-                    TAG,
-                    "Unregister appid mismatch: registered %s, requested %s",
-                    desktop->app.appid,
-                    message.appid);
+                FURI_LOG_W(TAG, "Unregister appid mismatch: registered %s, requested %s", desktop->app.appid, message.appid);
             } else {
                 FURI_LOG_I(TAG, "Registered app exiting: %s", message.appid);
 
-                // Hand the thread over to the timer daemon for join/free so
-                // the desktop event loop is not blocked while the app thread
-                // is still finishing its shutdown.
                 DesktopAppCleanupContext* cleanup = malloc(sizeof(DesktopAppCleanupContext));
                 cleanup->thread = desktop->app.thread;
                 cleanup->args = desktop->app.args;
@@ -241,7 +266,12 @@ static void desktop_app_message_logic(FuriEventLoopObject* object, void* context
                 desktop->app.name = NULL;
                 desktop->app.appid = NULL;
 
-                furi_timer_pending_callback(desktop_app_cleanup_callback, cleanup, 0);
+                FuriThread* worker = furi_thread_alloc_ex("DesktopAppCleanup", 1024, desktop_app_cleanup_worker, cleanup);
+                furi_thread_set_state_context(worker, desktop);
+                furi_thread_set_state_callback(worker, desktop_app_cleanup_worker_state_callback);
+                furi_thread_start(worker);
+
+                result = true;
             }
         } else if(desktop->app.running) {
             FURI_LOG_W(TAG, "Unregister requested for desktop-managed app %s, ignoring", message.appid);
@@ -249,9 +279,22 @@ static void desktop_app_message_logic(FuriEventLoopObject* object, void* context
             FURI_LOG_W(TAG, "Unregister requested for %s, but no app is running", message.appid);
         }
         break;
+    case DesktopMessageTypeAppCleanupWorkerDone:
+        // State is already Stopped by the time this fires, so this join is instant.
+        furi_thread_join(message.thread);
+        furi_thread_free(message.thread);
+        break;
     default:
         furi_assert(false);
         break;
+    }
+
+    if(message.result) {
+        *message.result = result;
+    }
+
+    if(message.lock) {
+        api_lock_unlock(message.lock);
     }
 }
 
@@ -391,28 +434,32 @@ int32_t desktop_srv(void* p) {
     return 0;
 }
 
+static void desktop_send_message(Desktop* instance, const DesktopAppMessage* message) {
+    furi_check(furi_message_queue_put(instance->app_message_queue, message, FuriWaitForever) == FuriStatusOk);
+
+    if(message->lock) {
+        api_lock_wait_unlock_and_free(message->lock);
+    }
+}
+
 bool desktop_start_app(const FlipperInternalApplication* app) {
     furi_assert(app);
 
     Desktop* desktop = furi_record_open(RECORD_DESKTOP);
 
-    if(desktop->app.running) {
-        FURI_LOG_E(
-            TAG, "App start requested for %s, but %s is already running", app->appid, desktop->app.name);
-        furi_record_close(RECORD_DESKTOP);
-        return false;
-    }
-
+    bool result = false;
     DesktopAppMessage message = {
         .type = DesktopMessageTypeAppStart,
         .app = app,
         .args = app->args,
+        .lock = api_lock_alloc_locked(),
+        .result = &result,
     };
 
-    furi_message_queue_put(desktop->app_message_queue, &message, FuriWaitForever);
+    desktop_send_message(desktop, &message);
     furi_record_close(RECORD_DESKTOP);
 
-    return true;
+    return result;
 }
 
 const char* desktop_get_running_app_name(void) {
@@ -439,7 +486,7 @@ bool desktop_stop_app(void) {
     DesktopAppMessage message = {
         .type = DesktopMessageTypeAppStop,
     };
-    furi_message_queue_put(desktop->app_message_queue, &message, FuriWaitForever);
+    desktop_send_message(desktop, &message);
     furi_record_close(RECORD_DESKTOP);
 
     return running;
@@ -451,33 +498,18 @@ bool desktop_register_app(const char* appid, FuriThread* thread) {
 
     Desktop* desktop = furi_record_open(RECORD_DESKTOP);
 
-    if(desktop->app.running) {
-        FURI_LOG_E(TAG, "App register requested for %s, but %s is already running", appid, desktop->app.name);
-        furi_record_close(RECORD_DESKTOP);
-        return false;
-    }
-
-    if(!desktop_is_known_appid(appid)) {
-        FURI_LOG_E(TAG, "App register requested for unknown appid: %s", appid);
-        furi_record_close(RECORD_DESKTOP);
-        return false;
-    }
-
-    if(strcmp(furi_thread_get_appid(thread), appid) != 0) {
-        FURI_LOG_E(TAG, "App register requested for %s, but thread appid is %s", appid, furi_thread_get_appid(thread));
-        furi_record_close(RECORD_DESKTOP);
-        return false;
-    }
-
+    bool result = false;
     DesktopAppMessage message = {
         .type = DesktopMessageTypeAppRegister,
         .appid = appid,
         .thread = thread,
+        .lock = api_lock_alloc_locked(),
+        .result = &result,
     };
-    furi_message_queue_put(desktop->app_message_queue, &message, FuriWaitForever);
+    desktop_send_message(desktop, &message);
     furi_record_close(RECORD_DESKTOP);
 
-    return true;
+    return result;
 }
 
 bool desktop_unregister_app(const char* appid) {
@@ -485,23 +517,17 @@ bool desktop_unregister_app(const char* appid) {
 
     Desktop* desktop = furi_record_open(RECORD_DESKTOP);
 
-    bool registered = desktop->app.running && desktop->app.external &&
-                      desktop->app.appid && strcmp(desktop->app.appid, appid) == 0;
-
-    if(!registered) {
-        FURI_LOG_W(TAG, "Unregister requested for %s, but no matching external app is running", appid);
-        furi_record_close(RECORD_DESKTOP);
-        return false;
-    }
-
+    bool result = false;
     DesktopAppMessage message = {
         .type = DesktopMessageTypeAppUnregister,
         .appid = appid,
+        .lock = api_lock_alloc_locked(),
+        .result = &result,
     };
-    furi_message_queue_put(desktop->app_message_queue, &message, FuriWaitForever);
+    desktop_send_message(desktop, &message);
     furi_record_close(RECORD_DESKTOP);
 
-    return true;
+    return result;
 }
 
 void desktop_start_cpu(bool to_maskrom) {

--- a/applications/services/desktop/desktop.h
+++ b/applications/services/desktop/desktop.h
@@ -8,6 +8,22 @@ extern "C" {
 #endif
 
 bool desktop_start_app(const FlipperInternalApplication* app);
+bool desktop_stop_app(void);
+
+/** Get the name of the currently running app, or NULL if none is running. */
+const char* desktop_get_running_app_name(void);
+
+/** Notify the desktop that an app is running. The app occupies the desktop
+ * app slot as if it was started with desktop_start_app(): no other app can
+ * be started until desktop_unregister_app() is called, and desktop_stop_app()
+ * can be used to request its exit.
+ * @param appid application ID (must stay valid until unregister)
+ * @param thread the FuriThread instance the app is running in
+ */
+bool desktop_register_app(const char* appid, FuriThread* thread);
+
+/** Notify the desktop that the registered app has exited. Frees the app slot. */
+bool desktop_unregister_app(const char* appid);
 
 #ifdef __cplusplus
 }

--- a/applications/services/desktop/desktop.h
+++ b/applications/services/desktop/desktop.h
@@ -7,35 +7,46 @@
 extern "C" {
 #endif
 
-/** Start an app from FLIPPER_APPS by its appid.
- * @param app  pointer to the FlipperInternalApplication struct
+/** Start an application by FLIPPER_APPS entry.
+ * @param app pointer to the FlipperInternalApplication struct
  * @return true if the app was started, false if another app is already running
  */
 bool desktop_start_app(const FlipperInternalApplication* app);
 
-/** Stop the currently running app, if any. Returns true if an app was stopped,
- * @return true if an app was stopped, false if no app was running
+/** Stop the currently running app, if any.
+ * @return true if an app was running and an exit was requested, false if no app was running
  */
 bool desktop_stop_app(void);
 
-/** Get the name of the currently running app.
- * @return the appid of the currently running app, or NULL if no app is running
+/** Get the name of the currently running app (human-readable; equals the
+ * appid for apps registered via desktop_register_app()).
+ * @return the name of the currently running app, or NULL if no app is running
  */
 const char* desktop_get_running_app_name(void);
+
+/** Get the appid of the currently running app.
+ * @return the appid of the currently running app, or NULL if no app is running
+ */
+const char* desktop_get_running_app_id(void);
 
 /** Notify the desktop that an app is running. The app occupies the desktop
  * app slot as if it was started with desktop_start_app(): no other app can
  * be started until desktop_unregister_app() is called, and desktop_stop_app()
  * can be used to request its exit.
- * @param appid application ID (must stay valid until unregister)
+ * The app must call desktop_unregister_app() before its thread returns; the
+ * desktop joins and frees the thread asynchronously after that.
+ * @param appid application ID: must match an entry in FLIPPER_APPS or
+ *              FLIPPER_AUTORUN_APPS and the appid of the given thread
  * @param thread the FuriThread instance the app is running in
- * @return true if the app was registered, false if another app is already running
+ * @return true if the app was registered, false if another app is already
+ *         running, the appid is unknown, or it does not match the thread
  */
 bool desktop_register_app(const char* appid, FuriThread* thread);
 
 /** Notify the desktop that the registered app has exited. Frees the app slot.
  * @param appid application ID (must match the one used in desktop_register_app())
- * @return true if the app was unregistered, false if no app was registered with that ID
+ * @return true if the app was unregistered, false if no external app with
+ *         that appid is registered
  */
 bool desktop_unregister_app(const char* appid);
 

--- a/applications/services/desktop/desktop.h
+++ b/applications/services/desktop/desktop.h
@@ -7,10 +7,20 @@
 extern "C" {
 #endif
 
+/** Start an app from FLIPPER_APPS by its appid.
+ * @param app  pointer to the FlipperInternalApplication struct
+ * @return true if the app was started, false if another app is already running
+ */
 bool desktop_start_app(const FlipperInternalApplication* app);
+
+/** Stop the currently running app, if any. Returns true if an app was stopped,
+ * @return true if an app was stopped, false if no app was running
+ */
 bool desktop_stop_app(void);
 
-/** Get the name of the currently running app, or NULL if none is running. */
+/** Get the name of the currently running app.
+ * @return the appid of the currently running app, or NULL if no app is running
+ */
 const char* desktop_get_running_app_name(void);
 
 /** Notify the desktop that an app is running. The app occupies the desktop
@@ -19,10 +29,14 @@ const char* desktop_get_running_app_name(void);
  * can be used to request its exit.
  * @param appid application ID (must stay valid until unregister)
  * @param thread the FuriThread instance the app is running in
+ * @return true if the app was registered, false if another app is already running
  */
 bool desktop_register_app(const char* appid, FuriThread* thread);
 
-/** Notify the desktop that the registered app has exited. Frees the app slot. */
+/** Notify the desktop that the registered app has exited. Frees the app slot.
+ * @param appid application ID (must match the one used in desktop_register_app())
+ * @return true if the app was unregistered, false if no app was registered with that ID
+ */
 bool desktop_unregister_app(const char* appid);
 
 #ifdef __cplusplus

--- a/applications/services/desktop/desktop_cli.c
+++ b/applications/services/desktop/desktop_cli.c
@@ -7,14 +7,12 @@
 #include <cli/cli_command.h>
 #include <furi_hal.h>
 
-
 typedef struct {
     const char* name;
     const char* arg_spec;
     const char* description;
     bool (*execute)(PipeSide*, FuriString*);
-} DesktopCmd; 
-
+} DesktopCmd;
 
 static bool desktop_cli_list_apps(PipeSide* pipe, FuriString* args) {
     UNUSED(pipe);
@@ -41,8 +39,7 @@ static bool desktop_cli_start_app(PipeSide* pipe, FuriString* args) {
 
         const char* name = furi_string_get_cstr(app_name);
         for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
-            if(strcmp(name, FLIPPER_APPS[i].name) == 0 ||
-               strcmp(name, FLIPPER_APPS[i].appid) == 0) {
+            if(strcmp(name, FLIPPER_APPS[i].name) == 0 || strcmp(name, FLIPPER_APPS[i].appid) == 0) {
                 target = &FLIPPER_APPS[i];
                 break;
             }
@@ -55,10 +52,7 @@ static bool desktop_cli_start_app(PipeSide* pipe, FuriString* args) {
 
         if(!desktop_start_app(target)) {
             const char* running = desktop_get_running_app_id();
-            printf(
-                "failed to start %s: %s is already running\r\n",
-                target->appid,
-                running ? running : "unknown app");
+            printf("failed to start %s: %s is already running\r\n", target->appid, running ? running : "unknown app");
             break;
         }
 

--- a/applications/services/desktop/desktop_cli.c
+++ b/applications/services/desktop/desktop_cli.c
@@ -1,0 +1,120 @@
+#include "desktop_cli.h"
+#include "desktop.h"
+
+#include <cli/args.h>
+#include <toolbox/strint.h>
+#include <cli/cli_ansi.h>
+#include <cli/cli_command.h>
+#include <furi_hal.h>
+
+
+typedef struct {
+    const char* name;
+    const char* arg_spec;
+    const char* description;
+    bool (*execute)(PipeSide*, FuriString*);
+} DesktopCmd; 
+
+
+static bool desktop_cli_list_apps(PipeSide* pipe, FuriString* args) {
+    UNUSED(pipe);
+    UNUSED(args);
+
+    printf("Available apps:\r\n");
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
+        printf("\t%s (%s)\r\n", FLIPPER_APPS[i].name, FLIPPER_APPS[i].appid);
+    }
+    return true;
+}
+
+static bool desktop_cli_start_app(PipeSide* pipe, FuriString* args) {
+    UNUSED(pipe);
+
+    FuriString* app_name = furi_string_alloc();
+    const FlipperInternalApplication* target = NULL;
+
+    do {
+        if(!args_read_string_and_trim(args, app_name)) {
+            printf("usage: desktop start_app <app_name|appid>\r\n");
+            break;
+        }
+
+        const char* name = furi_string_get_cstr(app_name);
+        for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
+            if(strcmp(name, FLIPPER_APPS[i].name) == 0 ||
+               strcmp(name, FLIPPER_APPS[i].appid) == 0) {
+                target = &FLIPPER_APPS[i];
+                break;
+            }
+        }
+
+        if(!target) {
+            printf("app not found: %s\r\n", name);
+            break;
+        }
+
+        if(!desktop_start_app(target)) {
+            const char* running = desktop_get_running_app_name();
+            printf(
+                "failed to start %s: %s is already running\r\n",
+                target->appid,
+                running ? running : "unknown app");
+            break;
+        }
+
+        printf("started %s (%s)\r\n", target->name, target->appid);
+    } while(false);
+
+    furi_string_free(app_name);
+    return true;
+}
+
+static bool desktop_cli_stop_app(PipeSide* pipe, FuriString* args) {
+    UNUSED(pipe);
+    UNUSED(args);
+
+    if(!desktop_stop_app()) {
+        printf("no app is running\r\n");
+    }
+    return true;
+}
+
+static const DesktopCmd desktop_cmds[] = {
+    {"start_app", "<app_name|appid>", "Start an application by name or appid", desktop_cli_start_app},
+    {"stop_app", "", "Request graceful exit of the running app", desktop_cli_stop_app},
+    {"list_apps", "", "List available apps", desktop_cli_list_apps},
+};
+
+static void desktop_command_cli_print_usage(void) {
+    printf("Usage:\r\ndesktop <cmd>\r\nCmd list:\r\n");
+    for(size_t i = 0; i < COUNT_OF(desktop_cmds); i++) {
+        const DesktopCmd* c = &desktop_cmds[i];
+        printf("\t%s %s - %s\r\n", c->name, c->arg_spec, c->description);
+    }
+}
+
+void desktop_command_cli(PipeSide* pipe, FuriString* args, void* context) {
+    UNUSED(context);
+    FuriString* cmd = furi_string_alloc();
+    bool handled = false;
+
+    if(args_read_string_and_trim(args, cmd)) {
+        const char* cmd_str = furi_string_get_cstr(cmd);
+        for(size_t i = 0; i < COUNT_OF(desktop_cmds); i++) {
+            const DesktopCmd* c = &desktop_cmds[i];
+            if(strcmp(cmd_str, c->name) == 0) {
+                if(!c->execute(pipe, args)) {
+                    printf("usage: desktop %s %s\r\n", c->name, c->arg_spec);
+                }
+                handled = true;
+                break;
+            }
+        }
+    }
+
+    if(!handled) {
+        desktop_command_cli_print_usage();
+    }
+
+    furi_string_free(cmd);
+}

--- a/applications/services/desktop/desktop_cli.c
+++ b/applications/services/desktop/desktop_cli.c
@@ -34,8 +34,8 @@ static bool desktop_cli_start_app(PipeSide* pipe, FuriString* args) {
     const FlipperInternalApplication* target = NULL;
 
     do {
-        if(!args_read_string_and_trim(args, app_name)) {
-            printf("usage: desktop start_app <app_name|appid>\r\n");
+        if(!args_read_probably_quoted_string_and_trim(args, app_name)) {
+            printf("usage: desktop start_app <appid|\"app name\">\r\n");
             break;
         }
 
@@ -54,7 +54,7 @@ static bool desktop_cli_start_app(PipeSide* pipe, FuriString* args) {
         }
 
         if(!desktop_start_app(target)) {
-            const char* running = desktop_get_running_app_name();
+            const char* running = desktop_get_running_app_id();
             printf(
                 "failed to start %s: %s is already running\r\n",
                 target->appid,
@@ -73,8 +73,12 @@ static bool desktop_cli_stop_app(PipeSide* pipe, FuriString* args) {
     UNUSED(pipe);
     UNUSED(args);
 
+    const char* appid = desktop_get_running_app_id();
+
     if(!desktop_stop_app()) {
         printf("no app is running\r\n");
+    } else {
+        printf("stop requested: %s\r\n", appid ? appid : "unknown app");
     }
     return true;
 }

--- a/applications/services/desktop/desktop_cli.c
+++ b/applications/services/desktop/desktop_cli.c
@@ -95,7 +95,7 @@ static bool desktop_cli_get_run_app(PipeSide* pipe, FuriString* args) {
 }
 
 static const DesktopCmd desktop_cmds[] = {
-    {"start_app", "<\"app_name\"|appid>", "Start an application by name or appid", desktop_cli_start_app},
+    {"start_app", "<\"app name\"|appid>", "Start an application by name or appid", desktop_cli_start_app},
     {"stop_app", "", "Request graceful exit of the running app", desktop_cli_stop_app},
     {"list_apps", "", "List available apps", desktop_cli_list_apps},
     {"get_run_app", "", "Get the appid of the currently running app", desktop_cli_get_run_app},

--- a/applications/services/desktop/desktop_cli.c
+++ b/applications/services/desktop/desktop_cli.c
@@ -79,10 +79,26 @@ static bool desktop_cli_stop_app(PipeSide* pipe, FuriString* args) {
     return true;
 }
 
+static bool desktop_cli_get_run_app(PipeSide* pipe, FuriString* args) {
+    UNUSED(pipe);
+    UNUSED(args);
+
+    const char* appid = desktop_get_running_app_id();
+
+    if(appid) {
+        printf("running app: %s\r\n", appid);
+    } else {
+        printf("no app is running\r\n");
+    }
+
+    return true;
+}
+
 static const DesktopCmd desktop_cmds[] = {
     {"start_app", "<app_name|appid>", "Start an application by name or appid", desktop_cli_start_app},
     {"stop_app", "", "Request graceful exit of the running app", desktop_cli_stop_app},
     {"list_apps", "", "List available apps", desktop_cli_list_apps},
+    {"get_run_app", "", "Get the appid of the currently running app", desktop_cli_get_run_app},
 };
 
 static void desktop_command_cli_print_usage(void) {

--- a/applications/services/desktop/desktop_cli.c
+++ b/applications/services/desktop/desktop_cli.c
@@ -95,7 +95,7 @@ static bool desktop_cli_get_run_app(PipeSide* pipe, FuriString* args) {
 }
 
 static const DesktopCmd desktop_cmds[] = {
-    {"start_app", "<app_name|appid>", "Start an application by name or appid", desktop_cli_start_app},
+    {"start_app", "<\"app_name\"|appid>", "Start an application by name or appid", desktop_cli_start_app},
     {"stop_app", "", "Request graceful exit of the running app", desktop_cli_stop_app},
     {"list_apps", "", "List available apps", desktop_cli_list_apps},
     {"get_run_app", "", "Get the appid of the currently running app", desktop_cli_get_run_app},

--- a/applications/services/desktop/desktop_cli.c
+++ b/applications/services/desktop/desktop_cli.c
@@ -30,10 +30,10 @@ static bool desktop_cli_start_app(PipeSide* pipe, FuriString* args) {
 
     FuriString* app_name = furi_string_alloc();
     const FlipperInternalApplication* target = NULL;
+    bool success = false;
 
     do {
         if(!args_read_probably_quoted_string_and_trim(args, app_name)) {
-            printf("usage: desktop start_app <appid|\"app name\">\r\n");
             break;
         }
 
@@ -57,10 +57,11 @@ static bool desktop_cli_start_app(PipeSide* pipe, FuriString* args) {
         }
 
         printf("started %s (%s)\r\n", target->name, target->appid);
+        success = true;
     } while(false);
 
     furi_string_free(app_name);
-    return true;
+    return success;
 }
 
 static bool desktop_cli_stop_app(PipeSide* pipe, FuriString* args) {
@@ -74,6 +75,7 @@ static bool desktop_cli_stop_app(PipeSide* pipe, FuriString* args) {
     } else {
         printf("stop requested: %s\r\n", appid ? appid : "unknown app");
     }
+
     return true;
 }
 

--- a/applications/services/desktop/desktop_cli.h
+++ b/applications/services/desktop/desktop_cli.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <containers/pipe.h>
+
+void desktop_command_cli(PipeSide* pipe, FuriString* args, void* context);

--- a/applications/services/desktop/desktop_i.h
+++ b/applications/services/desktop/desktop_i.h
@@ -27,6 +27,9 @@ void desktop_send_scene_event(Desktop* desktop, uint32_t event, void* data);
 
 void desktop_start_cpu(bool to_maskrom);
 
+/** Start an app from FLIPPER_APPS by its appid. Returns false if not found. */
+bool desktop_start_app_by_id(const char* appid);
+
 void desktop_power_off(void);
 
 #ifdef __cplusplus

--- a/applications/services/desktop/desktop_i.h
+++ b/applications/services/desktop/desktop_i.h
@@ -21,11 +21,16 @@ typedef enum {
 
     DesktopSceneEventTypePowerUpdate,
 
+    DesktopSceneEventTypeEnterSelfCheckApp,
+    DesktopSceneEventTypeEnterMaskromApp,
+    DesktopSceneEventTypeEnterCpuStartApp,
+    DesktopSceneEventTypeEnterKeypadApp,
+    DesktopSceneEventTypeEnterTouchpadApp,
+    DesktopSceneEventTypeEnterHapticApp,
+
 } DesktopSceneEvent;
 
 void desktop_send_scene_event(Desktop* desktop, uint32_t event, void* data);
-
-void desktop_start_cpu(bool to_maskrom);
 
 /** Start an app from FLIPPER_APPS by its appid. Returns false if not found. */
 bool desktop_start_app_by_id(const char* appid);

--- a/applications/services/desktop/desktop_i.h
+++ b/applications/services/desktop/desktop_i.h
@@ -21,19 +21,18 @@ typedef enum {
 
     DesktopSceneEventTypePowerUpdate,
 
-    DesktopSceneEventTypeEnterSelfCheckApp,
-    DesktopSceneEventTypeEnterMaskromApp,
-    DesktopSceneEventTypeEnterCpuStartApp,
-    DesktopSceneEventTypeEnterKeypadApp,
-    DesktopSceneEventTypeEnterTouchpadApp,
-    DesktopSceneEventTypeEnterHapticApp,
+    DesktopSceneEventTypeStartSelfCheckApp,
+    DesktopSceneEventTypeStartMaskromApp,
+    DesktopSceneEventTypeStartCpuApp,
+    DesktopSceneEventTypeStartKeypadApp,
+    DesktopSceneEventTypeStartTouchpadApp,
+    DesktopSceneEventTypeStartHapticApp,
+
+    DesktopSceneEventTypeStartAppById,
 
 } DesktopSceneEvent;
 
 void desktop_send_scene_event(Desktop* desktop, uint32_t event, void* data);
-
-/** Start an app from FLIPPER_APPS by its appid. Returns false if not found. */
-bool desktop_start_app_by_id(Desktop* desktop, const char* appid);
 
 void desktop_power_off(void);
 

--- a/applications/services/desktop/desktop_i.h
+++ b/applications/services/desktop/desktop_i.h
@@ -33,7 +33,7 @@ typedef enum {
 void desktop_send_scene_event(Desktop* desktop, uint32_t event, void* data);
 
 /** Start an app from FLIPPER_APPS by its appid. Returns false if not found. */
-bool desktop_start_app_by_id(const char* appid);
+bool desktop_start_app_by_id(Desktop* desktop, const char* appid);
 
 void desktop_power_off(void);
 

--- a/applications/services/desktop/scenes/debug_apps_menu.c
+++ b/applications/services/desktop/scenes/debug_apps_menu.c
@@ -68,7 +68,8 @@ static bool debug_menu_input(InputEvent* event, void* context) {
     if(event->type == InputTypePress && event->key == InputKeyOk) {
         uint32_t selected_index;
         with_view_model(view, DebugMenuViewModel * model, { selected_index = model->selected_index; }, false);
-        desktop_start_app_by_id(desktop, FLIPPER_APPS[selected_index].appid);
+        const char* appid = FLIPPER_APPS[selected_index].appid;
+        desktop_send_scene_event(desktop, DesktopSceneEventTypeStartAppById, (void*)appid);
         consumed = true;
     } else if(event->type == InputTypePress && event->key == InputKeyBack) {
         scene_exit(scene, desktop);

--- a/applications/services/desktop/scenes/debug_apps_menu.c
+++ b/applications/services/desktop/scenes/debug_apps_menu.c
@@ -68,7 +68,7 @@ static bool debug_menu_input(InputEvent* event, void* context) {
     if(event->type == InputTypePress && event->key == InputKeyOk) {
         uint32_t selected_index;
         with_view_model(view, DebugMenuViewModel * model, { selected_index = model->selected_index; }, false);
-        desktop_start_app(&FLIPPER_APPS[selected_index]);
+        desktop_start_app_by_id(desktop, FLIPPER_APPS[selected_index].appid);
         consumed = true;
     } else if(event->type == InputTypePress && event->key == InputKeyBack) {
         scene_exit(scene, desktop);

--- a/applications/services/desktop/scenes/power_menu.c
+++ b/applications/services/desktop/scenes/power_menu.c
@@ -23,7 +23,7 @@ static void power_menu_item_selected(size_t item_id, void* context) {
         FURI_LOG_I(TAG, "Exit");
         desktop_send_scene_event(desktop, DesktopSceneEventTypeTogglePowerMenu, desktop);
     } else if(item_id == PowerMenuItemStartCpu) {
-        desktop_start_cpu(false);
+        desktop_send_scene_event(desktop, DesktopSceneEventTypeEnterCpuStartApp, desktop);
         desktop_send_scene_event(desktop, DesktopSceneEventTypeTogglePowerMenu, desktop);
     } else if(item_id == PowerMenuItemPowerOff) {
         desktop_power_off();

--- a/applications/services/desktop/scenes/power_menu.c
+++ b/applications/services/desktop/scenes/power_menu.c
@@ -23,7 +23,7 @@ static void power_menu_item_selected(size_t item_id, void* context) {
         FURI_LOG_I(TAG, "Exit");
         desktop_send_scene_event(desktop, DesktopSceneEventTypeTogglePowerMenu, desktop);
     } else if(item_id == PowerMenuItemStartCpu) {
-        desktop_send_scene_event(desktop, DesktopSceneEventTypeEnterCpuStartApp, desktop);
+        desktop_send_scene_event(desktop, DesktopSceneEventTypeStartCpuApp, desktop);
         desktop_send_scene_event(desktop, DesktopSceneEventTypeTogglePowerMenu, desktop);
     } else if(item_id == PowerMenuItemPowerOff) {
         desktop_power_off();

--- a/applications/services/desktop/scenes/settings_menu.c
+++ b/applications/services/desktop/scenes/settings_menu.c
@@ -21,15 +21,6 @@ typedef struct {
     FuriStateSub* brightness_state_sub;
 } SettingsMenuData;
 
-extern int32_t self_check_app(void* p);
-static const FlipperInternalApplication test_app = {
-    .app = self_check_app,
-    .name = "Self Check",
-    .appid = "self_check",
-    .stack_size = 2048,
-    .flags = FlipperInternalApplicationFlagDefault,
-};
-
 static void settings_menu_item_callback(MenuItem* item, size_t item_id, void* context) {
     furi_check(context);
     Scene* scene = context;
@@ -43,7 +34,7 @@ static void settings_menu_item_callback(MenuItem* item, size_t item_id, void* co
     } else if(item_id == SettingsMenuItemPower) {
         desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterPowerSettings, scene);
     } else if(item_id == SettingsMenuItemSelfCheck) {
-        desktop_start_app(&test_app);
+        desktop_start_app_by_id("self_check");
     } else if(item_id == SettingsMenuItemMaskrom) {
         desktop_start_cpu(true);
     } else if(item_id == SettingsMenuItemTesting) {

--- a/applications/services/desktop/scenes/settings_menu.c
+++ b/applications/services/desktop/scenes/settings_menu.c
@@ -34,9 +34,9 @@ static void settings_menu_item_callback(MenuItem* item, size_t item_id, void* co
     } else if(item_id == SettingsMenuItemPower) {
         desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterPowerSettings, scene);
     } else if(item_id == SettingsMenuItemSelfCheck) {
-        desktop_start_app_by_id("self_check");
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterSelfCheckApp, scene);
     } else if(item_id == SettingsMenuItemMaskrom) {
-        desktop_start_cpu(true);
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterMaskromApp, scene);
     } else if(item_id == SettingsMenuItemTesting) {
         desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterTestingMenu, scene);
     } else if(item_id == SettingsMenuItemInfo) {

--- a/applications/services/desktop/scenes/settings_menu.c
+++ b/applications/services/desktop/scenes/settings_menu.c
@@ -34,9 +34,9 @@ static void settings_menu_item_callback(MenuItem* item, size_t item_id, void* co
     } else if(item_id == SettingsMenuItemPower) {
         desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterPowerSettings, scene);
     } else if(item_id == SettingsMenuItemSelfCheck) {
-        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterSelfCheckApp, scene);
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeStartSelfCheckApp, scene);
     } else if(item_id == SettingsMenuItemMaskrom) {
-        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterMaskromApp, scene);
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeStartMaskromApp, scene);
     } else if(item_id == SettingsMenuItemTesting) {
         desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterTestingMenu, scene);
     } else if(item_id == SettingsMenuItemInfo) {

--- a/applications/services/desktop/scenes/testing_menu.c
+++ b/applications/services/desktop/scenes/testing_menu.c
@@ -17,34 +17,6 @@ typedef struct {
     Menu* menu;
 } TestingMenuData;
 
-extern int32_t keypad_test_app(void* p);
-extern int32_t touchpad_test_app(void* p);
-extern int32_t haptic_test_app(void* p);
-
-static const FlipperInternalApplication test_keypad_app = {
-    .app = keypad_test_app,
-    .name = "Keypad Test",
-    .appid = "keypad_test",
-    .stack_size = 2048,
-    .flags = FlipperInternalApplicationFlagDefault,
-};
-
-static const FlipperInternalApplication test_touchpad_app = {
-    .app = touchpad_test_app,
-    .name = "Touchpad Test",
-    .appid = "touchpad_test",
-    .stack_size = 2048,
-    .flags = FlipperInternalApplicationFlagDefault,
-};
-
-static const FlipperInternalApplication test_haptic_app = {
-    .app = haptic_test_app,
-    .name = "Haptic Test",
-    .appid = "haptic_test",
-    .stack_size = 2048,
-    .flags = FlipperInternalApplicationFlagDefault,
-};
-
 static void testing_menu_callback(MenuItem* item, size_t item_id, void* context) {
     furi_check(context);
     Scene* scene = context;
@@ -55,11 +27,11 @@ static void testing_menu_callback(MenuItem* item, size_t item_id, void* context)
     } else if(item_id == TestingMenuItemLeds) {
         desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterLedsMenu, scene);
     } else if(item_id == TestingMenuItemKeypad) {
-        desktop_start_app(&test_keypad_app);
+        desktop_start_app_by_id("keypad_test");
     } else if(item_id == TestingMenuItemTouchpad) {
-        desktop_start_app(&test_touchpad_app);
+        desktop_start_app_by_id("touchpad_test");
     } else if(item_id == TestingMenuItemHaptic) {
-        desktop_start_app(&test_haptic_app);
+        desktop_start_app_by_id("haptic_test");
     }
 }
 

--- a/applications/services/desktop/scenes/testing_menu.c
+++ b/applications/services/desktop/scenes/testing_menu.c
@@ -27,11 +27,11 @@ static void testing_menu_callback(MenuItem* item, size_t item_id, void* context)
     } else if(item_id == TestingMenuItemLeds) {
         desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterLedsMenu, scene);
     } else if(item_id == TestingMenuItemKeypad) {
-        desktop_start_app_by_id("keypad_test");
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterKeypadApp, scene);
     } else if(item_id == TestingMenuItemTouchpad) {
-        desktop_start_app_by_id("touchpad_test");
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterTouchpadApp, scene);
     } else if(item_id == TestingMenuItemHaptic) {
-        desktop_start_app_by_id("haptic_test");
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterHapticApp, scene);
     }
 }
 

--- a/applications/services/desktop/scenes/testing_menu.c
+++ b/applications/services/desktop/scenes/testing_menu.c
@@ -27,11 +27,11 @@ static void testing_menu_callback(MenuItem* item, size_t item_id, void* context)
     } else if(item_id == TestingMenuItemLeds) {
         desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterLedsMenu, scene);
     } else if(item_id == TestingMenuItemKeypad) {
-        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterKeypadApp, scene);
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeStartKeypadApp, scene);
     } else if(item_id == TestingMenuItemTouchpad) {
-        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterTouchpadApp, scene);
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeStartTouchpadApp, scene);
     } else if(item_id == TestingMenuItemHaptic) {
-        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeEnterHapticApp, scene);
+        desktop_send_scene_event(scene_data->desktop, DesktopSceneEventTypeStartHapticApp, scene);
     }
 }
 

--- a/applications/services/gui/gui.c
+++ b/applications/services/gui/gui.c
@@ -399,11 +399,11 @@ static Gui* gui_alloc(void) {
     gui->redraw_flag = furi_event_flag_alloc();
     gui->input_queue = furi_message_queue_alloc(GUI_INPUT_EVENT_QUEUE_SIZE, sizeof(InputEvent));
     FURI_LOG_I(
-        TAG, "InputEvent: %zu bytes x %u → queue ~%zu bytes", sizeof(InputEvent), GUI_INPUT_EVENT_QUEUE_SIZE, sizeof(InputEvent) * GUI_INPUT_EVENT_QUEUE_SIZE);
+        TAG, "InputEvent: %zu bytes x %u -> queue ~%zu bytes", sizeof(InputEvent), GUI_INPUT_EVENT_QUEUE_SIZE, sizeof(InputEvent) * GUI_INPUT_EVENT_QUEUE_SIZE);
     gui->input_touch_queue = furi_message_queue_alloc(GUI_INPUT_TOUCH_EVENT_QUEUE_SIZE, sizeof(InputTouchEvent));
     FURI_LOG_I(
         TAG,
-        "InputTouchEvent: %zu bytes x %u → queue ~%zu bytes",
+        "InputTouchEvent: %zu bytes x %u -> queue ~%zu bytes",
         sizeof(InputTouchEvent),
         GUI_INPUT_TOUCH_EVENT_QUEUE_SIZE,
         sizeof(InputTouchEvent) * GUI_INPUT_TOUCH_EVENT_QUEUE_SIZE);

--- a/applications/services/gui/gui.c
+++ b/applications/services/gui/gui.c
@@ -479,6 +479,16 @@ void gui_push_frame(Gui* gui, const uint8_t* data) {
     gui_update(gui);
 }
 
+void gui_clear_frame(Gui* gui) {
+    furi_check(gui);
+
+    gui_lock(gui);
+    gui->pending_frame = NULL;
+    gui_unlock(gui);
+
+    gui_update(gui);
+}
+
 void gui_set_menu(Gui* gui, PopupMenu* menu) {
     furi_check(gui);
 

--- a/applications/services/gui/gui.h
+++ b/applications/services/gui/gui.h
@@ -56,6 +56,15 @@ size_t gui_get_height(Gui* gui);
 void gui_push_frame(Gui* gui, const uint8_t* data);
 
 /**
+ * Drop the pending full-screen frame (if any) and request a redraw.
+ *
+ * Call this when the frame source goes away (e.g. the owning app exits or
+ * the device feeding frames is reset) so the next redraw falls back to the
+ * normal Clay compositing instead of blitting a stale frame.
+ */
+void gui_clear_frame(Gui* gui);
+
+/**
  * Register the popup menu used as an overlay on top of pushed frames.
  *
  * The GUI checks its visibility to decide between the fast direct-blit path

--- a/lib/drivers/drv2605l/drv2605l.c
+++ b/lib/drivers/drv2605l/drv2605l.c
@@ -290,6 +290,19 @@ static bool drv2605l_load_settings(Drv2605l* instance) {
     return ret >= PICO_OK;
 }
 
+bool drv2605l_reset(Drv2605l* instance) {
+    furi_check(instance);
+
+    Drv2605lMode mode_reg = {
+        .device_reset = 1, //Software reset
+    };
+
+    int ret = drv2605l_write_reg(instance, Drv2605lRegMode, (uint8_t*)&mode_reg);
+    furi_delay_ms(1); // Datasheet: >= 1 ms after reset before further commands
+
+    return ret >= PICO_OK;
+}
+
 Drv2605l* drv2605l_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pin_en, const GpioPin* pin_trigger, uint8_t address) {
     Drv2605l* instance = (Drv2605l*)malloc(sizeof(Drv2605l));
     instance->i2c_handle = i2c_handle;
@@ -311,6 +324,10 @@ Drv2605l* drv2605l_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pi
 
     if(ret) {
         drv2605l_enable(instance);
+
+        if(!drv2605l_reset(instance)) {
+            FURI_LOG_E(TAG, "Failed to reset device");
+        }
 
         if(!drv2605l_load_settings(instance)) {
             FURI_LOG_E(TAG, "Failed to load settings");

--- a/lib/drivers/drv2605l/drv2605l.c
+++ b/lib/drivers/drv2605l/drv2605l.c
@@ -298,8 +298,10 @@ Drv2605l* drv2605l_init(const FuriHalI2cBusHandle* i2c_handle, const GpioPin* pi
     instance->address = address;
 
     furi_hal_gpio_init_simple(instance->pin_en, GpioModeOutputPushPull);
+    furi_hal_gpio_write(instance->pin_en, false);
+    furi_delay_ms(10);
     furi_hal_gpio_write(instance->pin_en, true);
-
+    furi_delay_ms(10);
     //Todo: GpioModeOutputPushPull
     //furi_hal_gpio_init_simple(instance->pin_trigger, GpioModeOutputPushPull);
 

--- a/targets/f1/furi_bsp/furi_bsp_expander.c
+++ b/targets/f1/furi_bsp/furi_bsp_expander.c
@@ -168,25 +168,18 @@ void furi_bsp_main_reset(void) {
     furi_check(expander_main != NULL);
     furi_check(furi_mutex_acquire(expander_main->handle_mutex, FuriWaitForever) == FuriStatusOk);
     if(expander_main->handle) {
-        pcal6416_deinit(expander_main->handle);
-        expander_main->handle = NULL;
-
+        // Reset main expander
         furi_hal_gpio_write_open_drain(&gpio_main_board_reset, false);
         furi_delay_ms(50);
         furi_hal_gpio_write_open_drain(&gpio_main_board_reset, true);
         furi_delay_ms(10);
 
-        expander_main->handle = pcal6416_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, PCAL6416_ADDRESS_A0);
-        if(expander_main->handle) {
-            pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
-            expander_main->control_state = FuriBspControlExpanderMainMcu;
-            // Todo: Errata lay the I2C line
-            pcal6416_write_output(expander_main->handle, OutputExpMainVcc5v0DevS0En & OutputExpMainMask);
-            pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
-            expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
-        } else {
-            furi_bsp_show_error_message_main_expander();
-        }
+        pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+        expander_main->control_state = FuriBspControlExpanderMainMcu;
+
+        pcal6416_write_output(expander_main->handle, OutputExpMainVcc5v0DevS0En & OutputExpMainMask);
+        pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
+        expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
     } else {
         furi_bsp_show_error_message_main_expander();
     }

--- a/targets/f1/furi_bsp/furi_bsp_expander.c
+++ b/targets/f1/furi_bsp/furi_bsp_expander.c
@@ -177,9 +177,14 @@ void furi_bsp_main_reset(void) {
         pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
         expander_main->control_state = FuriBspControlExpanderMainMcu;
 
-        pcal6416_write_output(expander_main->handle, OutputExpMainVcc5v0DevS0En & OutputExpMainMask);
-        pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
-        expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
+        const bool ok =
+            pcal6416_write_output(expander_main->handle, OutputExpMainVcc5v0DevS0En & OutputExpMainMask) &&
+            pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
+        if(!ok) {
+            furi_bsp_show_error_message_main_expander();
+        } else {
+            expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
+        }
     } else {
         furi_bsp_show_error_message_main_expander();
     }

--- a/targets/f2/furi_bsp/furi_bsp_expander.c
+++ b/targets/f2/furi_bsp/furi_bsp_expander.c
@@ -177,9 +177,14 @@ void furi_bsp_main_reset(void) {
         pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
         expander_main->control_state = FuriBspControlExpanderMainMcu;
 
-        pcal6416_write_output(expander_main->handle, OutputExpMainNMuxEn & OutputExpMainMask);
-        pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
-        expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
+        const bool ok =
+            pcal6416_write_output(expander_main->handle, OutputExpMainNMuxEn & OutputExpMainMask) &&
+            pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
+        if(!ok) {
+            furi_bsp_show_error_message_main_expander();
+        } else {
+            expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
+        }
     } else {
         furi_bsp_show_error_message_main_expander();
     }

--- a/targets/f2/furi_bsp/furi_bsp_expander.c
+++ b/targets/f2/furi_bsp/furi_bsp_expander.c
@@ -168,25 +168,18 @@ void furi_bsp_main_reset(void) {
     furi_check(expander_main != NULL);
     furi_check(furi_mutex_acquire(expander_main->handle_mutex, FuriWaitForever) == FuriStatusOk);
     if(expander_main->handle) {
-        pcal6416_deinit(expander_main->handle);
-        expander_main->handle = NULL;
-
+        // Reset main expander
         furi_hal_gpio_write_open_drain(&gpio_main_board_reset, false);
         furi_delay_ms(50);
         furi_hal_gpio_write_open_drain(&gpio_main_board_reset, true);
         furi_delay_ms(10);
 
-        expander_main->handle = pcal6416_init(&furi_hal_i2c_handle_main, &gpio_main_board_reset, &gpio_main_expander_int, PCAL6416_ADDRESS_A0);
-        if(expander_main->handle) {
-            pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
-            expander_main->control_state = FuriBspControlExpanderMainMcu;
+        pcal6416_set_input_callback(expander_main->handle, furi_bsp_expander_main_interrupt_handler, expander_main);
+        expander_main->control_state = FuriBspControlExpanderMainMcu;
 
-            pcal6416_write_output(expander_main->handle, OutputExpMainNMuxEn & OutputExpMainMask);
-            pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
-            expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
-        } else {
-            furi_bsp_show_error_message_main_expander();
-        }
+        pcal6416_write_output(expander_main->handle, OutputExpMainNMuxEn & OutputExpMainMask);
+        pcal6416_write_mode(expander_main->handle, InputExpMainInputMask);
+        expander_main->input_mask_old = ~pcal6416_read_input(expander_main->handle) & InputExpMainInputMask;
     } else {
         furi_bsp_show_error_message_main_expander();
     }


### PR DESCRIPTION
# What's new

- Desktop: start/stop app from CLI
- Furi_bsp_expander: reporting a false memory leak error
- DRV2605L: fix reboot

# Verification 

- launch the MCU CLI
- use the commands "desktop start_app <app_name|appid>", "desktop stop_app", and "desktop list_apps", and "get_run_app"

<img width="1708" height="1626" alt="image" src="https://github.com/user-attachments/assets/fd31af3d-9869-4cec-a31f-320cedc40c13" />

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
