### PR TITLE
Fix newlib alloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,19 @@ fw_find_file(linker_symbols.ld LINKER_SYMBOLS_LD)
 target_link_options(${PROJECT_NAME} PRIVATE "LINKER:-T,${LINKER_SYMBOLS_LD}")
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_DEPENDS ${LINKER_SYMBOLS_LD})
 
+# Route newlib's reentrant allocators (_malloc_r and friends) to the Furi heap.
+# pico_malloc only wraps malloc/free/calloc/realloc. Newlib internal users
+# (stdio buffering via __smakebuf_r, %f formatting via _dtoa_r, strdup, fopen,
+# etc.) go through the _r variants, which otherwise fall back to _sbrk over
+# the .heap section that overlaps the start of the Furi heap. memmgr.c already
+# provides __wrap__malloc_r/__wrap__free_r/__wrap__calloc_r/__wrap__realloc_r.
+target_link_options(${PROJECT_NAME} PRIVATE
+    "LINKER:--wrap=_malloc_r"
+    "LINKER:--wrap=_free_r"
+    "LINKER:--wrap=_calloc_r"
+    "LINKER:--wrap=_realloc_r"
+)
+
 include(lib/corelibs/lib/version/CMakeLists.txt)
 
 pico_set_program_name(${PROJECT_NAME} "${PROJECT_NAME}")

--- a/applications/debug/unit_test_app/minunit.h
+++ b/applications/debug/unit_test_app/minunit.h
@@ -66,6 +66,7 @@ extern "C" {
 #endif
 
 #include <stdio.h>
+#include <pico/stdio.h>
 #include <math.h>
 
 /*  Maximum length of last message */
@@ -117,7 +118,7 @@ void minunit_printf_warning(const char* format, ...);
             minunit_fail++;                                      \
             minunit_print_fail(minunit_last_message);            \
             minunit_status = 0;                                  \
-        } fflush(stdout);                                        \
+        } stdio_flush();                                         \
         if(minunit_teardown)(*minunit_teardown)();)
 
 #define MU_RUN_TEST_1(test, arg_1)                               \
@@ -134,7 +135,7 @@ void minunit_printf_warning(const char* format, ...);
             minunit_fail++;                                      \
             minunit_print_fail(minunit_last_message);            \
             minunit_status = 0;                                  \
-        } fflush(stdout);                                        \
+        } stdio_flush();                                         \
         if(minunit_teardown)(*minunit_teardown)();)
 
 /*  Report */

--- a/applications/debug/unit_test_app/minunit_glue.c
+++ b/applications/debug/unit_test_app/minunit_glue.c
@@ -1,6 +1,7 @@
 #include "minunit_vars_ex.h"
 
 #include <furi.h>
+#include <pico/stdio.h>
 
 void minunit_print_progress(void) {
     static const char progress[] = {'\\', '|', '/', '-'};
@@ -10,7 +11,7 @@ void minunit_print_progress(void) {
     if(current_tick - last_tick > 20) {
         last_tick = current_tick;
         printf("[%c]\033[3D", progress[++progress_counter % COUNT_OF(progress)]);
-        fflush(stdout);
+        stdio_flush();
     }
 }
 

--- a/applications/services/cli/cli_commands_common.c
+++ b/applications/services/cli/cli_commands_common.c
@@ -1,6 +1,7 @@
 #include "cli_commands_common.h"
 
 #include <furi_hal.h>
+#include <pico/stdio.h>
 #include <cli/cli_ansi.h>
 #include <cli/args.h>
 #include <cli/cli_command.h>
@@ -138,7 +139,7 @@ void cli_command_top(PipeSide* pipe, FuriString* args, void* context) {
         }
 
         printf(ANSI_ERASE_DISPLAY(ANSI_ERASE_FROM_CURSOR_TO_END));
-        fflush(stdout);
+        stdio_flush();
 
         if(interval > 0) {
             furi_delay_ms(interval);

--- a/applications/services/input/input_cli.c
+++ b/applications/services/input/input_cli.c
@@ -1,4 +1,5 @@
 #include <furi/furi.h>
+#include <pico/stdio.h>
 
 #include <input/input.h>
 #include <input_touch/input_touch.h>
@@ -87,7 +88,7 @@ static void input_cli_dump(PipeSide* pipe) {
                     ev.event.touch.y,
                     ev.event.touch.pressure);
             }
-            fflush(stdout);
+            stdio_flush();
         }
     }
 

--- a/lib/cli/shell/cli_shell_line.c
+++ b/lib/cli/shell/cli_shell_line.c
@@ -19,6 +19,9 @@ struct CliShellLine {
 CliShellLine* cli_shell_line_alloc(CliShell* shell) {
     CliShellLine* line = malloc(sizeof(CliShellLine));
     line->shell = shell;
+    line->history_position = 0;
+    line->line_position = 0;
+    line->about_to_exit = false;
 
     line->history[0] = furi_string_alloc();
     line->history_entries = 1;
@@ -304,7 +307,7 @@ static bool cli_shell_line_input_bksp(CliKeyCombo combo, void* context) {
     FuriString* editing_line = cli_shell_line_get_editing(line);
     cli_shell_line_clamp_position(line, editing_line);
     if(line->line_position == 0) {
-        putc(CliKeyBell, stdout);
+        putchar(CliKeyBell);
         stdio_flush();
         return true;
     }


### PR DESCRIPTION
# What's new

- Fix newlib alloc
- Fix flush stdio

# Verification 

# Fix newlib allocator overlap that corrupts the Furi heap on Backspace

## Summary

Fixes a deterministic firmware crash: pressing **Backspace on an empty CLI line**
corrupted the Furi heap and crashed the device. The corruption was caused by
newlib's reentrant allocators (`_malloc_r`/`_free_r`/`_calloc_r`/`_realloc_r`)
not being routed to the Furi heap. They silently used the Pico SDK's `_sbrk`
heap, which overlaps the start of the Furi heap.

## Problem

Reproduction:

1. Open the CLI (UART or VCP).
2. Run a few commands normally — everything works.
3. Press Backspace with an empty input line.
4. The firmware crashes with heap corruption.

The corrupting sequence:

- `putc(CliKeyBell, stdout)` in the CLI goes through the **newlib** FILE
  machinery (`__swbuf_r` → `__swsetup_r` → `__smakebuf_r`) because `putc` is
  not part of the linker's wrap list.
- On first use, `__smakebuf_r` calls `_malloc_r(BUFSIZ)` (1024 bytes). Since
  `_malloc_r` was not wrapped either, newlib's own malloc served the request
  from `_sbrk`.
- The Pico SDK's weak `_sbrk` grows a heap starting at `end` — the very same
  address where the Furi heap starts (`__heap_start__`). The newlib chunk
  header `{prev_size=0, size=0x409}` was written directly over the first Furi
  heap block — the `MemmgrHeapThreadDict` table, which is consulted on every
  `malloc`/`free`. The next allocation crashed in the dictionary code.

This is why only Backspace-on-empty-line triggered it: it is the only CLI path
that writes through the newlib `stdout` FILE; everything else uses the wrapped
`printf`/`putchar` family that goes through the Furi stdio chain.

## Changes

### 1. `CMakeLists.txt` — route newlib reentrant allocators to the Furi heap

`pico_malloc` wraps only `malloc`/`free`/`calloc`/`realloc`. Newlib's internal
users (stdio buffering via `__smakebuf_r`, `%f` formatting via `_dtoa_r`,
`strdup`, `fopen`, etc.) call the `_r` variants, which previously fell back to
`_sbrk` over the `.heap` section that overlaps the Furi heap start. The
`__wrap__*_r` implementations already exist in
`lib/corelibs/lib/furi/core/memmgr.c` — they were simply never linked in.

```cmake
target_link_options(${PROJECT_NAME} PRIVATE
    "LINKER:--wrap=_malloc_r"
    "LINKER:--wrap=_free_r"
    "LINKER:--wrap=_calloc_r"
    "LINKER:--wrap=_realloc_r"
)
```

This is the same set of wraps used by the original Flipper Zero firmware.

### 2. `lib/cli/shell/cli_shell_line.c` — send the bell through the Furi stdio chain

```c
-        putc(CliKeyBell, stdout);
+        putchar(CliKeyBell);
```

- `putc` is not wrapped and writes into the newlib `stdout` FILE, which is
  unrelated to the Furi stdio chain. Besides triggering the allocation above,
  the bell never actually reached the terminal (`stdio_flush()` only flushes
  the Furi stdio drivers, not the newlib FILE buffer).
- `putchar` is wrapped by `pico_stdio` and goes through the thread-local Furi
  stdout buffer, so the bell is actually delivered and flushed.

### 3. `lib/cli/shell/cli_shell_line.c` — initialize `CliShellLine` fields

`history_position`, `line_position` and `about_to_exit` are now explicitly
zero-initialized in `cli_shell_line_alloc()`, removing reliance on the
allocator's zeroed memory.

## Testing

- Firmware builds cleanly for target `f2` with CMake + Ninja.
- Verified with `arm-none-eabi-nm` that the real newlib
  `_malloc_r`/`_free_r`/`_calloc_r`/`_realloc_r`/`_sbrk` symbols are no longer
  present in the ELF — only `__wrap__*_r` remain, resolving into the Furi heap.
- Manual test on hardware (target f2):
  - type/backspace/enter sequences — no crash;
  - repeated Backspace on an empty line — no crash, bell is emitted;
  - `top`, `free`, `free_blocks` and regular commands work as before.

## Out of scope / follow-ups

- `realloc()` in `fbtng-corelibs` copies `size` bytes from the old block even
  when growing, which is an out-of-bounds read; `calloc()` lacks an overflow
  check. Worth a separate PR in the corelibs repository.
- `cli_command_top` and `input_cli` use newlib `fflush(stdout)`, which flushes
  the (unused) newlib FILE instead of the Furi stdio drivers — their output is
  only delivered via other flush paths. Could be replaced with `stdio_flush()`
  in a follow-up.

# Contributor checklist

- [x] I have read the changes in this PR and understand what they do
- [x] I can explain the approach taken and why alternatives were not chosen
- [x] I have tested these changes myself (on hardware or in simulation)
- [x] I am able to respond to review comments on my own, not by forwarding them to an AI

> If you used AI tools to assist with this PR, that is fine — but the checklist above still applies to you personally.
